### PR TITLE
Feat: clip duration label (SOF-239)

### DIFF
--- a/meteor/client/styles/pieceStatusIcon.scss
+++ b/meteor/client/styles/pieceStatusIcon.scss
@@ -5,7 +5,7 @@
 		width: 1.2em;
 		height: 1.2em;
 		vertical-align: top;
-		margin-top: -5px;
+		margin-top: 1px;
 		margin-right: 4px;
 	}
 }

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2266,6 +2266,27 @@ svg.icon {
 					object-position: center center;
 					margin-left: 0.5em;
 				}
+
+				&.with-duration {
+					display: inline-flex;					
+					flex-direction: row;
+
+					.segment-timeline__piece__label__duration {
+						font-weight: 300;
+						font-size: 0.9em;
+						margin-left: 0.2em;
+
+					}
+
+					&.swap-duration {
+						.segment-timeline__piece__label__duration
+						{
+						   order: -1;
+						   margin-left: 0;
+						   margin-right: 0.2em;
+						}
+					}
+				}
 			}
 
 			// Layer-item appendages are parts of a layer item going beyond the layer (usually, across the entire timeline)

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1857,7 +1857,6 @@ svg.icon {
 							transition: ($output-layer-group-collapse-animation-duration * 1/3) opacity
 								($output-layer-group-collapse-animation-duration * 2/3);
 							pointer-events: none;
-							display: inline-block;
 							white-space: nowrap;
 
 							transform: translate3d(0, 0, 1px); // Just to make it render in front

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2567,6 +2567,9 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 					return !!filter.assignHotKeys
 				}
