### PR TITLE
fix: Missing media notifications shown while media subscription is not ready yet

### DIFF
--- a/meteor/client/lib/reactiveData/reactiveDataHelper.ts
+++ b/meteor/client/lib/reactiveData/reactiveDataHelper.ts
@@ -161,10 +161,12 @@ export abstract class WithManagedTracker {
 		}, 2000) // wait for a couple of seconds, before unsubscribing
 	}
 
-	protected subscribe(sub: PubSub, ...args: any[]): Meteor.SubscriptionHandle {
-		const handle = Meteor.subscribe(sub, ...args)
-		this._subs.push(handle)
-		return handle
+	subscriptionsReady(): boolean {
+		return this._subs.every((e) => e.ready())
+	}
+
+	protected subscribe(sub: PubSub, ...args: any[]) {
+		this._subs.push(Meteor.subscribe(sub, ...args))
 	}
 
 	protected autorun(

--- a/meteor/client/lib/reactiveData/reactiveDataHelper.ts
+++ b/meteor/client/lib/reactiveData/reactiveDataHelper.ts
@@ -161,8 +161,10 @@ export abstract class WithManagedTracker {
 		}, 2000) // wait for a couple of seconds, before unsubscribing
 	}
 
-	protected subscribe(sub: PubSub, ...args: any[]) {
-		this._subs.push(Meteor.subscribe(sub, ...args))
+	protected subscribe(sub: PubSub, ...args: any[]): Meteor.SubscriptionHandle {
+		const handle = Meteor.subscribe(sub, ...args)
+		this._subs.push(handle)
+		return handle
 	}
 
 	protected autorun(

--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -544,14 +544,13 @@ class RundownViewNotifier extends WithManagedTracker {
 					// we don't want this to be in a non-reactive context, so we manage this computation manually
 					this._mediaStatusComps[unprotectString(piece._id)] = Tracker.autorun(() => {
 						const mediaId = getMediaObjectMediaId(piece, sourceLayer)
-						let handle: Meteor.SubscriptionHandle | undefined
 						if (mediaId) {
-							handle = this.subscribe(PubSub.mediaObjects, studio._id, {
+							this.subscribe(PubSub.mediaObjects, studio._id, {
 								mediaId: mediaId.toUpperCase(),
 							})
 						}
 
-						if (!handle?.ready()) return
+						if (!this.subscriptionsReady()) return
 
 						const { status, message } = checkPieceContentStatus(piece, sourceLayer, studio)
 						if (status !== RundownAPI.PieceStatusCode.UNKNOWN || message) {

--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -544,11 +544,15 @@ class RundownViewNotifier extends WithManagedTracker {
 					// we don't want this to be in a non-reactive context, so we manage this computation manually
 					this._mediaStatusComps[unprotectString(piece._id)] = Tracker.autorun(() => {
 						const mediaId = getMediaObjectMediaId(piece, sourceLayer)
+						let handle: Meteor.SubscriptionHandle | undefined
 						if (mediaId) {
-							this.subscribe(PubSub.mediaObjects, studio._id, {
+							handle = this.subscribe(PubSub.mediaObjects, studio._id, {
 								mediaId: mediaId.toUpperCase(),
 							})
 						}
+
+						if (!handle?.ready()) return
+
 						const { status, message } = checkPieceContentStatus(piece, sourceLayer, studio)
 						if (status !== RundownAPI.PieceStatusCode.UNKNOWN || message) {
 							localStatus.push({


### PR DESCRIPTION
This fixes an issue where the notification centre would have "phantom" notifications appear as you scroll through the rundown view. These notifications would state that the media object for e.g. a VO piece had not yet been loaded. This was due to the media object subscription not being ready yet.

This PR makes the notification centre wait until the media object subscription is ready before trying to evaluate the media object status for pieces.