### PR TITLE
Fix: Added guard for accessing selectedPartIntance in PartNamePanel

### DIFF
--- a/meteor/client/ui/Shelf/PartNamePanel.tsx
+++ b/meteor/client/ui/Shelf/PartNamePanel.tsx
@@ -104,9 +104,8 @@ export const PartNamePanel = translateWithTracker<IPartNamePanelProps, IState, I
 
 		if (selectedPartInstanceId) {
 			const selectedPartInstance = props.playlist.getActivePartInstances({ _id: selectedPartInstanceId })[0]
-			name = selectedPartInstance.part?.title
-
 			if (selectedPartInstance && props.panel.showPieceIconColor) {
+				name = selectedPartInstance.part?.title
 				const pieceInstances = PieceInstances.find({ partInstanceId: selectedPartInstance._id }).fetch()
 				instanceToShow = findPieceInstanceToShowFromInstances(
 					pieceInstances,


### PR DESCRIPTION
`selectedPartInstance` sometimes evaluates to `undefined` even though a `selectedPartInstanceId` is present. I haven't investigated when and why it evaluates to `undefined`.