+				const showDurationSourceLayers = this.state.rundownViewLayout?.showDurationSourceLayers
+					? new Set(this.state.rundownViewLayout?.showDurationSourceLayers)
+					: undefined
 				return this.props.matchedSegments.map((rundownAndSegments, rundownIndex, rundownArray) => {
 					const rundownIdsBefore = rundowns.slice(0, rundownIndex)
 					return (
@@ -2641,6 +2644,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 														this.state.rundownViewLayout?.countdownToSegmentRequireLayers
 													}
 													fixedSegmentDuration={this.state.rundownViewLayout?.fixedSegmentDuration}
+													showDurationSourceLayers={showDurationSourceLayers}
 												/>
 											</VirtualElement>
 										</ErrorBoundary>

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -38,6 +38,8 @@ export interface ICustomLayerItemProps {
 	getItemLabelOffsetRight?: () => React.CSSProperties
 	getItemDuration?: (returnInfinite?: boolean) => number
 	setAnchoredElsWidths?: (rightAnchoredWidth: number, leftAnchoredWidth: number) => void
+	shouldSwapDurationLabel?: () => boolean
+	showDurationSourceLayers?: Set<string>
 }
 export interface ISourceLayerItemState {}
 
@@ -45,6 +47,14 @@ export class CustomLayerItemRenderer<
 	IProps extends ICustomLayerItemProps,
 	IState extends ISourceLayerItemState
 > extends React.Component<ICustomLayerItemProps & IProps, ISourceLayerItemState & IState> {
+	shouldSwapDurationLabel(): boolean {
+		return !!(
+			this.props.shouldSwapDurationLabel &&
+			typeof this.props.shouldSwapDurationLabel === 'function' &&
+			this.props.shouldSwapDurationLabel()
+		)
+	}
+
 	getItemLabelOffsetLeft(): React.CSSProperties {
 		if (this.props.getItemLabelOffsetLeft && typeof this.props.getItemLabelOffsetLeft === 'function') {
 			return this.props.getItemLabelOffsetLeft()
@@ -180,6 +190,23 @@ export class CustomLayerItemRenderer<
 				<FontAwesomeIcon icon={faCut} />
 			</div>
 		) : null
+	}
+
+	renderDuration() {
+		const uiPiece = this.props.piece
+		const innerPiece = uiPiece.instance.piece
+		const content = innerPiece.content
+		const duration = content && content.sourceDuration
+		if (duration && this.props.showDurationSourceLayers?.has(innerPiece.sourceLayerId)) {
+			return (
+				<span className="segment-timeline__piece__label__duration">{`(${RundownUtils.formatDiffToTimecode(
+					duration,
+					false,
+					false,
+					true
+				)})`}</span>
+			)
+		}
 	}
 
 	render() {

--- a/meteor/client/ui/SegmentTimeline/Renderers/DefaultLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/DefaultLayerItemRenderer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import ClassNames from 'classnames'
 import { getElementWidth } from '../../../utils/dimensions'
 
 import { CustomLayerItemRenderer, ICustomLayerItemProps } from './CustomLayerItemRenderer'
@@ -43,26 +44,32 @@ export class DefaultLayerItemRenderer extends CustomLayerItemRenderer<IProps, IS
 	}
 
 	render() {
+		if (this.props.isTooSmallForText) return
 		return (
-			!this.props.isTooSmallForText && (
-				<>
+			<>
+				<span
+					className="segment-timeline__piece__label"
+					ref={this.setLeftLabelRef}
+					style={this.getItemLabelOffsetLeft()}
+				>
 					<span
-						className="segment-timeline__piece__label"
-						ref={this.setLeftLabelRef}
-						style={this.getItemLabelOffsetLeft()}
+						className={ClassNames('segment-timeline__piece__label', 'with-duration', {
+							'swap-duration': this.shouldSwapDurationLabel(),
+						})}
 					>
-						<span className="segment-timeline__piece__label">{this.props.piece.instance.piece.name}</span>
+						<span>{this.props.piece.instance.piece.name}</span>
+						{this.renderDuration()}
 					</span>
-					<span
-						className="segment-timeline__piece__label right-side"
-						ref={this.setRightLabelRef}
-						style={this.getItemLabelOffsetRight()}
-					>
-						{this.renderInfiniteIcon()}
-						{this.renderOverflowTimeLabel()}
-					</span>
-				</>
-			)
+				</span>
+				<span
+					className="segment-timeline__piece__label right-side"
+					ref={this.setRightLabelRef}
+					style={this.getItemLabelOffsetRight()}
+				>
+					{this.renderInfiniteIcon()}
+					{this.renderOverflowTimeLabel()}
+				</span>
+			</>
 		)
 	}
 }

--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -466,11 +466,13 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			<span className="segment-timeline__piece__label" ref={this.setLeftLabelRef} style={this.getItemLabelOffsetLeft()}>
 				{noticeLevel !== null && <PieceStatusIcon noticeLevel={noticeLevel} />}
 				<span
-					className={ClassNames('segment-timeline__piece__label', {
+					className={ClassNames('segment-timeline__piece__label', 'with-duration', {
 						'overflow-label': end !== '',
+						'swap-duration': this.shouldSwapDurationLabel(),
 					})}
 				>
-					{begin}
+					<span>{begin}</span>
+					{this.renderDuration()}
 				</span>
 				{begin && end === '' && vtContent && vtContent.loop && (
 					<div className="segment-timeline__piece__label label-icon label-loop-icon">

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -84,6 +84,7 @@ interface IProps {
 	budgetDuration?: number
 	showCountdownToSegment: boolean
 	fixedSegmentDuration: boolean | undefined
+	showDurationSourceLayers?: Set<string>
 }
 interface IStateHeader {
 	timelineWidth: number
@@ -810,6 +811,7 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 							previousPartIsLive &&
 							!!this.props.playlist.nextPartInstanceId
 						}
+						showDurationSourceLayers={this.props.showDurationSourceLayers}
 						part={part}
 						isBudgetGap={false}
 					/>

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -119,6 +119,7 @@ interface IProps {
 	rundownViewLayout: RundownViewLayout | undefined
 	countdownToSegmentRequireLayers: string[] | undefined
 	fixedSegmentDuration: boolean | undefined
+	showDurationSourceLayers?: Set<string>
 }
 interface IState {
 	scrollLeft: number
@@ -998,6 +999,7 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 								showCountdownToSegment={this.props.showCountdownToSegment}
 								fixedSegmentDuration={this.props.fixedSegmentDuration}
 								displayLiveLineCounter={this.props.displayLiveLineCounter}
+								showDurationSourceLayers={this.props.showDurationSourceLayers}
 							/>
 						)}
 						{this.props.segmentui.showShelf && this.props.adLibSegmentUi && (

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
@@ -77,6 +77,7 @@ interface ISourceLayerPropsBase {
 	layerIndex: number
 	onContextMenu?: (contextMenuContext: IContextMenuContext) => void
 	isPreview: boolean
+	showDurationSourceLayers?: Set<string>
 }
 interface ISourceLayerProps extends ISourceLayerPropsBase {
 	layer: ISourceLayerUi
@@ -156,6 +157,7 @@ class SourceLayer extends SourceLayerBase<ISourceLayerProps> {
 							onFollowLiveLine={this.props.onFollowLiveLine}
 							layerIndex={this.props.layerIndex}
 							isPreview={this.props.isPreview}
+							showDurationSourceLayers={this.props.showDurationSourceLayers}
 						/>
 					)
 				})
@@ -286,6 +288,7 @@ interface IOutputGroupProps {
 	onContextMenu?: (contextMenuContext: IContextMenuContext) => void
 	indexOffset: number
 	isPreview: boolean
+	showDurationSourceLayers?: Set<string>
 }
 class OutputGroup extends React.PureComponent<IOutputGroupProps> {
 	static whyDidYouRender = true
@@ -326,6 +329,7 @@ class OutputGroup extends React.PureComponent<IOutputGroupProps> {
 							onPieceClick={this.props.onPieceClick}
 							onPieceDoubleClick={this.props.onPieceDoubleClick}
 							isPreview={this.props.isPreview}
+							showDurationSourceLayers={this.props.showDurationSourceLayers}
 						/>
 					)
 				})
@@ -433,6 +437,7 @@ interface IProps {
 	isPreview?: boolean
 	cropDuration?: number
 	className?: string
+	showDurationSourceLayers?: Set<string>
 }
 
 interface IState {
@@ -821,6 +826,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 								liveLinePadding={SegmentTimelinePartClass.getLiveLineTimePadding(this.props.timeScale)}
 								indexOffset={currentIndex}
 								isPreview={this.props.isPreview || false}
+								showDurationSourceLayers={this.props.showDurationSourceLayers}
 							/>
 						)
 					}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
@@ -232,6 +232,7 @@ class FlattenedSourceLayers extends SourceLayerBase<IFlattenedSourceLayerProps> 
 								scrollWidth={this.props.scrollWidth}
 								layerIndex={this.props.layerIndex}
 								isPreview={this.props.isPreview}
+								showDurationSourceLayers={this.props.showDurationSourceLayers}
 							/>
 						)
 					})
@@ -366,6 +367,7 @@ class OutputGroup extends React.PureComponent<IOutputGroupProps> {
 						onPieceClick={this.props.onPieceClick}
 						onPieceDoubleClick={this.props.onPieceDoubleClick}
 						isPreview={this.props.isPreview}
+						showDurationSourceLayers={this.props.showDurationSourceLayers}
 					/>
 				)
 			}

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -51,6 +51,7 @@ export interface ISourceLayerItemProps {
 	liveLinePadding: number
 	layerIndex: number
 	studio: Studio | undefined
+	showDurationSourceLayers?: Set<string>
 }
 interface ISourceLayerItemState {
 	showMiniInspector: boolean
@@ -100,6 +101,13 @@ export const SourceLayerItem = withTranslation()(
 
 		convertTimeToPixels = (time: number) => {
 			return Math.round(this.props.timeScale * time)
+		}
+
+		shouldSwapDurationLabel = (): boolean => {
+			if (this.props.part && this.props.partStartsAt !== undefined && !this.props.isLiveLine) {
+				return this.state.leftAnchoredWidth > this.state.elementWidth - 10
+			}
+			return false
 		}
 
 		getItemLabelOffsetLeft = (): React.CSSProperties => {
@@ -595,6 +603,7 @@ export const SourceLayerItem = withTranslation()(
 							key={unprotectString(this.props.piece.instance._id)}
 							typeClass={typeClass}
 							getItemDuration={this.getItemDuration}
+							shouldSwapDurationLabel={this.shouldSwapDurationLabel}
 							getItemLabelOffsetLeft={this.getItemLabelOffsetLeft}
 							getItemLabelOffsetRight={this.getItemLabelOffsetRight}
 							setAnchoredElsWidths={this.setAnchoredElsWidths}
@@ -665,6 +674,7 @@ export const SourceLayerItem = withTranslation()(
 							key={unprotectString(this.props.piece.instance._id)}
 							typeClass={typeClass}
 							getItemDuration={this.getItemDuration}
+							shouldSwapDurationLabel={this.shouldSwapDurationLabel}
 							getItemLabelOffsetLeft={this.getItemLabelOffsetLeft}
 							getItemLabelOffsetRight={this.getItemLabelOffsetRight}
 							setAnchoredElsWidths={this.setAnchoredElsWidths}

--- a/meteor/client/ui/Settings/components/rundownLayouts/RundownViewLayoutSettings.tsx
+++ b/meteor/client/ui/Settings/components/rundownLayouts/RundownViewLayoutSettings.tsx
@@ -231,6 +231,35 @@ export default withTranslation()(
 							</span>
 						</label>
 					</div>
+					<div className="mod mvs mhs">
+						<label className="field">{t('Display piece duration for source layers')}</label>
+						<EditAttribute
+							modifiedClassName="bghl"
+							attribute={`showDurationSourceLayers`}
+							obj={this.props.item}
+							type="checkbox"
+							collection={RundownLayouts}
+							className="mod mas"
+							mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
+							mutateUpdateValue={(v) => undefined}
+						/>
+						<EditAttribute
+							modifiedClassName="bghl"
+							attribute={`showDurationSourceLayers`}
+							obj={this.props.item}
+							options={this.props.showStyleBase.sourceLayers.map((l) => {
+								return { name: l.name, value: l._id }
+							})}
+							type="multiselect"
+							label={t('Disabled')}
+							collection={RundownLayouts}
+							className="input text-input input-l dropdown"
+							mutateUpdateValue={(v) => (v && v.length > 0 ? v : undefined)}
+						/>
+						<span className="text-s dimmed">
+							{t('Piece on selected source layers will have a duration label shown')}
+						</span>
+					</div>
 				</React.Fragment>
 			)
 		}

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -481,6 +481,8 @@ export interface RundownViewLayout extends RundownLayoutBase {
 	countdownToSegmentRequireLayers: string[]
 	/** Always show planned segment duration instead of counting up/down when the segment is live */
 	fixedSegmentDuration: boolean
+	/** SourceLayer ids for which a piece duration label should be shown */
+	showDurationSourceLayers: string[]
 }
 
 export interface RundownLayoutShelfBase extends RundownLayoutWithFilters {


### PR DESCRIPTION
Adds a duration label to pieces that have `sourceDuration`.
Uses the rundown view layout settings to set for which source layers the duration should be displayed. 
![image](https://user-images.githubusercontent.com/9103996/134899661-1199f074-8520-46a0-9be2-187c9fa68fd5.png)
