### PR TITLE
Bug: Find last scriptet piece on script

### DIFF
--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -489,7 +489,7 @@ export namespace ServerPlayoutAdLibAPI {
 				return b.enable.start - a.enable.start
 			})
 
-		const piece: Piece = piecesSortedAsc[0]
+		const piece: Piece | undefined = piecesSortedAsc.shift()
 		if (!piece) {
 			return
 		}


### PR DESCRIPTION
innerFindLastScriptedPieceOnLayer would return the correct Piece but the object did only contain _id, startPartId and enable not the metadata property as required by the funtion calling it blueprints.
It will now fetch the entire Piece before returning the object. 