### PR TITLE
fix: moveNext when using segmentDelta

### DIFF
--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -425,7 +425,7 @@ export namespace ServerPlayoutAPI {
 
 			// find the allowable segment ids
 			const allowedSegments =
-				segmentDelta < 0
+				segmentDelta > 0
 					? considerSegments.slice(targetSegmentIndex)
 					: considerSegments.slice(0, targetSegmentIndex + 1).reverse()
 			// const allowedSegmentIds = new Set(allowedSegments.map((s) => s._id))


### PR DESCRIPTION
segmentDelta > 0, we're going down, hence we consider segments with indexes higher than target
segmentDelta < 0, we're going up, hence we consider segments with indexes <= the target, and reverse the order
