### PR TITLE
feat: synced time displays

### DIFF
--- a/meteor/client/lib/Moment.tsx
+++ b/meteor/client/lib/Moment.tsx
@@ -8,7 +8,7 @@ import { RundownUtils } from './rundown'
 import _ from 'underscore'
 import { RundownTiming } from '../ui/RundownView/RundownTiming/RundownTiming'
 
-const MAX_TIME_WITHOUT_UPDATE = 1000
+const MAX_TIME_WITHOUT_UPDATE = 2000
 
 /**
  * Use instead of <Moment fromNow></Moment>, its result is synced with getCurrentTime()

--- a/meteor/client/lib/Moment.tsx
+++ b/meteor/client/lib/Moment.tsx
@@ -3,6 +3,12 @@ import Moment, { MomentProps } from 'react-moment'
 import moment from 'moment'
 import { getCurrentTime } from '../../lib/lib'
 import timer from 'react-timer-hoc'
+import { uniqueId } from 'underscore'
+import { RundownUtils } from './rundown'
+import _ from 'underscore'
+import { RundownTiming } from '../ui/RundownView/RundownTiming/RundownTiming'
+
+const MAX_TIME_WITHOUT_UPDATE = 1000
 
 /**
  * Use instead of <Moment fromNow></Moment>, its result is synced with getCurrentTime()
@@ -11,3 +17,187 @@ import timer from 'react-timer-hoc'
 export const MomentFromNow = timer(60000)(function MomentFromNow(args: MomentProps) {
 	return <Moment {...args} from={moment(getCurrentTime())} interval={0}></Moment>
 })
+
+type SyncedTimeReadyFunction = () => boolean
+type SyncedTimeUpdateFunction = () => void
+class SyncedTimeDisplays {
+	displays: Map<string, { ready: SyncedTimeReadyFunction; update: SyncedTimeUpdateFunction }> = new Map()
+	lastUpdated: number = 0
+
+	constructor() {
+		window.addEventListener(RundownTiming.Events.timeupdate, () => this.updateMoments())
+	}
+
+	addMoment(readyFunc: SyncedTimeReadyFunction, updateFunc: SyncedTimeUpdateFunction): string {
+		let id = uniqueId('synced_moment')
+		this.displays.set(id, { ready: readyFunc, update: updateFunc })
+		return id
+	}
+	removeMoment(id: string): void {
+		this.displays.delete(id)
+	}
+
+	updateMoments() {
+		let timeSinceLastUpdate = Date.now() - this.lastUpdated
+		if (
+			timeSinceLastUpdate >= MAX_TIME_WITHOUT_UPDATE ||
+			Array.from(this.displays.values()).every((display) => display.ready())
+		) {
+			this.lastUpdated = Date.now()
+			for (const display of this.displays.values()) {
+				display.update()
+			}
+		}
+	}
+}
+const syncedTimeDisplays = new SyncedTimeDisplays()
+
+/**
+ * Rounds time to the nearest second
+ * @param time Time in ms
+ * @returns Time value rounded down to nearest second
+ */
+function toNearestSecond(time: number): number {
+	return (time / 1000) * 1000
+}
+
+interface SyncedMomentProps {
+	lockedDate: number | undefined
+}
+
+interface SyncedMomentState {
+	id?: string
+	date?: number
+	nextDate?: number
+}
+export class SyncedMoment extends React.Component<SyncedMomentProps & MomentProps, SyncedMomentState> {
+	constructor(props) {
+		super(props)
+
+		this.state = {}
+	}
+
+	componentDidMount() {
+		let id = syncedTimeDisplays.addMoment(
+			() => this.hasNextState(),
+			() => this.updateMoment()
+		)
+		this.setState({ id })
+	}
+
+	componentWillUnmount() {
+		if (this.state.id) {
+			syncedTimeDisplays.removeMoment(this.state.id)
+		}
+	}
+
+	hasNextState(): boolean {
+		if (this.state.nextDate !== undefined && this.state.nextDate !== this.state.date) {
+			return true
+		}
+
+		const now = toNearestSecond(Date.now())
+		if (this.props.lockedDate === undefined && this.state.date !== now) {
+			this.setState({ nextDate: now })
+			return true
+		}
+
+		if (this.state.date !== this.props.lockedDate) {
+			this.setState({ nextDate: this.props.lockedDate })
+			return true
+		}
+
+		return true
+	}
+
+	updateMoment() {
+		if (this.state.nextDate) {
+			this.setState({ date: this.state.nextDate, nextDate: undefined })
+		}
+	}
+
+	render() {
+		return <Moment {..._.omit(this.props, 'lockedDate')} date={this.state.date} />
+	}
+}
+
+interface SyncedDiffTimecodeProps {
+	diff?: number
+	showPlus?: boolean
+	showHours?: boolean
+	enDashAsMinus?: boolean
+	useSmartFloor?: boolean
+	useSmartHours?: boolean
+	minusPrefix?: string
+	floorTime?: boolean
+	hardFloor?: boolean
+}
+
+interface SyncedDiffTimecodeState {
+	id?: string
+	diff?: string
+	nextDiff?: string
+}
+
+export class SyncedDiffTimecode extends React.Component<SyncedDiffTimecodeProps, SyncedDiffTimecodeState> {
+	constructor(props) {
+		super(props)
+
+		this.state = {}
+	}
+
+	componentDidMount() {
+		let id = syncedTimeDisplays.addMoment(
+			() => this.hasNextState(),
+			() => this.updateMoment()
+		)
+		this.setState({ id })
+	}
+
+	componentWillUnmount() {
+		if (this.state.id) {
+			syncedTimeDisplays.removeMoment(this.state.id)
+		}
+	}
+
+	hasNextState(): boolean {
+		if (this.state.nextDiff !== undefined && this.state.nextDiff !== this.state.diff) {
+			return true
+		}
+
+		const next = this.props.diff
+			? RundownUtils.formatDiffToTimecode(
+					this.props.diff,
+					this.props.showPlus,
+					this.props.showHours,
+					this.props.enDashAsMinus,
+					this.props.useSmartFloor,
+					this.props.useSmartHours,
+					this.props.minusPrefix,
+					this.props.floorTime,
+					this.props.hardFloor
+			  )
+			: null
+
+		if (!next) {
+			return false
+		}
+
+		if (next !== this.state.diff) {
+			this.setState({ nextDiff: next })
+			return true
+		}
+
+		return false
+	}
+
+	updateMoment() {
+		if (this.state.nextDiff) {
+			this.setState({ diff: this.state.nextDiff, nextDiff: undefined })
+		}
+	}
+
+	render() {
+		return this.state.diff ?? null
+	}
+}

