### PR TITLE
fix: Updated statusbar+notification-center+notification-pop-up to hav…

### DIFF
--- a/meteor/client/styles/customInstallation.scss
+++ b/meteor/client/styles/customInstallation.scss
@@ -714,14 +714,14 @@ body.tv2 {
 
 	.rundown-view {
 		.status-bar {
-			top: 4rem;
+			top: 80px;
 		}
 		.notification-center-panel {
-			top: 4rem;
+			top: 80px;
 		}
 	}
 	.rundown-view + .notification-pop-ups {
-		top: 4rem;
+		top: 80px;
 	}
 
 	.notification-pop-ups {


### PR DESCRIPTION
Moved the status-bar, notifications and notification center a bit down.
This might create a gap between the visible part of the header and the top of the notification center panel.