### PR TITLE
fix: Failing rundownPlaylist test

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -479,7 +479,7 @@ export function setupDefaultRundown(
 		_rank: 0,
 
 		_id: rundownId,
-		externalId: 'MOCK_RUNDOWN',
+		externalId: unprotectString(rundownId),
 		name: 'Default Rundown',
 
 		created: getCurrentTime(),

--- a/meteor/server/api/__tests__/rundownPlaylist.test.ts
+++ b/meteor/server/api/__tests__/rundownPlaylist.test.ts
@@ -12,6 +12,7 @@ import { Rundowns, Rundown } from '../../../lib/collections/Rundowns'
 import { RundownPlaylists, RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { produceRundownPlaylistInfoFromRundown, updateRundownsInPlaylist } from '../rundownPlaylist'
 import { DbCacheWriteCollection } from '../../cache/CacheCollection'
+import { PlaylistTimingType } from '@sofie-automation/blueprints-integration'
 
 require('../client') // include in order to create the Meteor methods needed
 require('../rundown') // include in order to create the Meteor methods needed
@@ -52,13 +53,25 @@ describe('Rundown', () => {
 		expect(rundownId02).toEqual('rundown02')
 		// The setupDefaultRundown doesn't set _rank, set expectedStart so that they will get a default order from that:
 		Rundowns.update(rundownId00, {
-			$set: { playlistId: playlistId0, playlistIdIsSetInSofie: true, expectedStart: 1000 },
+			$set: {
+				playlistId: playlistId0,
+				playlistIdIsSetInSofie: true,
+				timing: { type: PlaylistTimingType.ForwardTime, expectedStart: 1000 },
+			},
 		})
 		Rundowns.update(rundownId01, {
-			$set: { playlistId: playlistId0, playlistIdIsSetInSofie: true, expectedStart: 2000 },
+			$set: {
+				playlistId: playlistId0,
+				playlistIdIsSetInSofie: true,
+				timing: { type: PlaylistTimingType.ForwardTime, expectedStart: 2000 },
+			},
 		})
 		Rundowns.update(rundownId02, {
-			$set: { playlistId: playlistId0, playlistIdIsSetInSofie: true, expectedStart: 3000 },
+			$set: {
+				playlistId: playlistId0,
+				playlistIdIsSetInSofie: true,
+				timing: { type: PlaylistTimingType.ForwardTime, expectedStart: 3000 },
+			},
 		})
 
 		const rundown00 = Rundowns.findOne(rundownId00) as Rundown

--- a/meteor/server/api/playout/__tests__/__snapshots__/playout.test.ts.snap
+++ b/meteor/server/api/playout/__tests__/__snapshots__/playout.test.ts.snap
@@ -113,7 +113,7 @@ Object {
   "_id": "randomId9002",
   "_rank": 0,
   "created": 0,
-  "externalId": "MOCK_RUNDOWN",
+  "externalId": "randomId9002",
   "externalNRCSName": "mock",
   "importVersions": Object {
     "blueprint": "",
@@ -194,7 +194,7 @@ Object {
   "_id": "randomId9002",
   "_rank": 0,
   "created": 0,
-  "externalId": "MOCK_RUNDOWN",
+  "externalId": "randomId9002",
   "externalNRCSName": "mock",
   "importVersions": Object {
     "blueprint": "",

--- a/meteor/server/api/rundownPlaylist.ts
+++ b/meteor/server/api/rundownPlaylist.ts
@@ -501,16 +501,16 @@ function sortDefaultRundownInPlaylistOrder(
 	rundowns: ReadonlyDeep<Array<DBRundown>>
 ): ReadonlyDeep<Array<IBlueprintRundown>> {
 	return mongoFindOptions<ReadonlyDeep<DBRundown>, ReadonlyDeep<DBRundown>>(rundowns).sort((a, b) => {
-		let timingSorting = PlaylistTiming.sortTiminings(a, b)
+		const timingSorting = PlaylistTiming.sortTiminings(a, b)
 		if (timingSorting !== 0) return timingSorting
 
-		let nameSorting = a.name.localeCompare(b.name)
+		const nameSorting = a.name.localeCompare(b.name)
 		if (nameSorting !== 0) return nameSorting
 
-		let externalIdSorting = a.externalId.localeCompare(b.externalId)
+		const externalIdSorting = a.externalId.localeCompare(b.externalId)
 		if (externalIdSorting !== 0) return externalIdSorting
 
-		let idSorting = unprotectString(a._id).localeCompare(unprotectString(b._id))
+		const idSorting = unprotectString(a._id).localeCompare(unprotectString(b._id))
 		return idSorting
 	})
 }

--- a/meteor/server/api/rundownPlaylist.ts
+++ b/meteor/server/api/rundownPlaylist.ts
@@ -500,11 +500,17 @@ export async function restoreRundownsInPlaylistToDefaultOrder(
 function sortDefaultRundownInPlaylistOrder(
 	rundowns: ReadonlyDeep<Array<DBRundown>>
 ): ReadonlyDeep<Array<IBlueprintRundown>> {
-	return mongoFindOptions<ReadonlyDeep<DBRundown>, ReadonlyDeep<DBRundown>>(rundowns, {
-		sort: {
-			name: 1,
-			externalId: 1,
-			_id: 1,
-		},
-	}).sort(PlaylistTiming.sortTiminings)
+	return mongoFindOptions<ReadonlyDeep<DBRundown>, ReadonlyDeep<DBRundown>>(rundowns).sort((a, b) => {
+		let timingSorting = PlaylistTiming.sortTiminings(a, b)
+		if (timingSorting !== 0) return timingSorting
+
+		let nameSorting = a.name.localeCompare(b.name)
+		if (nameSorting !== 0) return nameSorting
+
+		let externalIdSorting = a.externalId.localeCompare(b.externalId)
+		if (externalIdSorting !== 0) return externalIdSorting
+
+		let idSorting = unprotectString(a._id).localeCompare(unprotectString(b._id))
+		return idSorting
+	})
 }


### PR DESCRIPTION
This test was failing for three reasons:
- Test data had not been updated with the move to the `timing` type
- The sort function to produce the default rundown ordering was incorrect
- Rundown ordering now uses `externalId` rather than `_id`, so how the mock data is created needed to be updated, otherwise all of the rundowns had the same `externalId` and so got assigned the same ranks