### PR TITLE
fix: filtersTitle swapped for dashboard and rundown layouts

### DIFF
--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -174,7 +174,7 @@ class RundownLayoutsRegistry {
 export namespace RundownLayoutsAPI {
 	const registry = new RundownLayoutsRegistry()
 	registry.registerShelfLayout(RundownLayoutType.RUNDOWN_LAYOUT, {
-		filtersTitle: 'Panels',
+		filtersTitle: 'Tabs',
 		supportedFilters: [
 			RundownLayoutElementType.ADLIB_REGION,
 			RundownLayoutElementType.EXTERNAL_FRAME,
@@ -183,7 +183,7 @@ export namespace RundownLayoutsAPI {
 		],
 	})
 	registry.registerShelfLayout(RundownLayoutType.DASHBOARD_LAYOUT, {
-		filtersTitle: 'Tabs',
+		filtersTitle: 'Panels',
 		supportedFilters: [
 			RundownLayoutElementType.ADLIB_REGION,
 			RundownLayoutElementType.EXTERNAL_FRAME,


### PR DESCRIPTION
Swapped the `filtersTitle` for `dashboard_layout` and `rundown_layout`.