### PR TITLE
fix: resetting partInstances and pieceInstances

### DIFF
--- a/meteor/server/api/playout/__tests__/playout.test.ts
+++ b/meteor/server/api/playout/__tests__/playout.test.ts
@@ -433,7 +433,7 @@ describe('Playout API', () => {
 			// take the second part to check if we reset all previous partInstances correctly
 			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
 
-			// should contain one non-reset taken partInstance
+			// should contain two non-reset taken partInstances
 			expect(
 				getAllPartInstances().filter(
 					(partInstance) =>
@@ -442,7 +442,7 @@ describe('Playout API', () => {
 						partInstance.isTaken &&
 						partInstance.playlistActivationId === playlist1Activation2.activationId
 				)
-			).toHaveLength(1)
+			).toHaveLength(2)
 
 			// should contain one not-reset not-taken partInstance
 			expect(

--- a/meteor/server/api/playout/__tests__/playout.test.ts
+++ b/meteor/server/api/playout/__tests__/playout.test.ts
@@ -433,7 +433,7 @@ describe('Playout API', () => {
 			// take the second part to check if we reset all previous partInstances correctly
 			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
 
-			// should contain two non-reset taken partInstances
+			// should contain one non-reset taken partInstance
 			expect(
 				getAllPartInstances().filter(
 					(partInstance) =>
@@ -442,7 +442,7 @@ describe('Playout API', () => {
 						partInstance.isTaken &&
 						partInstance.playlistActivationId === playlist1Activation2.activationId
 				)
-			).toHaveLength(2)
+			).toHaveLength(1)
 
 			// should contain one not-reset not-taken partInstance
 			expect(

--- a/meteor/server/api/playout/__tests__/playout.test.ts
+++ b/meteor/server/api/playout/__tests__/playout.test.ts
@@ -382,38 +382,27 @@ describe('Playout API', () => {
 
 			await ServerPlayoutAPI.resetAndActivateRundownPlaylist(DEFAULT_ACCESS(getPlaylist1()), playlistId1, false)
 
-			const playlist1Activation2 = getPlaylist1()
-
-			// should contain two non-reset pieceInstance (from the first part)
+			// should contain two nonreset pieceInstance (from the first part)
 			expect(
 				getAllPieceInstances().filter(
-					(pieceInstance) =>
-						pieceInstance.rundownId === rundownId1 &&
-						!pieceInstance.reset &&
-						pieceInstance.playlistActivationId === playlist1Activation2.activationId
+					(pieceInstance) => pieceInstance.rundownId === rundownId1 && !pieceInstance.reset
 				)
 			).toHaveLength(2)
 
 			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
 
-			// should contain one not-reset taken partInstance
+			// should contain one nonreset taken partInstance
 			expect(
 				getAllPartInstances().filter(
 					(partInstance) =>
-						partInstance.rundownId === rundownId1 &&
-						!partInstance.reset &&
-						partInstance.isTaken &&
-						partInstance.playlistActivationId === playlist1Activation2.activationId
+						partInstance.rundownId === rundownId1 && !partInstance.reset && partInstance.isTaken
 				)
 			).toHaveLength(1)
 
-			// should contain three not-reset pieceInstance (two from the first part, one from the second)
+			// should contain three non-reset pieceInstance (two from the first part, one from the second)
 			expect(
 				getAllPieceInstances().filter(
-					(pieceInstance) =>
-						pieceInstance.rundownId === rundownId1 &&
-						!pieceInstance.reset &&
-						pieceInstance.playlistActivationId === playlist1Activation2.activationId
+					(pieceInstance) => pieceInstance.rundownId === rundownId1 && !pieceInstance.reset
 				)
 			).toHaveLength(3)
 
@@ -433,35 +422,26 @@ describe('Playout API', () => {
 			// take the second part to check if we reset all previous partInstances correctly
 			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
 
-			// should contain two non-reset taken partInstances
+			// should contain two nonreset taken partInstances
 			expect(
 				getAllPartInstances().filter(
 					(partInstance) =>
-						partInstance.rundownId === rundownId1 &&
-						!partInstance.reset &&
-						partInstance.isTaken &&
-						partInstance.playlistActivationId === playlist1Activation2.activationId
+						partInstance.rundownId === rundownId1 && !partInstance.reset && partInstance.isTaken
 				)
 			).toHaveLength(2)
 
-			// should contain one not-reset not-taken partInstance
+			// should contain one nonreset untaken partInstance
 			expect(
 				getAllPartInstances().filter(
 					(partInstance) =>
-						partInstance.rundownId === rundownId1 &&
-						!partInstance.reset &&
-						!partInstance.isTaken &&
-						partInstance.playlistActivationId === playlist1Activation2.activationId
+						partInstance.rundownId === rundownId1 && !partInstance.reset && !partInstance.isTaken
 				)
 			).toHaveLength(1)
 
-			// should contain three not-reset pieceInstances
+			// should contain three nonreset pieceInstances
 			expect(
 				getAllPieceInstances().filter(
-					(pieceInstance) =>
-						pieceInstance.rundownId === rundownId1 &&
-						!pieceInstance.reset &&
-						pieceInstance.playlistActivationId === playlist1Activation2.activationId
+					(pieceInstance) => pieceInstance.rundownId === rundownId1 && !pieceInstance.reset
 				)
 			).toHaveLength(3)
 
@@ -469,7 +449,7 @@ describe('Playout API', () => {
 
 			// Setting as next a non-previous and non-current part:
 
-			// set and take first Part afain
+			// set and take first Part again
 			await ServerPlayoutAPI.setNextPart(
 				DEFAULT_ACCESS(getPlaylist1()),
 				playlistId1,
@@ -477,48 +457,28 @@ describe('Playout API', () => {
 			)
 			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
 
-			// should contain two not-reset taken instance
+			// should contain two nonreset taken instance
 			expect(
 				getAllPartInstances().filter(
 					(partInstance) =>
-						partInstance.rundownId === rundownId1 &&
-						!partInstance.reset &&
-						partInstance.isTaken &&
-						partInstance.playlistActivationId === playlist1Activation2.activationId
+						partInstance.rundownId === rundownId1 && !partInstance.reset && partInstance.isTaken
 				)
 			).toHaveLength(2)
 
-			// should contain one not-reset not-taken partInstance (next)
+			// should contain one nonreset untaken partInstance (next)
 			expect(
 				getAllPartInstances().filter(
 					(partInstance) =>
-						partInstance.rundownId === rundownId1 &&
-						!partInstance.reset &&
-						!partInstance.isTaken &&
-						partInstance.playlistActivationId === playlist1Activation2.activationId
+						partInstance.rundownId === rundownId1 && !partInstance.reset && !partInstance.isTaken
 				)
 			).toHaveLength(1)
 
-			// should contain three non-reset pieceInstance
+			// should contain three nonreset pieceInstance
 			expect(
 				getAllPieceInstances().filter(
-					(pieceInstance) =>
-						pieceInstance.rundownId === rundownId1 &&
-						!pieceInstance.reset &&
-						pieceInstance.playlistActivationId === playlist1Activation2.activationId
+					(pieceInstance) => pieceInstance.rundownId === rundownId1 && !pieceInstance.reset
 				)
 			).toHaveLength(3)
-
-			/*const playlist1 = getPlaylist1()
-			expect(
-				getAllPartInstances().filter(
-					(partInstance) =>
-						partInstance.rundownId === rundownId1 &&
-						!partInstance.reset &&
-						partInstance.isTaken &&
-						partInstance.playlistActivationId === playlist1.activationId
-				)
-			).toHaveLength(1)*/
 		}
 	)
 	testInFiber('reloadRundownPlaylistData', async () => {

--- a/meteor/server/api/playout/cache.ts
+++ b/meteor/server/api/playout/cache.ts
@@ -25,6 +25,7 @@ import { getRundownsSegmentsAndPartsFromCache } from './lib'
 import { CacheForIngest } from '../ingest/cache'
 import { Meteor } from 'meteor/meteor'
 import { ShowStyleBaseId } from '../../../lib/collections/ShowStyleBases'
+import { MongoQuery } from '../../../lib/typings/meteor'
 
 /**
  * This is a cache used for playout operations.
@@ -216,26 +217,30 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 		// If there is an ingestCache, then avoid loading some bits from the db for that rundown
 		const loadRundownIds = ingestCache ? rundownIds.filter((id) => id !== ingestCache.RundownId) : rundownIds
 
+		const partInstancesSelector: MongoQuery<PartInstance> = {
+			rundownId: { $in: rundownIds },
+			$or: [
+				{
+					reset: { $ne: true },
+				},
+				{
+					_id: { $in: selectedPartInstanceIds },
+				},
+			],
+		}
+		const pieceInstancesSelector: MongoQuery<PieceInstance> = {
+			rundownId: { $in: rundownIds },
+			partInstanceId: { $in: selectedPartInstanceIds },
+		}
+		if (playlist.activationId) {
+			partInstancesSelector.playlistActivationId = playlist.activationId
+			pieceInstancesSelector.playlistActivationId = playlist.activationId
+		}
 		const [segments, parts, ...collections] = await Promise.all([
 			DbCacheReadCollection.createFromDatabase(Segments, { rundownId: { $in: loadRundownIds } }),
 			DbCacheReadCollection.createFromDatabase(Parts, { rundownId: { $in: loadRundownIds } }),
-			DbCacheWriteCollection.createFromDatabase(PartInstances, {
-				playlistActivationId: playlist.activationId,
-				rundownId: { $in: rundownIds },
-				$or: [
-					{
-						reset: { $ne: true },
-					},
-					{
-						_id: { $in: selectedPartInstanceIds },
-					},
-				],
-			}),
-			DbCacheWriteCollection.createFromDatabase(PieceInstances, {
-				playlistActivationId: playlist.activationId,
-				rundownId: { $in: rundownIds },
-				partInstanceId: { $in: selectedPartInstanceIds },
-			}),
+			DbCacheWriteCollection.createFromDatabase(PartInstances, partInstancesSelector),
+			DbCacheWriteCollection.createFromDatabase(PieceInstances, pieceInstancesSelector),
 			// Future: This could be defered until we get to updateTimeline. It could be a small performance boost
 			DbCacheWriteCollection.createFromDatabase(Timeline, { _id: playlist.studioId }),
 		])

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -54,28 +54,22 @@ export async function resetRundownPlaylist(cache: CacheForPlayout): Promise<void
 			partInstanceId: { $in: partInstancesToRemove },
 		})
 	})
-
-	const partInstancesToReset = cache.PartInstances.update(
-		{ $or: [{ reset: false }, { reset: { $exists: false } }] },
-		{
-			$set: {
-				reset: true,
-			},
-		}
-	)
+	const partInstancesToReset = cache.PartInstances.update((p) => !p.reset, {
+		$set: {
+			reset: true,
+		},
+	})
 	cache.deferAfterSave(() => {
 		PieceInstances.update(
 			{
-				$and: [
-					{ $or: [{ reset: false }, { reset: { $exists: false } }] },
-					{ partInstanceId: { $in: partInstancesToReset } },
-				],
+				partInstanceId: { $in: partInstancesToReset },
 			},
 			{
 				$set: {
 					reset: true,
 				},
-			}
+			},
+			{ multi: true }
 		)
 	})
 
@@ -326,15 +320,12 @@ export async function setNextPart(
 			cache.Playlist.doc.previousPartInstanceId,
 		])
 		// reset any previous instances of this part
-		const partInstanceIdsToReset = cache.PartInstances.findFetch({
-			_id: { $nin: selectedPartInstanceIds },
-			rundownId: nextPart.rundownId,
-			'part._id': nextPart._id,
-			reset: { $ne: true },
-		}).map((pi) => pi._id)
-		cache.PartInstances.update(
+		const partInstancesToReset = cache.PartInstances.update(
 			{
-				_id: { $in: partInstanceIdsToReset },
+				_id: { $nin: selectedPartInstanceIds },
+				rundownId: nextPart.rundownId,
+				'part._id': nextPart._id,
+				reset: { $ne: true },
 			},
 			{
 				$set: {
@@ -345,16 +336,16 @@ export async function setNextPart(
 		cache.deferAfterSave(() => {
 			PieceInstances.update(
 				{
-					partInstanceId: { $in: partInstanceIdsToReset },
+					partInstanceId: { $in: partInstancesToReset },
+					'piece.startPartId': nextPart._id,
+					reset: { $ne: true },
 				},
 				{
 					$set: {
 						reset: true,
 					},
 				},
-				{
-					multi: true,
-				}
+				{ multi: true }
 			)
 		})
 

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -48,9 +48,7 @@ export async function resetRundownPlaylist(cache: CacheForPlayout): Promise<void
 	// Remove all dunamically inserted pieces (adlibs etc)
 	// const rundownIds = new Set(getRundownIDsFromCache(cache))
 
-	const partInstancesToRemove = new Set(
-		cache.PartInstances.remove((p) => p.rehearsal || p.playlistActivationId !== cache.Playlist.doc.activationId)
-	)
+	const partInstancesToRemove = new Set(cache.PartInstances.remove((p) => p.rehearsal))
 	cache.deferAfterSave(() => {
 		PieceInstances.remove({
 			partInstanceId: { $in: Array.from(partInstancesToRemove.values()) },
@@ -58,12 +56,7 @@ export async function resetRundownPlaylist(cache: CacheForPlayout): Promise<void
 	})
 
 	cache.PartInstances.update(
-		{
-			$and: [
-				{ $or: [{ reset: false }, { reset: { $exists: false } }] },
-				{ _id: { $in: Array.from(partInstancesToRemove.values()) } },
-			],
-		},
+		{ $or: [{ reset: false }, { reset: { $exists: false } }] },
 		{
 			$set: {
 				reset: true,
@@ -72,12 +65,7 @@ export async function resetRundownPlaylist(cache: CacheForPlayout): Promise<void
 	)
 	cache.deferAfterSave(() => {
 		PieceInstances.update(
-			{
-				$and: [
-					{ $or: [{ reset: false }, { reset: { $exists: false } }] },
-					{ partInstanceId: { $in: Array.from(partInstancesToRemove.values()) } },
-				],
-			},
+			{ $or: [{ reset: false }, { reset: { $exists: false } }] },
 			{
 				$set: {
 					reset: true,


### PR DESCRIPTION
Fixes an issue leading to leftover non-reset partInstances from previous activations messing up the UI.

The new `activationId` is generated after resetting, so the correct behavior for the `resetRundownPlaylist` function is to
- remove rehearsal partInstances with the current activationId, and their pieceInstances
- reset partInstances with current activationId, and their pieceInstances