### PR TITLE
fix: Move resync rundown on take into take function

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -31,8 +31,6 @@ import { RundownId } from '../../../lib/collections/Rundowns'
 import { PartInstanceId, PartInstances, PartInstance } from '../../../lib/collections/PartInstances'
 import { PieceInstances } from '../../../lib/collections/PieceInstances'
 import { Parts, PartId, Part } from '../../../lib/collections/Parts'
-import { doUserAction, UserAction } from '../../lib/userAction'
-import { MeteorCall } from '../../../lib/api/methods'
 import { Tracker } from 'meteor/tracker'
 import { Meteor } from 'meteor/meteor'
 import RundownViewEventBus, {
@@ -477,15 +475,6 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 				this.isLiveSegment = false
 				this.stopLive()
 				if (Settings.autoRewindLeavingSegment) this.onRewindSegment()
-
-				if (this.props.segmentui && this.props.segmentui.unsynced) {
-					const { t } = this.props
-					// TODO: This doesn't seem right? componentDidUpdate can be triggered in a lot of different ways.
-					// What is this supposed to do?
-					doUserAction(t, undefined, UserAction.RESYNC_SEGMENT, (e) =>
-						MeteorCall.userAction.resyncSegment('', this.props.segmentui!.rundownId, this.props.segmentui!._id)
-					)
-				}
 
 				if (this.state.autoExpandCurrentNextSegment) {
 					this.setState({


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

Resync does not happen in commentator view.

* **What is the new behavior (if this is a feature change)?**

Resync is moved to server side, and is performed whenver the take function is called to move us from one segment to another.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