--- a/meteor/client/ui/ClockView/OverlayScreen.tsx
+++ b/meteor/client/ui/ClockView/OverlayScreen.tsx
@@ -9,6 +9,7 @@ import { PieceNameContainer } from '../PieceIcons/PieceName'
 import { Timediff } from './Timediff'
 import { getPresenterScreenReactive, PresenterScreenBase, RundownOverviewTrackedProps } from './PresenterScreen'
 import { StudioId } from '../../../lib/collections/Studios'
+import { SyncedMoment } from '../../lib/Moment'
 
 interface TimeMap {
 	[key: string]: number
@@ -97,7 +98,7 @@ export const OverlayScreen = withTranslation()(
 										)}
 									</div>
 									<span className="clocks-time-now">
-										<Moment interval={0} format="HH:mm:ss" date={currentTime} />
+										<SyncedMoment interval={0} format="HH:mm:ss" lockedDate={currentTime} />
 									</span>
 								</div>
 							</div>

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -33,6 +33,7 @@ import {
 import { ShelfDashboardLayout } from '../Shelf/ShelfDashboardLayout'
 import { ShowStyleVariant, ShowStyleVariantId, ShowStyleVariants } from '../../../lib/collections/ShowStyleVariants'
 import { Studio, StudioId, Studios } from '../../../lib/collections/Studios'
+import { SyncedDiffTimecode } from '../../lib/Moment'
 
 interface SegmentUi extends DBSegment {
 	items: Array<PartUi>
@@ -542,7 +543,15 @@ export class PresenterScreenBase extends MeteorReactComponent<
 								over: Math.floor(overUnderClock / 1000) >= 0,
 							})}
 						>
-							{RundownUtils.formatDiffToTimecode(overUnderClock, true, false, true, true, true, undefined, true)}
+							<SyncedDiffTimecode
+								diff={overUnderClock}
+								showPlus={true}
+								showHours={false}
+								enDashAsMinus={true}
+								useSmartFloor={true}
+								useSmartHours={true}
+								floorTime={true}
+							/>
 						</div>
 					</div>
 				</div>

--- a/meteor/client/ui/ClockView/Timediff.tsx
+++ b/meteor/client/ui/ClockView/Timediff.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import ClassNames from 'classnames'
 import { RundownUtils } from '../../lib/rundown'
+import { SyncedDiffTimecode } from '../../lib/Moment'
 
 export const Timediff = class Timediff extends React.Component<{ time: number }> {
 	render() {
 		const time = -this.props.time
 		const isNegative = Math.floor(time / 1000) > 0
-		const timeString = RundownUtils.formatDiffToTimecode(time, true, false, true, false, true, '', false, true)
 
 		return (
 			<span
@@ -15,7 +15,17 @@ export const Timediff = class Timediff extends React.Component<{ time: number }>
 					'clocks-counter-heavy': time / 1000 > -30,
 				})}
 			>
-				{timeString}
+				<SyncedDiffTimecode
+					diff={time}
+					showPlus={true}
+					showHours={false}
+					enDashAsMinus={true}
+					useSmartFloor={false}
+					useSmartHours={true}
+					minusPrefix={''}
+					floorTime={false}
+					hardFloor={true}
+				/>
 			</span>
 		)
 	}

--- a/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
@@ -11,6 +11,7 @@ import { NoraFloatingInspector } from './NoraFloatingInspector'
 import { FloatingInspector } from '../FloatingInspector'
 import { Time } from '../../../lib/lib'
 import { PieceInstancePiece } from '../../../lib/collections/PieceInstances'
+import { SyncedMoment } from '../../lib/Moment'
 
 interface IProps {
 	piece: PieceInstancePiece
@@ -137,7 +138,7 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 								)}
 								{changed && (
 									<span className="mini-inspector__changed">
-										<Moment date={changed} calendar={true} />
+										<SyncedMoment lockedDate={changed} calendar={true} />
 									</span>
 								)}
 							</td>

--- a/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
@@ -5,6 +5,7 @@ import Moment from 'react-moment'
 import { FloatingInspector } from '../FloatingInspector'
 import { ScriptContent } from '@sofie-automation/blueprints-integration'
 import { GetScriptPreview } from '../scriptPreview'
