### PR TITLE
Fix: Minishelf filters not working

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1666,9 +1666,9 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				}
 			}
 
-			let uiSegmentMap: Map<SegmentId, AdlibSegmentUi> = new Map()
-			let uiSegments: AdlibSegmentUi[] = []
-			let sourceLayerLookup: SourceLayerLookup = {}
+			const filteredUiSegmentMap: Map<SegmentId, AdlibSegmentUi> = new Map()
+			const filteredUiSegments: AdlibSegmentUi[] = []
+			let resultSourceLayerLookup: SourceLayerLookup = {}
 			if (props.playlist && props.showStyleBase && props.studio) {
 				const { t, i18n, tReady } = props
 				let filter =
@@ -1680,7 +1680,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				if (filter && !RundownLayoutsAPI.isFilter(filter)) {
 					filter = undefined
 				}
-				;({ uiSegmentMap, uiSegments, sourceLayerLookup } = fetchAndFilter({
+				const { uiSegmentMap, uiSegments, sourceLayerLookup } = fetchAndFilter({
 					t,
 					i18n,
 					tReady,
@@ -1693,10 +1693,11 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					hotkeyGroup: 'minishelf',
 					selectedPiece: undefined,
 					filter,
-				}))
+				})
+				resultSourceLayerLookup = sourceLayerLookup
 				const liveSegment = uiSegments.find((i) => i.isLive === true)
 
-				Object.values(uiSegmentMap).forEach((segment) => {
+				for (const segment of uiSegmentMap.values()) {
 					const uniquenessIds = new Set<string>()
 					const filteredPieces = segment.pieces.filter((piece) =>
 						matchFilter(
@@ -1718,9 +1719,11 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						...segment,
 						pieces: filteredPieces,
 					}
-					uiSegmentMap.set(segment._id, filteredSegment)
-					uiSegments.push(filteredSegment)
-				})
+					if (filteredPieces.length) {
+						filteredUiSegmentMap.set(segment._id, filteredSegment)
+						filteredUiSegments.push(filteredSegment)
+					}
+				}
 			}
 
 			return {
@@ -1738,9 +1741,9 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						? selectedMiniShelfLayout
 						: undefined,
 				currentRundown,
-				uiSegmentMap,
-				uiSegments,
-				sourceLayerLookup,
+				uiSegmentMap: filteredUiSegmentMap,
+				uiSegments: filteredUiSegments,
+				sourceLayerLookup: resultSourceLayerLookup,
 			}
 		}
 

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -311,7 +311,8 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 			props.timeScale !== nextProps.timeScale ||
 			!equalSets(props.segmentsIdsBefore, nextProps.segmentsIdsBefore) ||
 			!_.isEqual(props.countdownToSegmentRequireLayers, nextProps.countdownToSegmentRequireLayers) ||
-			props.minishelfRegisterHotkeys !== nextProps.minishelfRegisterHotkeys
+			props.minishelfRegisterHotkeys !== nextProps.minishelfRegisterHotkeys ||
+			!_.isEqual(props.adLibSegmentUi?.pieces, nextProps.adLibSegmentUi?.pieces)
 		) {
 			return true
 		}

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -17,7 +17,6 @@ import {
 	DashboardLayoutActionButton,
 	RundownLayoutElementType,
 	RundownLayoutId,
-	CustomizableRegions,
 } from '../../../lib/collections/RundownLayouts'
 import {
 	CustomizableRegionLayout,
@@ -62,8 +61,6 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 	const rundownLayouts = RundownLayouts.find({
 		showStyleBaseId: props.showStyleBase._id,
 		userId: { $exists: false },
-		type: { $in: layoutTypes },
-		regionId: props.customRegion._id as CustomizableRegions,
 	}).fetch()
 
 	return {


### PR DESCRIPTION
Fixes an issue causing the filter defined in the Mini Shelf Layout to have no effect.
Fixes reactivity issues - the mini shelves didn't update on changes to the adlibs they display. Sidenote: This needs more work in the future - I dislike the idea of the `RundownViewShelf` being inside `SegmentTimelineContainer`. They seem to have nothing in common (except one tracked prop) to back up having this hierarchy.
Fixes an issue preventing population of Shelf Layout, Mini Shelf Layout and Rundown Header Layout inside Rundown View Layouts editor.