### PR TITLE
fix: Re-evaluate cursor position as next part moves relative to cursor

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -507,13 +507,9 @@ export const SourceLayerItem = withTranslation()(
 					})
 				}
 
-				const elementPos = getElementDocumentOffset(this.state.itemElement) || {
-					top: 0,
-					left: 0,
-				}
 				const cursorPosition = {
-					left: this.state.cursorRawPosition.clientX - elementPos.left,
-					top: this.state.cursorRawPosition.clientY - elementPos.top,
+					left: this.state.cursorRawPosition.clientX - this.state.elementPosition.left,
+					top: this.state.cursorRawPosition.clientY - this.state.elementPosition.top,
 				}
 				const cursorTimePosition = Math.max(cursorPosition.left, 0) / this.props.timeScale
 				if (this.state.cursorTimePosition !== cursorTimePosition) {

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -589,7 +589,7 @@ export const SourceLayerItem = withTranslation()(
 				left: e.clientX - this.state.elementPosition.left,
 				top: e.clientY - this.state.elementPosition.top,
 			}
-			const cursorTimePosition = Math.max(cursorPosition.left, 0) / this.props.timeScale + this.state.scrollLeftOffset
+			const cursorTimePosition = Math.max(cursorPosition.left, 0) / this.props.timeScale
 
 			this.setState({
 				cursorPosition: _.extend(this.state.cursorPosition, cursorPosition),

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -58,6 +58,7 @@ interface ISourceLayerItemState {
 	showMiniInspector: boolean
 	elementPosition: OffsetPosition
 	cursorPosition: OffsetPosition
+	cursorRawPosition: { clientX: number; clientY: number }
 	scrollLeftOffset: number
 	cursorTimePosition: number
 	elementWidth: number
@@ -82,6 +83,10 @@ export const SourceLayerItem = withTranslation()(
 				cursorPosition: {
 					top: 0,
 					left: 0,
+				},
+				cursorRawPosition: {
+					clientX: 0,
+					clientY: 0,
 				},
 				scrollLeftOffset: 0,
 				cursorTimePosition: 0,
@@ -496,10 +501,23 @@ export const SourceLayerItem = withTranslation()(
 		componentDidUpdate(prevProps: ISourceLayerItemProps, _prevState: ISourceLayerItemState) {
 			if (prevProps.scrollLeft !== this.props.scrollLeft && this.state.showMiniInspector) {
 				const scrollLeftOffset = this.state.scrollLeftOffset + (this.props.scrollLeft - prevProps.scrollLeft)
-				const cursorTimePosition = this.state.cursorTimePosition + (this.props.scrollLeft - prevProps.scrollLeft)
-				if (this.state.scrollLeftOffset !== scrollLeftOffset && this.state.cursorTimePosition !== cursorTimePosition) {
+				if (this.state.scrollLeftOffset !== scrollLeftOffset) {
 					this.setState({
 						scrollLeftOffset,
+					})
+				}
+
+				const elementPos = getElementDocumentOffset(this.state.itemElement) || {
+					top: 0,
+					left: 0,
+				}
+				const cursorPosition = {
+					left: this.state.cursorRawPosition.clientX - elementPos.left,
+					top: this.state.cursorRawPosition.clientY - elementPos.top,
+				}
+				const cursorTimePosition = Math.max(cursorPosition.left, 0) / this.props.timeScale
+				if (this.state.cursorTimePosition !== cursorTimePosition) {
+					this.setState({
 						cursorTimePosition,
 					})
 				}
@@ -563,6 +581,10 @@ export const SourceLayerItem = withTranslation()(
 				elementPosition: elementPos,
 				cursorPosition,
 				cursorTimePosition,
+				cursorRawPosition: {
+					clientX: e.clientX,
+					clientY: e.clientY,
+				},
 			})
 		}
 
@@ -576,6 +598,10 @@ export const SourceLayerItem = withTranslation()(
 			this.setState({
 				cursorPosition: _.extend(this.state.cursorPosition, cursorPosition),
 				cursorTimePosition,
+				cursorRawPosition: {
+					clientX: e.clientX,
+					clientY: e.clientY,
+				},
 			})
 		}
 

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -24,47 +24,83 @@ import { SourceDurationLabelAlignment } from './Renderers/CustomLayerItemRendere
 const LEFT_RIGHT_ANCHOR_SPACER = 15
 
 export interface ISourceLayerItemProps {
+	/** SourceLayer this item is on */
 	layer: ISourceLayerUi
+	/** Output layer the source layer belongs to */
 	outputLayer: IOutputLayerUi
+	/** URL where media previews / thumbnails are available (e.g. media manager)  */
 	mediaPreviewUrl: string
-	// segment: SegmentUi
+	/** Part containing this item */
 	part: PartUi
+	/** When the part starts (unix timestamp)  */
 	partStartsAt: number
+	/** Part definite duration (generally set after part is played) */
 	partDuration: number
+	/** Part expected duration (before playout) */
 	partExpectedDuration: number
+	/** The piece being rendered in this layer */
 	piece: PieceUi
+	/** Scaling factor for this segment */
 	timeScale: number
+	/** Whether this part is live */
 	isLiveLine: boolean
+	/** Whether this part is next */
 	isNextLine: boolean
+	/** Seemingly always true? */
 	isPreview: boolean
+	/** Whether the element does not have enough width to render text */
 	isTooSmallForText: boolean
+	/** Callback fired when the segment tracks to the live line */
 	onFollowLiveLine?: (state: boolean, event: any) => void
+	/** Callback fired when the element is clicked */
 	onClick?: (piece: PieceUi, e: React.MouseEvent<HTMLDivElement>) => void
+	/** Callback fired when the element is double-clicked */
 	onDoubleClick?: (item: PieceUi, e: React.MouseEvent<HTMLDivElement>) => void
+	/** Seemingly always true? */
 	relative?: boolean
+	/** Whether the movement of the element should follow the live line. False when the user is scrolling the segment themselves */
 	followLiveLine: boolean
+	/** True when we are automatically moving to the next part at the end of the allocated time */
 	autoNextPart: boolean
+	/** How much of the segment to show behind the live line position */
 	liveLineHistorySize: number
+	/** Position of the live line */
 	livePosition: number | null
+	/** Whether output groups are in "collapsed" mode, showing just a preview of each source layer */
 	outputGroupCollapsed: boolean
+	/** Amount of scroll relative to left of segment container */
 	scrollLeft: number
+	/** Width of element including content not visible due to overflow */
 	scrollWidth: number
+	/** Seemingly unused */
 	liveLinePadding: number
+	/** Index of this source layer in an array of sorted sourcelayers (generally sorted by rank) */
 	layerIndex: number
+	/** The studio this content belongs to */
 	studio: Studio | undefined
+	/** Source layers on which to display the piece duration next to any labels */
 	showDurationSourceLayers?: Set<string>
 }
 interface ISourceLayerItemState {
+	/** Whether hover-scrub / inspector is shown */
 	showMiniInspector: boolean
+	/** Element position relative to document top-left */
 	elementPosition: OffsetPosition
+	/** Cursor position relative to element */
 	cursorPosition: OffsetPosition
+	/** Cursor position relative to entire viewport */
 	cursorRawPosition: { clientX: number; clientY: number }
-	scrollLeftOffset: number
+	/** Timecode under cursor */
 	cursorTimePosition: number
+	/** Width of the element (px) excluding padding  */
 	elementWidth: number
+	/** A reference to this element (&self) */
 	itemElement: HTMLDivElement | null
+	/** Width of the child element anchored to the left side of this element */
 	leftAnchoredWidth: number
+	/** Width of the child element anchored to the right side of this element */
 	rightAnchoredWidth: number
+	/** Set to `true` when the segment is "highlighted" (in focus, generally from a scroll event) */
 	highlight: boolean
 }
 export const SourceLayerItem = withTranslation()(
@@ -88,7 +124,6 @@ export const SourceLayerItem = withTranslation()(
 					clientX: 0,
 					clientY: 0,
 				},
-				scrollLeftOffset: 0,
 				cursorTimePosition: 0,
 				elementWidth: 0,
 				itemElement: null,
@@ -499,23 +534,18 @@ export const SourceLayerItem = withTranslation()(
 		}
 
 		componentDidUpdate(prevProps: ISourceLayerItemProps, _prevState: ISourceLayerItemState) {
-			if (prevProps.scrollLeft !== this.props.scrollLeft && this.state.showMiniInspector) {
-				const scrollLeftOffset = this.state.scrollLeftOffset + (this.props.scrollLeft - prevProps.scrollLeft)
-				if (this.state.scrollLeftOffset !== scrollLeftOffset) {
-					this.setState({
-						scrollLeftOffset,
-					})
-				}
-
-				const cursorPosition = {
-					left: this.state.cursorRawPosition.clientX - this.state.elementPosition.left,
-					top: this.state.cursorRawPosition.clientY - this.state.elementPosition.top,
-				}
-				const cursorTimePosition = Math.max(cursorPosition.left, 0) / this.props.timeScale
-				if (this.state.cursorTimePosition !== cursorTimePosition) {
-					this.setState({
-						cursorTimePosition,
-					})
+			if (this.state.showMiniInspector) {
+				if (prevProps.scrollLeft !== this.props.scrollLeft) {
+					const cursorPosition = {
+						left: this.state.cursorRawPosition.clientX - this.state.elementPosition.left,
+						top: this.state.cursorRawPosition.clientY - this.state.elementPosition.top,
+					}
+					const cursorTimePosition = Math.max(cursorPosition.left, 0) / this.props.timeScale
+					if (this.state.cursorTimePosition !== cursorTimePosition) {
+						this.setState({
+							cursorTimePosition,
+						})
+					}
 				}
 			}
 
@@ -573,7 +603,6 @@ export const SourceLayerItem = withTranslation()(
 			const cursorTimePosition = Math.max(cursorPosition.left, 0) / this.props.timeScale
 
 			this.setState({
-				scrollLeftOffset: 0,
 				elementPosition: elementPos,
 				cursorPosition,
 				cursorTimePosition,


### PR DESCRIPTION
This fixes a bug where the hover scrub in the next part would advance on its own. This was due to the `scrollLeftOffset` pushing the current time along, despite the relative position of the cursor and div not changing in screen-space. I have stored the cursor position in the places we capture it and use that to re-calculate the time position.