### PR TITLE
fix: Close button in rundown moved to front

### DIFF
--- a/meteor/client/styles/customInstallation.scss
+++ b/meteor/client/styles/customInstallation.scss
@@ -64,6 +64,7 @@ body.tv2 {
 
 		.header.rundown .close {
 			margin: 17px 20px 9px;
+			z-index: 10000;
 		}
 	}
 	.col.rundown-overview {


### PR DESCRIPTION
The close button (X) has been moved to the front by setting z-index to 10000. This is a quick fix and the UI shall at some point be revisited and refactored.