### PR TITLE
fix: change the freeze countdown color

### DIFF
--- a/meteor/client/styles/customInstallation.scss
+++ b/meteor/client/styles/customInstallation.scss
@@ -106,6 +106,10 @@ body.tv2 {
 				border-top-right-radius: 1em;
 				border-bottom-right-radius: 1em;
 			}
+
+			.segment-timeline__liveline__appendage.segment-timeline__liveline__appendage--piece-countdown {
+				color: #fff;
+			}
 		}
 
 		.segment-timeline__editorialline {


### PR DESCRIPTION
Changes the text color of the freeze countdown to white
![image](https://user-images.githubusercontent.com/9103996/139134119-403d0b59-27b3-4849-8173-0e89a42a192d.png)

