### PR TITLE
fix: check if livePart exists when using getActivePartInstances as it…

### DIFF
--- a/meteor/client/ui/Shelf/PlaylistNamePanel.tsx
+++ b/meteor/client/ui/Shelf/PlaylistNamePanel.tsx
@@ -72,7 +72,7 @@ export const PlaylistNamePanel = withTracker<IPlaylistNamePanelProps, IState, IP
 				const currentRundown = props.playlist.getRundowns({ _id: livePart.rundownId })[0]
 
 				return {
-					currentRundown
+					currentRundown,
 				}
 			}
 		}

--- a/meteor/client/ui/Shelf/PlaylistNamePanel.tsx
+++ b/meteor/client/ui/Shelf/PlaylistNamePanel.tsx
@@ -68,10 +68,12 @@ export const PlaylistNamePanel = withTracker<IPlaylistNamePanelProps, IState, IP
 	(props: IPlaylistNamePanelProps) => {
 		if (props.playlist.currentPartInstanceId) {
 			const livePart = props.playlist.getActivePartInstances({ _id: props.playlist.currentPartInstanceId })[0]
-			const currentRundown = props.playlist.getRundowns({ _id: livePart.rundownId })[0]
+			if (livePart) {
+				const currentRundown = props.playlist.getRundowns({ _id: livePart.rundownId })[0]
 
-			return {
-				currentRundown,
+				return {
+					currentRundown
+				}
 			}
 		}
 


### PR DESCRIPTION
We can't always assume that getActivePartInstances will return an array with values
Check for undefined before using the returned objects