### PR TITLE
fix: Show hardcoded SERVER A/B when sourcelayer is VT instead of clip id

### DIFF
--- a/meteor/client/ui/Shelf/PartNamePanel.tsx
+++ b/meteor/client/ui/Shelf/PartNamePanel.tsx
@@ -45,16 +45,12 @@ class PartNamePanelInner extends MeteorReactComponent<
 		const { t, panel } = this.props
 
 		const sourceLayerType = this.props.instanceToShow?.sourceLayer?.type
-		let backgroundSourceLayer = sourceLayerType ? sourceLayerTypeToString(sourceLayerType) : undefined
-
-		if (!backgroundSourceLayer) {
-			backgroundSourceLayer = ''
-		}
+		const backgroundBySourceLayer: string = sourceLayerTypeToString(sourceLayerType) || 'unknown'
 
 		return (
 			<div
 				className={ClassNames('part-name-panel', {
-					[backgroundSourceLayer || 'unknown']: true,
+					[backgroundBySourceLayer]: true,
 				})}
 				style={_.extend(
 					isDashboardLayout
@@ -69,15 +65,23 @@ class PartNamePanelInner extends MeteorReactComponent<
 					<span className="part-name-title">
 						{this.props.panel.part === 'current' ? t('Current Part') : t('Next Part')}
 					</span>
-					<span className="part-name">{this.props.name}</span>
+					<span className="part-name">{getPartName(sourceLayerType, this.props.name)}</span>
 				</div>
 			</div>
 		)
 	}
 }
 
-function sourceLayerTypeToString(sourceLayerType: SourceLayerType) {
-	if (!sourceLayerType) return
+function getPartName(sourceLayerType: SourceLayerType, name: string | undefined): string | undefined {
+	const isVtClip: boolean = sourceLayerType == SourceLayerType.VT
+	if (isVtClip) {
+		return 'SERVER A/B'
+	}
+	return name
+}
+
+function sourceLayerTypeToString(sourceLayerType: SourceLayerType): string {
+	if (!sourceLayerType) return ''
 
 	switch (sourceLayerType) {
 		case SourceLayerType.GRAPHICS:
@@ -92,6 +96,8 @@ function sourceLayerTypeToString(sourceLayerType: SourceLayerType) {
 			return 'vt'
 		case SourceLayerType.CAMERA:
 			return 'camera'
+		default:
+			return ''
 	}
 }
 


### PR DESCRIPTION
In the presenter view when the next part is a clip of type SourceLayerType.VT  "SERVER A/B" will now be shown instead of the clipId