### PR TITLE
fix: Queued segment looping until cleared manually

### DIFF
--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -270,10 +270,20 @@ export async function setNextPart(
 		let newInstanceId: PartInstanceId
 		if (newNextPartInstance) {
 			newInstanceId = newNextPartInstance._id
+			cache.PartInstances.update(newInstanceId, {
+				$set: {
+					consumesNextSegmentId: newNextPart?.consumesNextSegmentId,
+				},
+			})
 			await syncPlayheadInfinitesForNextPartInstance(cache)
 		} else if (nextPartInstance && nextPartInstance.part._id === nextPart._id) {
 			// Re-use existing
 			newInstanceId = nextPartInstance._id
+			cache.PartInstances.update(newInstanceId, {
+				$set: {
+					consumesNextSegmentId: newNextPart?.consumesNextSegmentId,
+				},
+			})
 			await syncPlayheadInfinitesForNextPartInstance(cache)
 		} else {
 			// Create new isntance

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -185,8 +185,8 @@ export async function setNextSegment(
 
 		const { currentPartInstance, nextPartInstance } = playlist.getSelectedPartInstances()
 		if (!currentPartInstance || !nextPartInstance || nextPartInstance.segmentId !== currentPartInstance.segmentId) {
-			// Special: in this case, the user probably dosen't want to setNextSegment, but rather just setNextPart
-			return ServerPlayoutAPI.setNextPart(access, rundownPlaylistId, firstValidPartInSegment._id, true, 0)
+			// Special: in this case, the user probably dosen't want to setNextSegment, but rather just setNextPart and clear previous nextSegmentId
+			return ServerPlayoutAPI.setNextPart(access, rundownPlaylistId, firstValidPartInSegment._id, true, 0, true)
 		}
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix in the Queued (Next) Segment feature


* **What is the current behavior?** (You can also link to an open issue here)
In various edge cases the queued segment starts looping infinitely (until cleared manually), or is queued an extra time.
Sample steps to reproduce the unwanted behavior:

  Case 1:
  - Take a Part in segment A
  - Queue segment B
  - Set first part of Segment B as next
  - Queue Segment A twice
  - Take - Segment A will loop until manually unqueued

  Case 2:

  - Take the first part in a segment (A) that has multiple parts
  - Queue a segment (B) that has only one part
  - Set as next segment B
  - Take - Segment A will loop until manually unqueued

  Case 3:

  - Take the first part in a segment A, that has multiple parts
  - Queue segment B, that has only one part
  - Take, Take (reaching B) - B will be set as next once more

  The causes of the issue: Wrong order of selecting next part and clearing `nextSegmentId` during a take. Not applying `consumesNextSegmentId` to reused partInstances. Not clearing `nextSegmentId` when user queues a segment while being on the last part of the current segment.

* **What is the new behavior (if this is a feature change)?**
Queued segment no longer loops infinitely, nor is queued more times than expected.
