### PR TITLE
feat: shouldRemoveOrphanedPartInstance

### DIFF
--- a/meteor/server/api/blueprints/context/context.ts
+++ b/meteor/server/api/blueprints/context/context.ts
@@ -38,6 +38,7 @@ import {
 	IStudioBaselineContext,
 	IShowStyleUserContext,
 	IBlueprintSegmentRundown,
+	IRundownUserContext,
 } from '@sofie-automation/blueprints-integration'
 import { Studio, StudioId } from '../../../../lib/collections/Studios'
 import {
@@ -304,6 +305,38 @@ export class RundownContext extends ShowStyleContext implements IRundownContext 
 		this.rundown = rundownToSegmentRundown(rundown)
 		this._rundown = rundown
 		this.playlistId = rundown.playlistId
+	}
+}
+
+export class RundownUserContext extends RundownContext implements IRundownUserContext {
+	public readonly notes: INoteBase[] = []
+	private readonly tempSendNotesIntoBlackHole: boolean
+
+	notifyUserError(message: string, params?: { [key: string]: any }): void {
+		if (this.tempSendNotesIntoBlackHole) {
+			this.logError(`UserNotes: "${message}", ${JSON.stringify(params)}`)
+		} else {
+			this.notes.push({
+				type: NoteType.ERROR,
+				message: {
+					key: message,
+					args: params,
+				},
+			})
+		}
+	}
+	notifyUserWarning(message: string, params?: { [key: string]: any }): void {
+		if (this.tempSendNotesIntoBlackHole) {
+			this.logWarning(`UserNotes: "${message}", ${JSON.stringify(params)}`)
+		} else {
+			this.notes.push({
+				type: NoteType.WARNING,
+				message: {
+					key: message,
+					args: params,
+				},
+			})
+		}
 	}
 }
 

--- a/meteor/server/api/blueprints/context/removeOrphanedPartInstance.ts
+++ b/meteor/server/api/blueprints/context/removeOrphanedPartInstance.ts
@@ -1,0 +1,60 @@
+import { IRemoveOrphanedPartInstanceContext } from '@sofie-automation/blueprints-integration'
+import { ReadonlyDeep } from 'type-fest'
+import { INoteBase, NoteType } from '../../../../lib/api/notes'
+import { Rundown } from '../../../../lib/collections/Rundowns'
+import { ShowStyleCompound } from '../../../../lib/collections/ShowStyleVariants'
+import { Studio } from '../../../../lib/collections/Studios'
+import { ContextInfo, RundownContext } from './context'
+
+export class RemoveOrphanedPartInstanceContext extends RundownContext implements IRemoveOrphanedPartInstanceContext {
+	/**
+	 * Set to true if blueprints have requested that the instance be removed
+	 */
+	private removeInstance: boolean
+	public readonly notes: INoteBase[] = []
+	private readonly tempSendNotesIntoBlackHole: boolean
+
+	constructor(
+		contextInfo: ContextInfo,
+		studio: ReadonlyDeep<Studio>,
+		showStyleCompound: ReadonlyDeep<ShowStyleCompound>,
+		rundown: ReadonlyDeep<Rundown>
+	) {
+		super(contextInfo, studio, showStyleCompound, rundown)
+	}
+
+	notifyUserError(message: string, params?: { [key: string]: any }): void {
+		if (this.tempSendNotesIntoBlackHole) {
+			this.logError(`UserNotes: "${message}", ${JSON.stringify(params)}`)
+		} else {
+			this.notes.push({
+				type: NoteType.ERROR,
+				message: {
+					key: message,
+					args: params,
+				},
+			})
+		}
+	}
+	notifyUserWarning(message: string, params?: { [key: string]: any }): void {
+		if (this.tempSendNotesIntoBlackHole) {
+			this.logWarning(`UserNotes: "${message}", ${JSON.stringify(params)}`)
+		} else {
+			this.notes.push({
+				type: NoteType.WARNING,
+				message: {
+					key: message,
+					args: params,
+				},
+			})
+		}
+	}
+
+	removePartInstance() {
+		this.removeInstance = true
+	}
+
+	public instanceIsRemoved(): boolean {
+		return this.removeInstance
+	}
+}

--- a/meteor/server/api/blueprints/context/removeOrphanedPartInstance.ts
+++ b/meteor/server/api/blueprints/context/removeOrphanedPartInstance.ts
@@ -1,18 +1,18 @@
 import { IRemoveOrphanedPartInstanceContext } from '@sofie-automation/blueprints-integration'
 import { ReadonlyDeep } from 'type-fest'
