### PR TITLE
fix: dimming the segment duration (SOF-548)

### DIFF
--- a/meteor/client/styles/customInstallation.scss
+++ b/meteor/client/styles/customInstallation.scss
@@ -301,6 +301,13 @@ body.tv2 {
 					,var(--segment-layer-background-vt) 50%,var(--segment-layer-background-camera) 50.0001%) !important;
 			}
 		}
+
+		&.time-of-day-countdowns {
+			.segment-timeline__duration {
+				color: unset;
+			}
+		}
+	
 	}
 	.segment-timeline.next,
 	.segment-timeline.live {


### PR DESCRIPTION
Fixes the segment duration to stay the same color no matter what the mode of the segment sidebar clocks is.
