### PR TITLE
refactor: disable NTP time adjustment

### DIFF
--- a/meteor/__mocks__/meteor.ts
+++ b/meteor/__mocks__/meteor.ts
@@ -85,9 +85,9 @@ const $ = {
 export namespace MeteorMock {
 	export const isTest: boolean = true
 
-	export const isClient: boolean = false
+	export let isClient: boolean = false
 	export const isCordova: boolean = false
-	export const isServer: boolean = true
+	export let isServer: boolean = true
 	export const isProduction: boolean = false
 	export const release: string = ''
 
@@ -285,6 +285,14 @@ export namespace MeteorMock {
 	}
 	export function mockSetUsersCollection(usersCollection) {
 		users = usersCollection
+	}
+	export function mockSetClientEnvironment() {
+		isServer = false
+		isClient = true
+	}
+	export function mockSetServerEnvironment() {
+		isServer = true
+		isClient = false
 	}
 
 	// locally defined function here, so there are no import to the rest of the code

--- a/meteor/lib/__tests__/lib.test.ts
+++ b/meteor/lib/__tests__/lib.test.ts
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor'
 import { Mongo } from 'meteor/mongo'
-import { testInFiber } from '../../__mocks__/helpers/jest'
+import { afterEachInFiber, testInFiber } from '../../__mocks__/helpers/jest'
 import { setLoggerLevel } from '../../server/api/logger'
 import {
 	getHash,
@@ -30,10 +30,14 @@ import {
 import { TimelineObjType, TimelineObjGeneric } from '../collections/Timeline'
 import { TSR } from '@sofie-automation/blueprints-integration'
 import { FindOptions } from '../typings/meteor'
+import { MeteorMock } from '../../__mocks__/meteor'
 
 // require('../../../../../server/api/ingest/mosDevice/api.ts') // include in order to create the Meteor methods needed
 
 describe('lib/lib', () => {
+	afterEachInFiber(() => {
+		MeteorMock.mockSetServerEnvironment()
+	})
 	testInFiber('getHash', () => {
 		const h0 = getHash('abc')
 		const h1 = getHash('abcd')
@@ -66,7 +70,10 @@ describe('lib/lib', () => {
 	})
 	testInFiber('getCurrentTime', () => {
 		systemTime.diff = 5439
+		MeteorMock.mockSetClientEnvironment()
 		expect(getCurrentTime() / 1000).toBeCloseTo((Date.now() - 5439) / 1000, 1)
+		MeteorMock.mockSetServerEnvironment()
+		expect(getCurrentTime() / 1000).toBeCloseTo(Date.now() / 1000, 1)
 	})
 	testInFiber('literal', () => {
 		const obj = literal<TimelineObjGeneric>({

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -120,12 +120,13 @@ const systemTime = {
 }
 /**
  * Returns the current (synced) time
- * The synced time differs from Date.now() in that it uses a time synced with the Sofie server,
+ * On the server: It equals Date.now() because we're assuming the system clock is NTP-synced and accurate enough.
+ * On the client: The synced time differs from Date.now() in that it uses a time synced with the Sofie server,
  * so it is unaffected of whether the client has a well-synced computer time or not.
  * @return {Time}
  */
 export function getCurrentTime(): Time {
-	return Math.floor(Date.now() - systemTime.diff)
+	return Math.floor(Date.now() - (Meteor.isServer ? 0 : systemTime.diff))
 }
 export { systemTime }
 


### PR DESCRIPTION
Change `getCurrentTime` for server environment to no longer subtract the diff calculated using the NTP server.
From now on we're assuming that the system clock on the server running Core is NTP-synced and accurate enough.
Diff calculation using NTP is kept for information purposes only. System status and logging is adjusted to reflect that.
Syncing the time between server and the client, and between server and peripheral devices stays as it was.