-import { INoteBase, NoteType } from '../../../../lib/api/notes'
 import { Rundown } from '../../../../lib/collections/Rundowns'
 import { ShowStyleCompound } from '../../../../lib/collections/ShowStyleVariants'
 import { Studio } from '../../../../lib/collections/Studios'
-import { ContextInfo, RundownContext } from './context'
+import { ContextInfo, RundownUserContext } from './context'
 
-export class RemoveOrphanedPartInstanceContext extends RundownContext implements IRemoveOrphanedPartInstanceContext {
+export class RemoveOrphanedPartInstanceContext
+	extends RundownUserContext
+	implements IRemoveOrphanedPartInstanceContext
+{
 	/**
 	 * Set to true if blueprints have requested that the instance be removed
 	 */
 	private removeInstance: boolean
-	public readonly notes: INoteBase[] = []
-	private readonly tempSendNotesIntoBlackHole: boolean
 
 	constructor(
 		contextInfo: ContextInfo,
@@ -21,33 +21,6 @@ export class RemoveOrphanedPartInstanceContext extends RundownContext implements
 		rundown: ReadonlyDeep<Rundown>
 	) {
 		super(contextInfo, studio, showStyleCompound, rundown)
-	}
-
-	notifyUserError(message: string, params?: { [key: string]: any }): void {
-		if (this.tempSendNotesIntoBlackHole) {
-			this.logError(`UserNotes: "${message}", ${JSON.stringify(params)}`)
-		} else {
-			this.notes.push({
-				type: NoteType.ERROR,
-				message: {
-					key: message,
-					args: params,
-				},
-			})
-		}
-	}
-	notifyUserWarning(message: string, params?: { [key: string]: any }): void {
-		if (this.tempSendNotesIntoBlackHole) {
-			this.logWarning(`UserNotes: "${message}", ${JSON.stringify(params)}`)
-		} else {
-			this.notes.push({
-				type: NoteType.WARNING,
-				message: {
-					key: message,
-					args: params,
-				},
-			})
-		}
 	}
 
 	removePartInstance() {

--- a/meteor/server/api/blueprints/context/syncIngestUpdateToPartInstance.ts
+++ b/meteor/server/api/blueprints/context/syncIngestUpdateToPartInstance.ts
@@ -1,4 +1,4 @@
-import { ContextInfo, RundownContext } from './context'
+import { ContextInfo, RundownUserContext } from './context'
 import {
 	IBlueprintPiece,
 	IBlueprintPieceInstance,
@@ -29,7 +29,6 @@ import { Rundown } from '../../../../lib/collections/Rundowns'
 import { DbCacheWriteCollection } from '../../../cache/CacheCollection'
 import { setupPieceInstanceInfiniteProperties } from '../../playout/pieces'
 import { Meteor } from 'meteor/meteor'
-import { INoteBase, NoteType } from '../../../../lib/api/notes'
 import { RundownPlaylistActivationId } from '../../../../lib/collections/RundownPlaylists'
 import { ReadonlyDeep } from 'type-fest'
 import { ShowStyleCompound } from '../../../../lib/collections/ShowStyleVariants'
@@ -37,14 +36,12 @@ import { Studio } from '../../../../lib/collections/Studios'
 import { CacheForPlayout } from '../../playout/cache'
 
 export class SyncIngestUpdateToPartInstanceContext
-	extends RundownContext
+	extends RundownUserContext
 	implements ISyncIngestUpdateToPartInstanceContext
 {
 	private readonly _partInstanceCache: DbCacheWriteCollection<PartInstance, DBPartInstance>
 	private readonly _pieceInstanceCache: DbCacheWriteCollection<PieceInstance, PieceInstance>
 	private readonly _proposedPieceInstances: Map<PieceInstanceId, PieceInstance>
-	public readonly notes: INoteBase[] = []
-	private readonly tempSendNotesIntoBlackHole: boolean
 
 	constructor(
 		contextInfo: ContextInfo,
@@ -64,33 +61,6 @@ export class SyncIngestUpdateToPartInstanceContext
 		this._partInstanceCache = DbCacheWriteCollection.createFromArray(PartInstances, [partInstance])
 
 		this._proposedPieceInstances = normalizeArrayToMap(proposedPieceInstances, '_id')
-	}
-
-	notifyUserError(message: string, params?: { [key: string]: any }): void {
-		if (this.tempSendNotesIntoBlackHole) {
-			this.logError(`UserNotes: "${message}", ${JSON.stringify(params)}`)
-		} else {
-			this.notes.push({
-				type: NoteType.ERROR,
-				message: {
-					key: message,
-					args: params,
-				},
-			})
-		}
-	}
-	notifyUserWarning(message: string, params?: { [key: string]: any }): void {
-		if (this.tempSendNotesIntoBlackHole) {
-			this.logWarning(`UserNotes: "${message}", ${JSON.stringify(params)}`)
-		} else {
-			this.notes.push({
-				type: NoteType.WARNING,
-				message: {
-					key: message,
-					args: params,
-				},
-			})
-		}
 	}
 
 	applyChangesToCache(cache: CacheForPlayout) {

--- a/meteor/server/api/ingest/commit.ts
+++ b/meteor/server/api/ingest/commit.ts
@@ -39,6 +39,7 @@ import { getTranslatedMessage, ServerTranslatedMesssages } from '../../../lib/ru
 import { getShowStyleCompoundForRundown } from '../showStyles'
 import { updateExpectedPackagesOnRundown } from './expectedPackages'
 import { Studio } from '../../../lib/collections/Studios'
+import { shouldRemoveOrphanedPartInstance } from './shouldRemoveOrphanedPartInstance'
 
 export type BeforePartMap = ReadonlyMap<SegmentId, Array<{ id: PartId; rank: number }>>
 
@@ -264,6 +265,8 @@ export async function CommitIngestOperation(
 							blueprint.blueprint,
 							newRundown
 						)
+
+						await shouldRemoveOrphanedPartInstance(playoutCache, showStyle, blueprint.blueprint, newRundown)
 
 						playoutCache.deferAfterSave(() => {
 							// Run in the background, we don't want to hold onto the lock to do this

--- a/meteor/server/api/ingest/shouldRemoveOrphanedPartInstance.ts
+++ b/meteor/server/api/ingest/shouldRemoveOrphanedPartInstance.ts
@@ -1,0 +1,84 @@
+import {
+	BlueprintRemoveOrphanedPartInstance,
+	ShowStyleBlueprintManifest,
+} from '@sofie-automation/blueprints-integration'
+import { ReadonlyDeep } from 'type-fest'
+import { PartNote, SegmentNote } from '../../../lib/api/notes'
+import { Rundown } from '../../../lib/collections/Rundowns'
+import { ShowStyleCompound } from '../../../lib/collections/ShowStyleVariants'
+import { clone, literal, unprotectObject, unprotectObjectArray } from '../../../lib/lib'
+import { logger } from '../../logging'
+import { RemoveOrphanedPartInstanceContext } from '../blueprints/context/removeOrphanedPartInstance'
+import { CacheForPlayout, getSelectedPartInstancesFromCache } from '../playout/cache'
+
+export async function shouldRemoveOrphanedPartInstance(
+	cache: CacheForPlayout,
+	showStyle: ReadonlyDeep<ShowStyleCompound>,
+	blueprint: ReadonlyDeep<ShowStyleBlueprintManifest>,
+	rundown: ReadonlyDeep<Rundown>
+): Promise<void> {
+	if (!cache.Playlist.doc.activationId) return
+	if (!blueprint.shouldRemoveOrphanedPartInstance) return
+
+	const playlistPartInstances = getSelectedPartInstancesFromCache(cache)
+	if (!playlistPartInstances.nextPartInstance?.orphaned) return
+
+	const orphanedPartInstance = playlistPartInstances.nextPartInstance
+	const pieceInstancesInPart = cache.PieceInstances.findFetch({
+		partInstanceId: orphanedPartInstance._id,
+	})
+
+	const existingResultPartInstance: BlueprintRemoveOrphanedPartInstance = {
+		partInstance: unprotectObject(orphanedPartInstance),
+		pieceInstances: unprotectObjectArray(pieceInstancesInPart),
+	}
+
+	const orphanedPartInstanceContext = new RemoveOrphanedPartInstanceContext(
+		{
+			name: `Update to ${orphanedPartInstance.part.externalId}`,
+			identifier: `rundownId=${orphanedPartInstance.part.rundownId},segmentId=${orphanedPartInstance.part.segmentId}`,
+		},
+		cache.Studio.doc,
+		showStyle,
+		rundown
+	)
+
+	try {
+		blueprint.shouldRemoveOrphanedPartInstance(orphanedPartInstanceContext, clone(existingResultPartInstance))
+	} catch (e) {
+		logger.error(e)
+	}
+
+	// Save notes:
+	if (!orphanedPartInstance.part.notes) orphanedPartInstance.part.notes = []
+	const notes: PartNote[] = orphanedPartInstance.part.notes
+	let changed = false
+	for (const note of orphanedPartInstanceContext.notes) {
+		changed = true
+		notes.push(
+			literal<SegmentNote>({
+				type: note.type,
+				message: note.message,
+				origin: {
+					name: '',
+				},
+			})
+		)
+	}
+	if (changed) {
+		cache.PartInstances.update(orphanedPartInstance._id, {
+			$set: {
+				'part.notes': notes,
+			},
+		})
+	}
+
+	if (orphanedPartInstanceContext.instanceIsRemoved()) {
+		cache.PartInstances.update(orphanedPartInstance._id, {
+			$set: {
+				reset: true,
+			},
+		})
+		cache.Playlist.update({ $unset: { nextPartInstanceId: 1 } })
+	}
+}

--- a/meteor/server/api/ingest/shouldRemoveOrphanedPartInstance.ts
+++ b/meteor/server/api/ingest/shouldRemoveOrphanedPartInstance.ts
@@ -10,6 +10,7 @@ import { clone, literal, unprotectObject, unprotectObjectArray } from '../../../
 import { logger } from '../../logging'
 import { RemoveOrphanedPartInstanceContext } from '../blueprints/context/removeOrphanedPartInstance'
 import { CacheForPlayout, getSelectedPartInstancesFromCache } from '../playout/cache'
+import { isTooCloseToAutonext } from '../playout/lib'
 
 export async function shouldRemoveOrphanedPartInstance(
 	cache: CacheForPlayout,
@@ -73,7 +74,10 @@ export async function shouldRemoveOrphanedPartInstance(
 		})
 	}
 
-	if (orphanedPartInstanceContext.instanceIsRemoved()) {
+	if (
+		orphanedPartInstanceContext.instanceIsRemoved() &&
+		!isTooCloseToAutonext(playlistPartInstances.currentPartInstance)
+	) {
 		cache.PartInstances.update(orphanedPartInstance._id, {
 			$set: {
 				reset: true,

--- a/packages/blueprints-integration/src/api.ts
+++ b/packages/blueprints-integration/src/api.ts
@@ -15,6 +15,7 @@ import {
 	IRundownDataChangedEventContext,
 	IRundownTimingEventContext,
 	IStudioBaselineContext,
+	IRemoveOrphanedPartInstanceContext,
 } from './context'
 import { IngestAdlib, ExtendedIngestRundown, IngestSegment } from './ingest'
 import { IBlueprintExternalMessageQueueObj } from './message'
@@ -142,6 +143,12 @@ export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
 		playoutStatus: 'current' | 'next'
 	) => void
 
+	/**
+	 * Allows the blueprint to remove the next part instance if it has become orphaned.
+	 * This call will only be made if the part instance has been orphaned.
+	 */
+	shouldRemoveOrphanedPartInstance?: (context: IRemoveOrphanedPartInstanceContext, partInstance: BlueprintRemoveOrphanedPartInstance) => void
+
 	/** Execute an action defined by an IBlueprintActionManifest */
 	executeAction?: (
 		context: IActionExecutionContext,
@@ -261,6 +268,11 @@ export interface BlueprintSyncIngestPartInstance {
 	// Upcoming interface:
 	// adLibPieceInstances: IBlueprintAdlibPieceInstance[]
 	// adLibActionInstances: IBlueprintAdlibActionInstance[]
+}
+
+export interface BlueprintRemoveOrphanedPartInstance {
+	partInstance: IBlueprintPartInstance,
+	pieceInstances: IBlueprintPieceInstance[]
 }
 
 /** Key is the ID of the external ID of the Rundown, Value is the rank to be assigned */

--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -225,6 +225,10 @@ export interface ISyncIngestUpdateToPartInstanceContext extends IRundownUserCont
 	updatePartInstance(props: Partial<IBlueprintMutatablePart>): IBlueprintPartInstance
 }
 
+export interface IRemoveOrphanedPartInstanceContext extends IRundownUserContext {
+	removePartInstance (): void
+}
+
 /** Events */
 
 export interface IEventContext {


### PR DESCRIPTION
This PR adds a showstyle blueprint method `shouldRemoveOrphanedPartInstance`. This method is called whenever the part associated with whatever is set as next is deleted.

If the blueprints want the part instance for next to be removed, and a new next to be found, they call a method on the context object passed to this function.

This function itself does not select a new next, as it is not expected to be used in isolation but as part of the commit phase of database operations, which ensure a safe next point before finalizing the commit.