### PR TITLE
fix: Added filter support for TEXT_LABEL to panel-based dashboard_layouts.

### DIFF
--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -191,6 +191,7 @@ export namespace RundownLayoutsAPI {
 			RundownLayoutElementType.FILTER,
 			RundownLayoutElementType.PIECE_COUNTDOWN,
 			RundownLayoutElementType.NEXT_INFO,
+			RundownLayoutElementType.TEXT_LABEL,
 		],
 	})
 	registry.registerMiniShelfLayout(RundownLayoutType.DASHBOARD_LAYOUT, {


### PR DESCRIPTION
It adds support for text label filters in panel-based dashboard layouts.

Motivation for this is to use it as title for external frames (e.g. microphone tally).