### PR TITLE
feat: Add time-jump detection

### DIFF
--- a/meteor/lib/__tests__/systemTime.test.ts
+++ b/meteor/lib/__tests__/systemTime.test.ts
@@ -1,0 +1,38 @@
+import { runTimersUntilNow, testInFiber } from '../../__mocks__/helpers/jest'
+import { TimeJumpDetector } from '../systemTime'
+
+describe('lib/systemTime', () => {
+	testInFiber('TimeJumpDetector', async () => {
+		jest.useFakeTimers()
+		const mockCallback = jest.fn()
+		let now = Date.now()
+		let monotonicNow = BigInt(5000 * 1000000) // say it's running for 5 seconds
+		const mockDateNow = jest.spyOn(global.Date, 'now').mockImplementation(() => now)
+		const mockProcessHrtime = jest.spyOn(global.process.hrtime, 'bigint').mockImplementation(() => monotonicNow)
+
+		const timeJumpDetector = new TimeJumpDetector(10000, mockCallback)
+		timeJumpDetector.start()
+
+		jest.advanceTimersByTime(11000)
+		await runTimersUntilNow()
+		expect(mockCallback).toHaveBeenCalledTimes(0)
+
+		now += 11000
+		monotonicNow += BigInt(11051 * 1000000)
+
+		jest.advanceTimersByTime(11000)
+		await runTimersUntilNow()
+		expect(mockCallback).toHaveBeenCalledTimes(1)
+		mockCallback.mockClear()
+
+		now += 11000
+		monotonicNow += BigInt(10951 * 1000000)
+
+		jest.advanceTimersByTime(11000)
+		await runTimersUntilNow()
+		expect(mockCallback).toHaveBeenCalledTimes(0)
+
+		mockDateNow.mockRestore()
+		mockProcessHrtime.mockRestore()
+	})
+})

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -113,10 +113,12 @@ export async function MeteorPromiseCall(callName: string, ...args: any[]): Promi
 export type Time = number
 export type TimeDuration = number
 
