### PR TITLE
fix: florr diff counter when below 0 and ceil if over

### DIFF
--- a/meteor/client/ui/RundownView/RundownTiming/PlaylistEndTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/PlaylistEndTiming.tsx
@@ -46,6 +46,8 @@ export const PlaylistEndTiming = withTranslation()(
 					  (expectedDuration ?? this.props.timingDurations.totalPlaylistDuration ?? 0)
 					: frontAnchor + (this.props.timingDurations.remainingPlaylistDuration || 0) - backAnchor
 
+				const floorTimeForDiff: boolean = diff > 0
+
 				return (
 					<React.Fragment>
 						{!this.props.hidePlannedEnd ? (
@@ -125,7 +127,7 @@ export const PlaylistEndTiming = withTranslation()(
 									})}
 								>
 									{!this.props.hideDiffLabel && <span className="timing-clock-label right">{t('Diff')}</span>}
-									{RundownUtils.formatDiffToTimecode(diff, true, false, true, true, true, undefined, true)}
+									{RundownUtils.formatDiffToTimecode(diff, true, false, true, true, false, undefined, floorTimeForDiff)}
 								</span>
 							) : null
 						) : null}


### PR DESCRIPTION
The diff counter would always floor the diff decimal causing it to show 00:00 twice.
Changed it to ceil the decimal when below 0 and floor when above 0
when diff in millis is:
-1529 would show -00:01, now it will show -00:02
-529 would show -00:00, now it will show -00:01
470 would show +00:00, now it will show +00:00
1470 would show +00:01, now it will show +00:02