### PR TITLE
fix: timing issue when refreshing page where livePosition was not yet…

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -922,12 +922,16 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 		}
 
 		getShowAllTimeScale = () => {
-			if (!this.timelineDiv) return this.state.maxTimeScale
+			if (!this.timelineDiv || isLiveSegmentButLivePositionNotSet(this.state.isLiveSegment, this.state.livePosition)) {
+				return this.state.maxTimeScale
+			}
 
-			let newScale =
-				(getElementWidth(this.timelineDiv) - TIMELINE_RIGHT_PADDING || 1) /
-				((computeSegmentDisplayDuration(this.context.durations, this.props.parts) || 1) -
-					(this.state.isLiveSegment ? this.state.livePosition : 0))
+			const elementWidth: number = getElementWidth(this.timelineDiv)
+			const elementWidthOr1: number = elementWidth - TIMELINE_RIGHT_PADDING || 1
+			const segmentDisplayDurationOr1: number =
+				computeSegmentDisplayDuration(this.context.durations, this.props.parts) || 1
+			const livePositionOr0: number = this.state.isLiveSegment ? this.state.livePosition : 0
+			let newScale = elementWidthOr1 / (segmentDisplayDurationOr1 - livePositionOr0)
 			newScale = Math.min(MINIMUM_ZOOM_FACTOR, newScale)
 			if (!Number.isFinite(newScale) || newScale === 0) {
 				newScale = FALLBACK_ZOOM_FACTOR
@@ -1037,6 +1041,10 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 		}
 	}
 )
+
+function isLiveSegmentButLivePositionNotSet(isLiveSegment: boolean, livePosition: number): boolean {
+	return isLiveSegment && livePosition === 0
+}
 
 function getMinimumReactivePieceNotesForPart(
 	studio: Studio,


### PR DESCRIPTION
This will hopefully fix a randomly occurring problem when the user refreshes the browser during a live rundown.
The timing issue happens when when calculating a new scale for the timeline. In some cases the livePosition on the live segment has not yet been set so it defaults to 0 making it squish the queued segments.
The solution is to use the default maxTimeScale if it's a live segment and livePosition is 0.