### PR TITLE
SOF-725 fix: Minishelf not queuing next adLib

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2545,17 +2545,19 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 			if (!pieceToQueue) {
 				if (currentSegmentId) {
-					const currentSegmentInd = uiSegments.findIndex((segment) => segment._id === currentSegmentId)
-					if (currentSegmentInd >= 0) {
-						const nextShelfOnlySegment = forward
-							? this.findShelfOnlySegment(currentSegmentInd + 1, uiSegments.length) ||
-							  this.findShelfOnlySegment(0, currentSegmentInd)
-							: this.findShelfOnlySegment(currentSegmentInd - 1, -1) ||
-							  this.findShelfOnlySegment(uiSegments.length - 1, currentSegmentInd)
-						if (nextShelfOnlySegment && nextShelfOnlySegment.queueablePieces.length) {
-							pieceToQueue =
-								nextShelfOnlySegment.queueablePieces[forward ? 0 : nextShelfOnlySegment.queueablePieces.length - 1]
-						}
+					let currentSegmentInd = uiSegments.findIndex((segment) => segment._id === currentSegmentId)
+					if (currentSegmentInd < 0) {
+						currentSegmentInd = 0
+					}
+
+					const nextShelfOnlySegment = forward
+						? this.findShelfOnlySegment(currentSegmentInd + 1, uiSegments.length) ||
+						  this.findShelfOnlySegment(0, currentSegmentInd)
+						: this.findShelfOnlySegment(currentSegmentInd - 1, -1) ||
+						  this.findShelfOnlySegment(uiSegments.length - 1, currentSegmentInd)
+					if (nextShelfOnlySegment && nextShelfOnlySegment.queueablePieces.length) {
+						pieceToQueue =
+							nextShelfOnlySegment.queueablePieces[forward ? 0 : nextShelfOnlySegment.queueablePieces.length - 1]
 					}
 				}
 			}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2545,19 +2545,17 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 			if (!pieceToQueue) {
 				if (currentSegmentId) {
-					let currentSegmentInd = uiSegments.findIndex((segment) => segment._id === currentSegmentId)
-					if (currentSegmentInd < 0) {
-						currentSegmentInd = 0
-					}
-
-					const nextShelfOnlySegment = forward
-						? this.findShelfOnlySegment(currentSegmentInd + 1, uiSegments.length) ||
-						  this.findShelfOnlySegment(0, currentSegmentInd)
-						: this.findShelfOnlySegment(currentSegmentInd - 1, -1) ||
-						  this.findShelfOnlySegment(uiSegments.length - 1, currentSegmentInd)
-					if (nextShelfOnlySegment && nextShelfOnlySegment.queueablePieces.length) {
-						pieceToQueue =
-							nextShelfOnlySegment.queueablePieces[forward ? 0 : nextShelfOnlySegment.queueablePieces.length - 1]
+					const currentSegmentInd = uiSegments.findIndex((segment) => segment._id === currentSegmentId)
+					if (currentSegmentInd >= 0) {
+						const nextShelfOnlySegment = forward
+							? this.findShelfOnlySegment(currentSegmentInd + 1, uiSegments.length) ||
+							  this.findShelfOnlySegment(0, currentSegmentInd)
+							: this.findShelfOnlySegment(currentSegmentInd - 1, -1) ||
+							  this.findShelfOnlySegment(uiSegments.length - 1, currentSegmentInd)
+						if (nextShelfOnlySegment && nextShelfOnlySegment.queueablePieces.length) {
+							pieceToQueue =
+								nextShelfOnlySegment.queueablePieces[forward ? 0 : nextShelfOnlySegment.queueablePieces.length - 1]
+						}
 					}
 				}
 			}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1719,10 +1719,9 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						...segment,
 						pieces: filteredPieces,
 					}
-					if (filteredPieces.length) {
-						filteredUiSegmentMap.set(segment._id, filteredSegment)
-						filteredUiSegments.push(filteredSegment)
-					}
+
+					filteredUiSegmentMap.set(segment._id, filteredSegment)
+					filteredUiSegments.push(filteredSegment)
 				}
 			}
 


### PR DESCRIPTION
Fixes issue where the next minishelf adLib would not be queued if the current live segment does not include any minishelf adLibs.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

It's currently not possible to queue the next minishelf adLib if the current segment does not include any minishelf adLibs.

* **What is the new behavior (if this is a feature change)?**

If we can't find the current position in the `uiSegments` array, we will start searching from position `0`.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