+import { SyncedMoment } from '../../lib/Moment'
 
 interface IProps {
 	typeClass?: string
@@ -47,7 +48,7 @@ export function MicFloatingInspector(props: IProps) {
 				{props.content && props.content.lastModified ? (
 					<div className="mini-inspector__footer">
 						<span className="mini-inspector__changed">
-							<Moment date={props.content.lastModified} calendar={true} />
+							<SyncedMoment lockedDate={props.content.lastModified} calendar={true} />
 						</span>
 					</div>
 				) : null}

--- a/meteor/client/ui/Prompter/OverUnderTimer.tsx
+++ b/meteor/client/ui/Prompter/OverUnderTimer.tsx
@@ -5,6 +5,7 @@ import { RundownUtils } from '../../lib/rundown'
 import ClassNames from 'classnames'
 import { getCurrentTime } from '../../../lib/lib'
 import { PlaylistTiming } from '../../../lib/rundown/rundownTiming'
+import { SyncedDiffTimecode } from '../../lib/Moment'
 
 interface IProps {
 	rundownPlaylist: RundownPlaylist
@@ -32,16 +33,15 @@ export const OverUnderTimer = withTiming<IProps, {}>()(
 						light: (this.props.timingDurations.totalPlaylistDuration || 0) > target,
 					})}
 				>
-					{RundownUtils.formatDiffToTimecode(
-						(this.props.timingDurations.totalPlaylistDuration || 0) - target,
-						true,
-						false,
-						true,
-						true,
-						true,
-						undefined,
-						true
-					)}
+					<SyncedDiffTimecode
+						diff={(this.props.timingDurations.totalPlaylistDuration || 0) - target}
+						showPlus={true}
+						showHours={false}
+						enDashAsMinus={true}
+						useSmartFloor={true}
+						useSmartHours={true}
+						floorTime={true}
+					/>
 				</span>
 			) : null
 		}

--- a/meteor/client/ui/RundownList/RundownListItemView.tsx
+++ b/meteor/client/ui/RundownList/RundownListItemView.tsx
@@ -14,6 +14,7 @@ import { RundownViewLayoutSelection } from './RundownViewLayoutSelection'
 import { RundownLayoutBase } from '../../../lib/collections/RundownLayouts'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { PlaylistTiming } from '../../../lib/rundown/rundownTiming'