+// The diff is currently only used client-side
 const systemTime = {
 	hasBeenSet: false,
 	diff: 0,
 	stdDev: 9999,
+	lastSync: 0,
 }
 /**
  * Returns the current (synced) time

--- a/meteor/lib/systemTime.ts
+++ b/meteor/lib/systemTime.ts
@@ -6,46 +6,75 @@ import { MeteorCall } from './api/methods'
 if (Meteor.isServer) {
 	// handled in systemTime
 } else {
+	/** How often the client should sync its time to the server [ms] */
+	const SYNC_TIME = 5 * 60 * 1000 // 5 minutes
+
+	/** How good time sync quality we should strive for [ms] */
+	const TARGET_TIME_SYNC_QUALITY = 50 // 50 milliseconds
+
+	/** How much we assume a clock to drift over time [time unit per time unit] */
+	const ASSUMED_CLOCK_DRIFT = 5 / (3600 * 24) // We assume 5 seconds drift in a day for the system clock
+
 	// fetch time from server:
 	const updateDiffTime = () => {
-		const sentTime = Date.now()
-		MeteorCall.peripheralDevice
-			.getTimeDiff()
-			.then((stat) => {
-				const replyTime = Date.now()
-				const diffTime = (sentTime + replyTime) / 2 - stat.currentTime
+		// Calculate an "adjusted standard deviation", something that increases over time.
+		// Using this we can decide wether a new measurement is better or worse than previous one.
+		const currentSyncQuality = systemTime.stdDev + (Date.now() - systemTime.lastSync) * ASSUMED_CLOCK_DRIFT
 
-				systemTime.diff = diffTime
-				systemTime.stdDev = Math.abs(sentTime - replyTime) / 2
-				logger.debug(
-					'time diff to server: ' +
-						systemTime.diff +
-						'ms (stdDev: ' +
-						Math.floor(systemTime.stdDev * 10) / 10 +
-						'ms)'
-				)
-				if (!stat.good) {
-					Meteor.setTimeout(() => {
-						updateDiffTime()
-					}, 20 * 1000)
-				} else if (!stat.good || systemTime.stdDev > 50) {
-					Meteor.setTimeout(() => {
-						updateDiffTime()
-					}, 2000)
-				}
-			})
-			.catch((err) => {
-				logger.error(err)
-			})
+		// If the sync quality is better than the target, there's no need to re-sync it
+		if (currentSyncQuality > TARGET_TIME_SYNC_QUALITY) {
+			const sentTime = Date.now()
+			MeteorCall.peripheralDevice
+				.getTimeDiff()
+				.then((stat) => {
+					const replyTime = Date.now()
+
+					const diff = (sentTime + replyTime) / 2 - stat.currentTime
+					const stdDev = Math.abs(sentTime - replyTime) / 2 // Not really a standard deviation calculation, but it's what we can do with just one measuring point..
+
+					// Only use the result if the stdDev is better than previous sync quality:
+					if (stdDev <= currentSyncQuality) {
+						// Only trace the result if the diff is different than the previous:
+						if (Math.abs(systemTime.diff - diff) > 10) {
+							logger.verbose(
+								`Time diff set to: ${diff} ms (server stdDev: ${
+									Math.floor(stat.stdDev * 10) / 10
+								} ms, client stdDev: ${stdDev} ms)`
+							)
+						}
+
+						// Store the result into the global variable `systemTime` (used in getCurrentTime()):
+						systemTime.diff = diff
+						systemTime.stdDev = stdDev
+						systemTime.lastSync = Date.now()
+						systemTime.hasBeenSet = true
+					}
+				})
+				.catch((err) => {
+					logger.error(err)
+				})
+		}
 	}
 
 	Meteor.startup(() => {
-		Meteor.setInterval(() => {
-			updateDiffTime()
-		}, 3600 * 1000)
+		// Run it once right away:
 		updateDiffTime()
-		// Meteor.setTimeout(() => {
-		// 	updateDiffTime()
-		// }, 2000)
+
+		// Also run it a few seconds in, to get a more accurate reading:
+		Meteor.setTimeout(() => {
+			updateDiffTime()
+		}, 5000)
+
+		// Also run it after 30 seconds, to get an even more accurate reading:
+		Meteor.setTimeout(() => {
+			updateDiffTime()
+		}, 30 * 1000)
+
+		// Then run it on an interval, to ensure it is kept up to date:
+		Meteor.setInterval(() => {
+			if (Meteor.status().connected) {
+				updateDiffTime()
+			}
+		}, SYNC_TIME)
 	})
 }

--- a/meteor/server/api/systemTime/startup.ts
+++ b/meteor/server/api/systemTime/startup.ts
@@ -1,0 +1,12 @@
+import { Meteor } from 'meteor/meteor'
+import { systemTime } from '../../../lib/lib'
+
+Meteor.startup(() => {
+	// Since we currently don't set any diff in systemTime and just use the parent OS's time,
+	// we just set these to zero:
+
+	systemTime.diff = 0
+	systemTime.stdDev = 0
+	systemTime.lastSync = Date.now()
+	systemTime.hasBeenSet = true
+})

--- a/meteor/server/api/systemTime/startup.ts
+++ b/meteor/server/api/systemTime/startup.ts
@@ -7,6 +7,6 @@ Meteor.startup(() => {
 
 	systemTime.diff = 0
 	systemTime.stdDev = 0
-	systemTime.lastSync = Date.now()
+	systemTime.lastSync = performance.now()
 	systemTime.hasBeenSet = true
 })


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature/improvement


* **What is the current behavior?** (You can also link to an open issue here)
When wall time (returned by `Date.now()`) jumps (or is gradually adjusted) by the OS where the client is running, previously calculated diff becomes no longer valid, but it will be updated only after certain amount of time passes (based of fixed interval and sync degradation calculation)


* **What is the new behavior (if this is a feature change)?**
The added `TimeJumpDetector` class works both server- and client-side.
On the client, difference between wall clock and monotonic clock is computed every 10 seconds, and if they go out of sync by more than `TARGET_TIME_SYNC_QUALITY` (50ms), an immediate diff update is triggered.
On the server it's currently enabled with 60 second interval, just for the purpose of logging, but in the future it should trigger pushing events to clients in order to trigger diff update as well.