+import { SyncedDiffTimecode } from '../../lib/Moment'
 
 interface IRundownListItemViewProps {
 	isActive: boolean
@@ -133,7 +134,14 @@ export default withTranslation()(function RundownListItemView(props: Translated<
 							</span>
 						</Tooltip>
 					) : (
-						RundownUtils.formatDiffToTimecode(expectedDuration, false, true, true, false, true)
+						<SyncedDiffTimecode
+							diff={expectedDuration}
+							showPlus={false}
+							showHours={true}
+							enDashAsMinus={true}
+							useSmartFloor={false}
+							useSmartHours={true}
+						/>
 					)
 				) : isOnlyRundownInPlaylist && playlist.loop ? (
 					<Tooltip overlay={t('This rundown will loop indefinitely')} placement="top">

--- a/meteor/client/ui/RundownList/RundownPlaylistUi.tsx
+++ b/meteor/client/ui/RundownList/RundownPlaylistUi.tsx
@@ -41,6 +41,7 @@ import { doUserAction, UserAction } from '../../lib/userAction'
 import { RundownViewLayoutSelection } from './RundownViewLayoutSelection'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { PlaylistTiming } from '../../../lib/rundown/rundownTiming'
+import { SyncedDiffTimecode } from '../../lib/Moment'
 
 export interface RundownPlaylistUi extends RundownPlaylist {
 	rundowns: Rundown[]
@@ -310,7 +311,14 @@ export const RundownPlaylistUi = DropTarget(
 							</span>
 						</Tooltip>
 					) : (
-						RundownUtils.formatDiffToTimecode(playlistExpectedDuration, false, true, true, false, true)
+						<SyncedDiffTimecode
+							diff={playlistExpectedDuration}
+							showPlus={false}
+							showHours={true}
+							enDashAsMinus={true}
+							useSmartFloor={false}
+							useSmartHours={true}
+						/>
 					))
 
 				const classNames = ClassNames(['rundown-playlist', { droptarget: isActiveDropZone }])

--- a/meteor/client/ui/RundownView/PlaylistLoopingHeader.tsx
+++ b/meteor/client/ui/RundownView/PlaylistLoopingHeader.tsx
@@ -6,6 +6,7 @@ import Moment from 'react-moment'
 import { LoopingIcon } from '../../lib/ui/icons/looping'
 import { WithTiming, withTiming } from './RundownTiming/withTiming'
 import { RundownUtils } from '../../lib/rundown'
+import { SyncedMoment } from '../../lib/Moment'
 
 const NextLoopClock = withTiming<{ useWallClock?: boolean }, {}>()(
 	class NextLoopClock extends React.Component<
@@ -24,10 +25,10 @@ const NextLoopClock = withTiming<{ useWallClock?: boolean }, {}>()(
 			return (
 				<span>
 					{useWallClock ? (
-						<Moment
+						<SyncedMoment
 							interval={0}
 							format="HH:mm:ss"
-							date={(timingDurations.currentTime || 0) + (thisPartCountdown || 0)}
+							lockedDate={(timingDurations.currentTime || 0) + (thisPartCountdown || 0)}
 						/>
 					) : (
 						RundownUtils.formatTimeToShortTime(

--- a/meteor/client/ui/RundownView/RundownDividerHeader.tsx
+++ b/meteor/client/ui/RundownView/RundownDividerHeader.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import { Rundown } from '../../../lib/collections/Rundowns'
 import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
-import Moment from 'react-moment'
 import { withTiming, WithTiming } from './RundownTiming/withTiming'
 import { RundownUtils } from '../../lib/rundown'
 import { withTranslation } from 'react-i18next'
 import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { PlaylistTiming } from '../../../lib/rundown/rundownTiming'
+import { SyncedDiffTimecode, SyncedMoment } from '../../lib/Moment'
 
 interface IProps {
 	rundown: Rundown
@@ -78,14 +78,13 @@ export const RundownDividerHeader = withTranslation()(function RundownDividerHea
 			{expectedStart ? (
 				<div className="rundown-divider-timeline__expected-start">
 					<span>{t('Planned Start')}</span>&nbsp;
-					<Moment
+					<SyncedMoment
 						interval={1000}
 						calendar={{
 							sameElse: 'lll',
 						}}
-					>
-						{expectedStart}
-					</Moment>
+						lockedDate={expectedStart}
+					/>
 					&nbsp;
 					<MarkerCountdownText
 						className="rundown-divider-timeline__expected-start__countdown"
@@ -96,20 +95,26 @@ export const RundownDividerHeader = withTranslation()(function RundownDividerHea
 			{expectedDuration ? (
 				<div className="rundown-divider-timeline__expected-duration">
 					<span>{t('Planned Duration')}</span>&nbsp;
-					{RundownUtils.formatDiffToTimecode(expectedDuration, false, true, true, false, true)}
+					<SyncedDiffTimecode
+						diff={expectedDuration}
+						showPlus={false}
+						showHours={true}
+						enDashAsMinus={true}
+						useSmartFloor={false}
+						useSmartHours={true}
+					/>
 				</div>
 			) : null}
 			{expectedEnd ? (
 				<div className="rundown-divider-timeline__expected-end">
 					<span>{t('Planned End')}</span>&nbsp;
-					<Moment
+					<SyncedMoment
 						interval={1000}
 						calendar={{
 							sameElse: 'lll',
 						}}
-					>
-						{expectedEnd}
-					</Moment>
+						lockedDate={expectedEnd}
+					/>
 					&nbsp;
 					<MarkerCountdownText
 						className="rundown-divider-timeline__expected-end__countdown"

--- a/meteor/client/ui/RundownView/RundownOverview.tsx
+++ b/meteor/client/ui/RundownView/RundownOverview.tsx
@@ -13,6 +13,7 @@ import { RundownUtils } from '../../lib/rundown'
 import { RundownPlaylists, RundownPlaylist, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
 import { findPartInstanceOrWrapToTemporary } from '../../../lib/collections/PartInstances'
 import { PlaylistTiming } from '../../../lib/rundown/rundownTiming'
+import { SyncedDiffTimecode } from '../../lib/Moment'
 
 interface SegmentUi extends DBSegment {
 	items: Array<PartUi>
@@ -200,7 +201,14 @@ export const RundownOverview = withTracker<RundownOverviewProps, RundownOverview
 									{segment.name}
 									{segmentDuration && _.isNumber(segmentDuration) && (
 										<span className="rundown__overview__segment__part__label__duration">
-											{RundownUtils.formatDiffToTimecode(segmentDuration, false, false, false, false, true)}
+											<SyncedDiffTimecode
+												diff={segmentDuration}
+												showPlus={false}
+												showHours={false}
+												enDashAsMinus={false}
+												useSmartFloor={false}
+												useSmartHours={true}
+											/>
 										</span>
 									)}
 								</div>

--- a/meteor/client/ui/RundownView/RundownTiming/CurrentPartElapsed.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/CurrentPartElapsed.tsx
@@ -4,6 +4,7 @@ import { withTiming, WithTiming } from './withTiming'
 import { RundownUtils } from '../../../lib/rundown'
 import { PartId } from '../../../../lib/collections/Parts'
 import { unprotectString } from '../../../../lib/lib'
+import { SyncedDiffTimecode } from '../../../lib/Moment'
 
 interface IPartElapsedProps {
 	currentPartId: PartId | undefined
@@ -27,7 +28,17 @@ export const CurrentPartElapsed = withTiming<IPartElapsedProps, {}>({
 
 			return (
 				<span className={ClassNames(this.props.className)}>
-					{RundownUtils.formatDiffToTimecode(displayTimecode || 0, true, false, true, false, true, '', false, true)}
+					<SyncedDiffTimecode
+						diff={displayTimecode || 0}
+						showPlus={true}
+						showHours={false}
+						enDashAsMinus={true}
+						useSmartFloor={false}
+						useSmartHours={true}
+						minusPrefix={''}
+						floorTime={false}
+						hardFloor={true}
+					/>
 				</span>
 			)
 		}

--- a/meteor/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
@@ -4,6 +4,7 @@ import { withTiming, WithTiming } from './withTiming'
 import { RundownUtils } from '../../../lib/rundown'
 import { PartInstanceId } from '../../../../lib/collections/PartInstances'
 import { SpeechSynthesiser } from '../../../lib/speechSynthesis'
+import { SyncedDiffTimecode } from '../../../lib/Moment'
 
 const SPEAK_ADVANCE = 500
 
@@ -36,7 +37,17 @@ export const CurrentPartRemaining = withTiming<IPartRemainingProps, {}>({
 						Math.floor((displayTimecode || 0) / 1000) > 0 ? this.props.heavyClassName : undefined
 					)}
 				>
-					{RundownUtils.formatDiffToTimecode(displayTimecode || 0, true, false, true, false, true, '', false, true)}
+					<SyncedDiffTimecode
+						diff={displayTimecode || 0}
+						showPlus={true}
+						showHours={false}
+						enDashAsMinus={true}
+						useSmartFloor={false}
+						useSmartHours={true}
+						minusPrefix={''}
+						floorTime={false}
+						hardFloor={true}
+					/>
 				</span>
 			)
 		}

--- a/meteor/client/ui/RundownView/RundownTiming/NextBreakTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/NextBreakTiming.tsx
@@ -6,6 +6,7 @@ import { Translated } from '../../../lib/ReactMeteorData/ReactMeteorData'
 import { WithTiming, withTiming } from './withTiming'
 import ClassNames from 'classnames'
 import { PlaylistTiming } from '../../../../lib/rundown/rundownTiming'
+import { SyncedMoment } from '../../../lib/Moment'
 
 interface INextBreakTimingProps {
 	loop?: boolean
@@ -34,7 +35,7 @@ export const NextBreakTiming = withTranslation()(
 					<React.Fragment>
 						<span className={ClassNames('timing-clock plan-end right', { 'visual-last-child': this.props.lastChild })}>
 							<span className="timing-clock-label right">{t(this.props.breakText || 'Next Break')}</span>
-							<Moment interval={0} format="HH:mm:ss" date={expectedEnd} />
+							<SyncedMoment interval={0} format="HH:mm:ss" lockedDate={expectedEnd} />
 						</span>
 					</React.Fragment>
 				)

--- a/meteor/client/ui/RundownView/RundownTiming/PartCountdown.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/PartCountdown.tsx
@@ -1,11 +1,11 @@
 import React, { ReactNode } from 'react'
-import Moment from 'react-moment'
 import { PartId } from '../../../../lib/collections/Parts'
 import { withTiming, WithTiming } from './withTiming'
 import { unprotectString } from '../../../../lib/lib'
 import { RundownUtils } from '../../../lib/rundown'
 import { RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
 import { PlaylistTiming } from '../../../../lib/rundown/rundownTiming'
+import { SyncedMoment } from '../../../lib/Moment'
 
 interface IPartCountdownProps {
 	partId?: PartId
@@ -33,10 +33,10 @@ export const PartCountdown = withTiming<IPartCountdownProps, {}>()(function Part
 			{props.label}
 			<span>
 				{props.useWallClock ? (
-					<Moment
+					<SyncedMoment
 						interval={0}
 						format="HH:mm:ss"
-						date={
+						lockedDate={
 							(props.playlist.activationId
 								? // if show is activated, use currentTime as base
 								  props.timingDurations.currentTime ?? 0

--- a/meteor/client/ui/RundownView/RundownTiming/PlaylistEndTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/PlaylistEndTiming.tsx
@@ -8,6 +8,7 @@ import { withTiming, WithTiming } from './withTiming'
 import ClassNames from 'classnames'
 import { RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
 import { PlaylistTiming } from '../../../../lib/rundown/rundownTiming'
+import { SyncedDiffTimecode, SyncedMoment } from '../../../lib/Moment'
 
 interface IEndTimingProps {
 	rundownPlaylist: RundownPlaylist
@@ -55,14 +56,14 @@ export const PlaylistEndTiming = withTranslation()(
 										{!this.props.hidePlannedEndLabel && (
 											<span className="timing-clock-label right">{this.props.endLabel ?? t('Planned End')}</span>
 										)}
-										<Moment interval={0} format="HH:mm:ss" date={expectedEnd} />
+										<SyncedMoment interval={0} format="HH:mm:ss" lockedDate={expectedEnd} />
 									</span>
 								) : (
 									<span className="timing-clock plan-end right visual-last-child">
 										{!this.props.hidePlannedEndLabel && (
 											<span className="timing-clock-label right">{this.props.endLabel ?? t('Expected End')}</span>
 										)}
-										<Moment interval={0} format="HH:mm:ss" date={expectedEnd} />
+										<SyncedMoment interval={0} format="HH:mm:ss" lockedDate={expectedEnd} />
 									</span>
 								)
 							) : this.props.timingDurations ? (
@@ -74,10 +75,10 @@ export const PlaylistEndTiming = withTranslation()(
 											{!this.props.hidePlannedEndLabel && (
 												<span className="timing-clock-label right">{t('Next Loop at')}</span>
 											)}
-											<Moment
+											<SyncedMoment
 												interval={0}
 												format="HH:mm:ss"
-												date={
+												lockedDate={
 													now +
 													(this.props.timingDurations.partCountdown[
 														Object.keys(this.props.timingDurations.partCountdown)[0]
@@ -91,10 +92,10 @@ export const PlaylistEndTiming = withTranslation()(
 										{!this.props.hidePlannedEndLabel && (
 											<span className="timing-clock-label right">{this.props.endLabel ?? t('Expected End')}</span>
 										)}
-										<Moment
+										<SyncedMoment
 											interval={0}
 											format="HH:mm:ss"
-											date={(expectedStart || now) + (this.props.timingDurations.remainingPlaylistDuration || 0)}
+											lockedDate={(expectedStart || now) + (this.props.timingDurations.remainingPlaylistDuration || 0)}
 										/>
 									</span>
 								)
@@ -104,16 +105,16 @@ export const PlaylistEndTiming = withTranslation()(
 							!this.props.hideCountdown &&
 							(expectedEnd ? (
 								<span className="timing-clock countdown plan-end right">
-									{RundownUtils.formatDiffToTimecode(now - expectedEnd, true, true, true)}
+									<SyncedDiffTimecode diff={now - expectedEnd} showPlus={true} showHours={true} enDashAsMinus={true} />
 								</span>
 							) : expectedStart && expectedDuration ? (
 								<span className="timing-clock countdown plan-end right">
-									{RundownUtils.formatDiffToTimecode(
-										getCurrentTime() - (expectedStart + expectedDuration),
-										true,
-										true,
-										true
-									)}
+									<SyncedDiffTimecode
+										diff={getCurrentTime() - (expectedStart + expectedDuration)}
+										showPlus={true}
+										showHours={true}
+										enDashAsMinus={true}
+									/>
 								</span>
 							) : null)}
 						{!this.props.hideDiff ? (
@@ -125,7 +126,15 @@ export const PlaylistEndTiming = withTranslation()(
 									})}
 								>
 									{!this.props.hideDiffLabel && <span className="timing-clock-label right">{t('Diff')}</span>}
-									{RundownUtils.formatDiffToTimecode(diff, true, false, true, true, true, undefined, true)}
+									<SyncedDiffTimecode
+										diff={diff}
+										showPlus={true}
+										showHours={false}
+										enDashAsMinus={true}
+										useSmartFloor={true}
+										useSmartHours={true}
+										floorTime={true}
+									/>
 								</span>
 							) : null
 						) : null}

--- a/meteor/client/ui/RundownView/RundownTiming/PlaylistStartTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/PlaylistStartTiming.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import { WithTranslation, withTranslation } from 'react-i18next'
-import Moment from 'react-moment'
 import { Translated } from '../../../lib/ReactMeteorData/ReactMeteorData'
 import { withTiming, WithTiming } from './withTiming'
 import { RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
-import { RundownUtils } from '../../../lib/rundown'
 import { getCurrentTime } from '../../../../lib/lib'
 import ClassNames from 'classnames'
 import { PlaylistTiming } from '../../../../lib/rundown/rundownTiming'
+import { SyncedDiffTimecode, SyncedMoment } from '../../../lib/Moment'
 
 interface IEndTimingProps {
 	rundownPlaylist: RundownPlaylist
@@ -36,17 +35,21 @@ export const PlaylistStartTiming = withTranslation()(
 							(rundownPlaylist.startedPlayback && rundownPlaylist.activationId && !rundownPlaylist.rehearsal ? (
 								<span className="timing-clock plan-start left">
 									<span className="timing-clock-label left">{t('Started')}</span>
-									<Moment interval={0} format="HH:mm:ss" date={rundownPlaylist.startedPlayback} />
+									<SyncedMoment interval={0} format="HH:mm:ss" lockedDate={rundownPlaylist.startedPlayback} />
 								</span>
 							) : playlistExpectedStart ? (
 								<span className="timing-clock plan-start left">
 									<span className="timing-clock-label left">{this.props.plannedStartText || t('Planned Start')}</span>
-									<Moment interval={0} format="HH:mm:ss" date={playlistExpectedStart} />
+									<SyncedMoment interval={0} format="HH:mm:ss" lockedDate={playlistExpectedStart} />
 								</span>
 							) : playlistExpectedEnd && playlistExpectedDuration ? (
 								<span className="timing-clock plan-start left">
 									<span className="timing-clock-label left">{this.props.plannedStartText || t('Expected Start')}</span>
-									<Moment interval={0} format="HH:mm:ss" date={playlistExpectedEnd - playlistExpectedDuration} />
+									<SyncedMoment
+										interval={0}
+										format="HH:mm:ss"
+										lockedDate={playlistExpectedEnd - playlistExpectedDuration}
+									/>
 								</span>
 							) : null)}
 						{!this.props.hideDiff && expectedStart && (
@@ -57,16 +60,25 @@ export const PlaylistStartTiming = withTranslation()(
 								})}
 							>
 								<span className="timing-clock-label">{t('Diff')}</span>
-								{rundownPlaylist.startedPlayback
-									? RundownUtils.formatDiffToTimecode(
-											rundownPlaylist.startedPlayback - expectedStart,
-											true,
-											false,
-											true,
-											true,
-											true
-									  )
-									: RundownUtils.formatDiffToTimecode(getCurrentTime() - expectedStart, true, false, true, true, true)}
+								{rundownPlaylist.startedPlayback ? (
+									<SyncedDiffTimecode
+										diff={rundownPlaylist.startedPlayback - expectedStart}
+										showPlus={true}
+										showHours={false}
+										enDashAsMinus={true}
+										useSmartFloor={true}
+										useSmartHours={true}
+									/>
+								) : (
+									<SyncedDiffTimecode
+										diff={getCurrentTime() - expectedStart}
+										showPlus={true}
+										showHours={false}
+										enDashAsMinus={true}
+										useSmartFloor={true}
+										useSmartHours={true}
+									/>
+								)}
 							</span>
 						)}
 					</React.Fragment>

--- a/meteor/client/ui/RundownView/RundownTiming/RundownName.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/RundownName.tsx
@@ -9,6 +9,7 @@ import { Rundown } from '../../../../lib/collections/Rundowns'
 import { RundownUtils } from '../../../lib/rundown'
 import { getCurrentTime } from '../../../../lib/lib'
 import { PlaylistTiming } from '../../../../lib/rundown/rundownTiming'
+import { SyncedDiffTimecode } from '../../../lib/Moment'
 
 interface IRundownNameProps {
 	rundownPlaylist: RundownPlaylist
@@ -74,17 +75,26 @@ export const RundownName = withTranslation()(
 						rundownPlaylist.startedPlayback &&
 						rundownPlaylist.activationId &&
 						!rundownPlaylist.rehearsal
-							? expectedStart &&
-							  RundownUtils.formatDiffToTimecode(
-									rundownPlaylist.startedPlayback - expectedStart,
-									true,
-									false,
-									true,
-									true,
-									true
+							? expectedStart && (
+									<SyncedDiffTimecode
+										diff={rundownPlaylist.startedPlayback - expectedStart}
+										showPlus={true}
+										showHours={false}
+										enDashAsMinus={true}
+										useSmartFloor={true}
+										useSmartHours={true}
+									/>
 							  )
-							: expectedStart &&
-							  RundownUtils.formatDiffToTimecode(getCurrentTime() - expectedStart, true, false, true, true, true)}
+							: expectedStart && (
+									<SyncedDiffTimecode
+										diff={getCurrentTime() - expectedStart}
+										showPlus={true}
+										showHours={false}
+										enDashAsMinus={true}
+										useSmartFloor={true}
+										useSmartHours={true}
+									/>
+							  )}
 					</span>
 				)
 			}

--- a/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
@@ -5,6 +5,7 @@ import { getCurrentTime, unprotectString } from '../../../../lib/lib'
 import { RundownUtils } from '../../../lib/rundown'
 import { PartUi } from '../../SegmentTimeline/SegmentTimelineContainer'
 import { SegmentId } from '../../../../lib/collections/Segments'
+import { SyncedDiffTimecode } from '../../../lib/Moment'
 
 interface ISegmentDurationProps {
 	segmentId: SegmentId
@@ -61,15 +62,39 @@ export const SegmentDuration = withTiming<ISegmentDurationProps, {}>()(function 
 				{props.label}
 				{props.fixed ? (
 					<span className={ClassNames(props.className)}>
-						{RundownUtils.formatDiffToTimecode(budget, false, false, true, false, true, '+')}
+						<SyncedDiffTimecode
+							diff={budget}
+							showPlus={false}
+							showHours={false}
+							enDashAsMinus={true}
+							useSmartFloor={false}
+							useSmartHours={true}
+							minusPrefix={'+'}
+						/>
 					</span>
 				) : props.countUp ? (
 					<span className={ClassNames(props.className)}>
-						{RundownUtils.formatDiffToTimecode(playedOut, false, false, true, false, true, '+')}
+						<SyncedDiffTimecode
+							diff={playedOut}
+							showPlus={false}
+							showHours={false}
+							enDashAsMinus={true}
+							useSmartFloor={false}
+							useSmartHours={true}
+							minusPrefix={'+'}
+						/>
 					</span>
 				) : (
 					<span className={ClassNames(props.className, duration < 0 ? 'negative' : undefined)}>
-						{RundownUtils.formatDiffToTimecode(duration, false, false, true, false, true, '+')}
+						<SyncedDiffTimecode
+							diff={duration}
+							showPlus={false}
+							showHours={false}
+							enDashAsMinus={true}
+							useSmartFloor={false}
+							useSmartHours={true}
+							minusPrefix={'+'}
+						/>
 					</span>
 				)}
 			</>

--- a/meteor/client/ui/RundownView/RundownTiming/TimeOfDay.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/TimeOfDay.tsx
@@ -3,7 +3,7 @@ import { WithTranslation, withTranslation } from 'react-i18next'
 import { Translated } from '../../../lib/ReactMeteorData/ReactMeteorData'
 import { withTiming, WithTiming } from './withTiming'
 import { getCurrentTime } from '../../../../lib/lib'
-import Moment from 'react-moment'
+import { SyncedMoment } from '../../../lib/Moment'
 
 interface ITimeOfDayProps {}
 
@@ -13,7 +13,7 @@ export const TimeOfDay = withTranslation()(
 			render() {
 				return (
 					<span className="timing-clock time-now">
-						<Moment interval={0} format="HH:mm:ss" date={getCurrentTime()} />
+						<SyncedMoment interval={0} format="HH:mm:ss" lockedDate={getCurrentTime()} />
 					</span>
 				)
 			}

--- a/meteor/client/ui/SegmentTimeline/BreakSegment.tsx
+++ b/meteor/client/ui/SegmentTimeline/BreakSegment.tsx
@@ -3,6 +3,7 @@ import { withTranslation } from 'react-i18next'
 import Moment from 'react-moment'
 import { getCurrentTime } from '../../../lib/lib'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
+import { SyncedDiffTimecode, SyncedMoment } from '../../lib/Moment'
 import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { RundownUtils } from '../../lib/rundown'
 import { RundownTiming } from '../RundownView/RundownTiming/RundownTiming'
@@ -47,7 +48,8 @@ class BreakSegmentInner extends MeteorReactComponent<Translated<IProps>, IState>
 			<div className="segment-timeline has-break">
 				<div className="segment-timeline__title">
 					<h2 className="segment-timeline__title__label">
-						{this.props.breakTime && <Moment interval={0} format="HH:mm:ss" date={this.props.breakTime} />}&nbsp;
+						{this.props.breakTime && <SyncedMoment interval={0} format="HH:mm:ss" lockedDate={this.props.breakTime} />}
+						&nbsp;
 						{t('BREAK')}
 					</h2>
 				</div>
@@ -55,14 +57,7 @@ class BreakSegmentInner extends MeteorReactComponent<Translated<IProps>, IState>
 					<div className="segment-timeline__timeUntil">
 						<span className="segment-timeline__timeUntil__label">{t('Break In')}</span>
 						<span>
-							{RundownUtils.formatDiffToTimecode(
-								this.state.displayTimecode,
-								false,
-								undefined,
-								undefined,
-								undefined,
-								true
-							)}
+							<SyncedDiffTimecode diff={this.state.displayTimecode} showPlus={false} useSmartHours={true} />
 						</span>
 					</div>
 				)}

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -7,6 +7,7 @@ import { faCut } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { PieceLifespan, VTContent } from '@sofie-automation/blueprints-integration'
 import { OffsetPosition } from '../../../utils/positions'
+import { SyncedDiffTimecode } from '../../../lib/Moment'
 
 export type SourceDurationLabelAlignment = 'left' | 'right'
 
@@ -129,7 +130,7 @@ export class CustomLayerItemRenderer<
 		) {
 			return (
 				<div className="segment-timeline__piece__label label-overflow-time">
-					{RundownUtils.formatDiffToTimecode(overflowTime, true, false, true)}
+					<SyncedDiffTimecode diff={overflowTime} showPlus={true} showHours={false} enDashAsMinus={true} />
 				</div>
 			)
 		}

--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -23,6 +23,7 @@ import { RundownUtils } from '../../../lib/rundown'
 import { FreezeFrameIcon } from '../../../lib/ui/icons/freezeFrame'
 import StudioContext from '../../RundownView/StudioContext'
 import { Studio } from '../../../../lib/collections/Studios'
+import { SyncedDiffTimecode } from '../../../lib/Moment'
 
 interface IProps extends ICustomLayerItemProps {
 	studio: Studio | undefined
@@ -488,7 +489,17 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 						}}
 					>
 						<span className="segment-timeline__liveline__appendage--piece-countdown__content">
-							{RundownUtils.formatDiffToTimecode(counter || 0, false, false, true, false, true, '', false, false)}
+							<SyncedDiffTimecode
+								diff={counter || 0}
+								showPlus={false}
+								showHours={false}
+								enDashAsMinus={true}
+								useSmartFloor={false}
+								useSmartHours={true}
+								minusPrefix={''}
+								floorTime={false}
+								hardFloor={false}
+							/>
 						</span>
 						<FreezeFrameIcon className="segment-timeline__liveline__appendage--piece-countdown__icon" />
 					</div>

--- a/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelinePartHoverPreview.tsx
+++ b/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelinePartHoverPreview.tsx
@@ -6,6 +6,7 @@ import { unprotectString } from '../../../../lib/lib'
 import { RundownUtils } from '../../../lib/rundown'
 import { PartUi, SegmentUi } from '../SegmentTimelineContainer'
 import { SegmentTimelinePart } from '../SegmentTimelinePart'
+import { SyncedDiffTimecode } from '../../../lib/Moment'
 
 export const SegmentTimelinePartHoverPreview = ({
 	t,
@@ -69,7 +70,14 @@ export const SegmentTimelinePartHoverPreview = ({
 		>
 			<div className="segment-timeline__mini-inspector--small-parts__duration">
 				<span className="segment-timeline__mini-inspector--small-parts__duration__label">{t('Parts Duration')}</span>
-				{RundownUtils.formatDiffToTimecode(totalSegmentDuration, false, false, true, false, true)}
+				<SyncedDiffTimecode
+					diff={totalSegmentDuration}
+					showPlus={false}
+					showHours={false}
+					enDashAsMinus={true}
+					useSmartFloor={false}
+					useSmartHours={true}
+				/>
 			</div>
 			<div className="segment-timeline__mini-inspector__mini-timeline">
 				{parts.map((part, index) => {

--- a/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
+++ b/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
@@ -16,6 +16,7 @@ import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { PieceInstance } from '../../../lib/collections/PieceInstances'
 import { VTContent } from '@sofie-automation/blueprints-integration'
 import { getUnfinishedPieceInstancesReactive } from '../../lib/rundownLayouts'
+import { SyncedDiffTimecode } from '../../lib/Moment'
 interface IPieceCountdownPanelProps {
 	visible?: boolean
 	layout: RundownLayoutBase
@@ -91,17 +92,17 @@ export class PieceCountdownPanelInner extends MeteorReactComponent<
 							: undefined,
 					}}
 				>
-					{RundownUtils.formatDiffToTimecode(
-						this.state.displayTimecode || 0,
-						true,
-						false,
-						true,
-						false,
-						true,
-						'',
-						false,
-						true
-					)}
+					<SyncedDiffTimecode
+						diff={this.state.displayTimecode || 0}
+						showPlus={true}
+						showHours={false}
+						enDashAsMinus={true}
+						useSmartFloor={false}
+						useSmartHours={true}
+						minusPrefix={''}
+						floorTime={false}
+						hardFloor={true}
+					/>
 				</span>
 			</div>
 		)


### PR DESCRIPTION
This PR makes timers tick in lock-step. It achieves this by waiting for all timers to have a new value ready (or a maximum of 2 seconds) before ticking over to the next value.