### PR TITLE
SOF-510(SOF-717) feat: action triggers with keyboard map

### DIFF
--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import Sorensen from '@sofie-automation/sorensen'
@@ -8,12 +8,12 @@ import { ShowStyleBase, ShowStyleBaseId, ShowStyleBases } from '../../../lib/col
 import { TriggeredActionId, TriggeredActions } from '../../../lib/collections/TriggeredActions'
 import { useSubscription, useTracker } from '../ReactMeteorData/ReactMeteorData'
 import { RundownPlaylistId, RundownPlaylists } from '../../../lib/collections/RundownPlaylists'
-import { ISourceLayer, SomeAction, TriggerType } from '@sofie-automation/blueprints-integration'
+import { ISourceLayer, PlayoutActions, SomeAction, TriggerType } from '@sofie-automation/blueprints-integration'
 import { RundownId } from '../../../lib/collections/Rundowns'
 import {
-	ActionContext,
 	createAction as libCreateAction,
 	isPreviewableAction,
+	ReactivePlaylistActionContext,
 } from '../../../lib/api/triggers/actionFactory'
 import { Tracker } from 'meteor/tracker'
 import { PartId } from '../../../lib/collections/Parts'
@@ -26,6 +26,8 @@ import { PieceId } from '../../../lib/collections/Pieces'
 import { ReactiveVar } from 'meteor/reactive-var'
 import { ITranslatableMessage } from '../../../lib/api/TranslatableMessage'
 import { preventDefault } from '../SorensenContext'
+import { getFinalKey } from './codesToKeyLabels'
+import RundownViewEventBus, { RundownViewEvents, TriggerActionEvent } from '../../ui/RundownView/RundownViewEventBus'
 
 type HotkeyTriggerListener = (e: KeyboardEvent) => void
 
@@ -95,7 +97,7 @@ function createAction(
 	actions: SomeAction[],
 	showStyleBase: ShowStyleBase,
 	t: TFunction,
-	collectContext: () => ActionContext | null
+	collectContext: () => ReactivePlaylistActionContext | null
 ): {
 	listener: HotkeyTriggerListener
 	preview: () => IWrappedAdLib[]
@@ -112,7 +114,6 @@ function createAction(
 		},
 		listener: (e) => {
 			e.preventDefault()
-			e.stopPropagation()
 
 			const ctx = collectContext()
 			if (ctx) {
@@ -122,11 +123,12 @@ function createAction(
 	}
 }
 
-const rundownPlaylistContext: ReactiveVar<ActionContext | null> = new ReactiveVar(null)
-function setRundownPlaylistContext(ctx: ActionContext | null) {
+const rundownPlaylistContext: ReactiveVar<ReactivePlaylistActionContext | null> = new ReactiveVar(null)
+
+function setRundownPlaylistContext(ctx: ReactivePlaylistActionContext | null) {
 	rundownPlaylistContext.set(ctx)
 }
-function getCurrentContext(): ActionContext | null {
+function getCurrentContext(): ReactivePlaylistActionContext | null {
 	return rundownPlaylistContext.get()
 }
 
@@ -142,10 +144,16 @@ export interface MountedAdLibTrigger {
 	type: IWrappedAdLib['type']
 	/** The ID in the collection specified by `type` */
 	targetId: AdLibActionId | RundownBaselineAdLibActionId | PieceId | ISourceLayer['_id']
-	/** Keys that have a listener mounted to */
+	/** Keys or combos that have a listener mounted to */
 	keys: string[]
+	/** Final keys in the combos */
+	finalKeys: string[]
 	/** A label of the action, if available */
 	name?: string | ITranslatableMessage
+	/** SourceLayerId of the target, if available */
+	sourceLayerId?: ISourceLayer['_id']
+	/** A label of the target if available */
+	targetName?: string | ITranslatableMessage
 }
 
 export const MountedAdLibTriggers = new Mongo.Collection<MountedAdLibTrigger>(null)
@@ -158,13 +166,23 @@ export interface MountedGenericTrigger {
 	_rank: number
 	/** The ID of the action that will be triggered */
 	triggeredActionId: TriggeredActionId
-	/** Keys that have a listener mounted to */
+	/** Keys or combos that have a listener mounted to */
 	keys: string[]
+	/** Final keys in the combos */
+	finalKeys: string[]
 	/** A label of the action, if available */
 	name: string | ITranslatableMessage
+	/** Hint that all actions of this trigger are adLibs */
+	adLibOnly: boolean
 }
 
 export const MountedGenericTriggers = new Mongo.Collection<MountedGenericTrigger>(null)
+
+export function isMountedAdLibTrigger(
+	mountedTrigger: MountedAdLibTrigger | MountedGenericTrigger
+): mountedTrigger is MountedAdLibTrigger {
+	return !!mountedTrigger['targetId']
+}
 
 function isolatedAutorunWithCleanup(autorun: () => void | (() => void)): Tracker.Computation {
 	const computation = Tracker.nonreactive(() =>
@@ -197,6 +215,7 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 	const [initialized, setInitialized] = useState(props.sorensen ? true : false)
 	const { t } = useTranslation()
 	const localSorensen = props.sorensen || Sorensen
+	const createdActions = useRef<Map<TriggeredActionId, (e) => void>>(new Map())
 
 	function bindHotkey(id: TriggeredActionId, keys: string, up: boolean, action: HotkeyTriggerListener) {
 		try {
@@ -215,6 +234,13 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 
 	function unbindHotkey(keys: string, listener: (e: KeyboardEvent) => void) {
 		localSorensen.unbind(keys, listener)
+	}
+
+	function triggerAction(e: TriggerActionEvent) {
+		const listener = createdActions.current.get(e.actionId)
+		if (listener) {
+			listener(e.context)
+		}
 	}
 
 	useEffect(() => {
@@ -319,6 +345,13 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 	}, [initialized]) // run once once Sorensen is initialized
 
 	useEffect(() => {
+		RundownViewEventBus.on(RundownViewEvents.TRIGGER_ACTION, triggerAction)
+		return () => {
+			RundownViewEventBus.removeListener(RundownViewEvents.TRIGGER_ACTION, triggerAction)
+		}
+	}, [])
+
+	useEffect(() => {
 		Tracker.nonreactive(() => {
 			const playlist = RundownPlaylists.findOne(props.rundownPlaylistId, {
 				fields: {
@@ -330,23 +363,36 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 				},
 			})
 			if (playlist) {
-				setRundownPlaylistContext({
-					rundownPlaylist: playlist,
-					currentRundownId: props.currentRundownId,
-					currentPartId: props.currentPartId,
-					nextPartId: props.nextPartId,
-					currentSegmentPartIds: props.currentSegmentPartIds,
-					nextSegmentPartIds: props.nextSegmentPartIds,
-				})
+				let context = rundownPlaylistContext.get()
+				if (context === null) {
+					context = {
+						rundownPlaylistId: new ReactiveVar(playlist._id),
+						rundownPlaylist: new ReactiveVar(playlist),
+						currentRundownId: new ReactiveVar(props.currentRundownId),
+						currentPartId: new ReactiveVar(props.currentPartId),
+						nextPartId: new ReactiveVar(props.nextPartId),
+						currentSegmentPartIds: new ReactiveVar(props.currentSegmentPartIds),
+						nextSegmentPartIds: new ReactiveVar(props.nextSegmentPartIds),
+					}
+					rundownPlaylistContext.set(context)
+				} else {
+					context.rundownPlaylistId.set(playlist._id)
+					context.rundownPlaylist.set(playlist)
+					context.currentRundownId.set(props.currentRundownId)
+					context.currentPartId.set(props.currentPartId)
+					context.nextPartId.set(props.nextPartId)
+					context.currentSegmentPartIds.set(props.currentSegmentPartIds)
+					context.nextSegmentPartIds.set(props.nextSegmentPartIds)
+				}
 			}
 		})
 	}, [
 		props.rundownPlaylistId,
 		props.currentRundownId,
 		props.currentPartId,
-		props.currentSegmentPartIds,
+		JSON.stringify(props.currentSegmentPartIds),
 		props.nextPartId,
-		props.nextSegmentPartIds,
+		JSON.stringify(props.nextSegmentPartIds),
 	])
 
 	const triggerSubReady = useSubscription(PubSub.triggeredActions, {
@@ -393,13 +439,13 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 			return
 		}
 
-		const createdActions: Map<TriggeredActionId, (e) => void> = new Map()
+		createdActions.current = new Map()
 		const previewAutoruns: Tracker.Computation[] = []
 
 		triggeredActions.forEach((pair) => {
 			const action = createAction(pair._id, pair.actions, showStyleBase, t, getCurrentContext)
 			if (!props.simulateTriggerBinding) {
-				createdActions.set(pair._id, action.listener)
+				createdActions.current.set(pair._id, action.listener)
 				pair.triggers.forEach((trigger) => {
 					if (trigger.type === TriggerType.hotkey) {
 						bindHotkey(pair._id, trigger.keys, !!trigger.up, action.listener)
@@ -410,13 +456,18 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 			if (pair.name) {
 				const triggers = pair.triggers.filter((trigger) => trigger.type === TriggerType.hotkey)
 				const genericTriggerId = protectString(`${pair._id}`)
+				const keys = triggers.map((trigger) => trigger.keys)
+				const finalKeys = keys.map((key) => getFinalKey(key))
+				const adLibOnly = pair.actions.every((action) => action.action === PlayoutActions.adlib)
 				MountedGenericTriggers.upsert(genericTriggerId, {
 					$set: {
 						_id: genericTriggerId,
 						_rank: pair._rank,
 						triggeredActionId: pair._id,
-						keys: triggers.map((trigger) => trigger.keys),
+						keys,
+						finalKeys,
 						name: pair.name,
+						adLibOnly,
 					},
 				})
 			}
@@ -424,6 +475,8 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 			const hotkeyTriggers = pair.triggers
 				.filter((trigger) => trigger.type === TriggerType.hotkey)
 				.map((trigger) => trigger.keys)
+
+			const finalKeys = hotkeyTriggers.map((key) => getFinalKey(key))
 
 			previewAutoruns.push(
 				isolatedAutorunWithCleanup(() => {
@@ -444,7 +497,10 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 								type: adLib.type,
 								triggeredActionId: pair._id,
 								keys: hotkeyTriggers,
+								finalKeys,
 								name: pair.name,
+								targetName: adLib.label,
+								sourceLayerId: adLib.sourceLayerId,
 							},
 						})
 					})
@@ -461,7 +517,7 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 		return () => {
 			if (initialized) {
 				triggeredActions.forEach((pair) => {
-					const actionListener = createdActions.get(pair._id)
+					const actionListener = createdActions.current.get(pair._id)
 					if (actionListener) {
 						pair.triggers.forEach((trigger) => {
 							if (trigger.type === TriggerType.hotkey) {

--- a/meteor/client/lib/triggers/codesToKeyLabels.ts
+++ b/meteor/client/lib/triggers/codesToKeyLabels.ts
@@ -30,3 +30,8 @@ export function keyLabelsToCodes(labels: string, sorensen: Sorensen) {
 		})
 		.join(' ')
 }
+
+export function getFinalKey(keys: string) {
+	const individualKeys = keys.split(/\+/gi)
+	return individualKeys[individualKeys.length - 1]
+}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -90,6 +90,7 @@ import { memoizedIsolatedAutorun } from '../lib/reactiveData/reactiveDataHelper'
 import RundownViewEventBus, {
 	ActivateRundownPlaylistEvent,
 	IEventContext,
+	MiniShelfQueueAdLibEvent,
 	RundownViewEvents,
 } from './RundownView/RundownViewEventBus'
 import StudioContext from './RundownView/StudioContext'
@@ -1671,6 +1672,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 			RundownViewEventBus.on(RundownViewEvents.GO_TO_LIVE_SEGMENT, this.onGoToLiveSegment)
 			RundownViewEventBus.on(RundownViewEvents.GO_TO_TOP, this.onGoToTop)
+			RundownViewEventBus.on(RundownViewEvents.MINI_SHELF_QUEUE_ADLIB, this.eventQueueMiniShelfAdLib)
 
 			if (this.props.playlist) {
 				documentTitle.set(this.props.playlist.name)
@@ -1847,6 +1849,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 			RundownViewEventBus.off(RundownViewEvents.GO_TO_LIVE_SEGMENT, this.onGoToLiveSegment)
 			RundownViewEventBus.off(RundownViewEvents.GO_TO_TOP, this.onGoToTop)
+			RundownViewEventBus.off(RundownViewEvents.MINI_SHELF_QUEUE_ADLIB, this.eventQueueMiniShelfAdLib)
 		}
 
 		onBeforeUnload = (e: any) => {
@@ -1947,6 +1950,10 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					followLiveSegments: true,
 				})
 			}
+		}
+
+		eventQueueMiniShelfAdLib = (e: MiniShelfQueueAdLibEvent) => {
+			this.queueMinishelfAdLib(e, e.forward)
 		}
 
 		onActivate = () => {

--- a/meteor/client/ui/RundownView/RundownViewEventBus.ts
+++ b/meteor/client/ui/RundownView/RundownViewEventBus.ts
@@ -23,6 +23,7 @@ export enum RundownViewEvents {
 	REVEAL_IN_SHELF = 'revealInShelf',
 	SWITCH_SHELF_TAB = 'switchShelfTab',
 	SHELF_STATE = 'shelfState',
+	MINI_SHELF_QUEUE_ADLIB = 'miniShelfQueueAdLib',
 	GO_TO_PART = 'goToPart',
 	GO_TO_PART_INSTANCE = 'goToPartInstance',
 	SELECT_PIECE = 'selectPiece',
@@ -57,6 +58,10 @@ export interface SwitchToShelfTabEvent extends IEventContext {
 
 export interface ShelfStateEvent extends IEventContext {
 	state: boolean | 'toggle'
+}
+
+export interface MiniShelfQueueAdLibEvent extends IEventContext {
+	forward: boolean
 }
 
 export interface GoToPartEvent extends IEventContext {
@@ -104,6 +109,7 @@ class RundownViewEventBus0 extends EventEmitter {
 	emit(event: RundownViewEvents.SHELF_STATE, e: ShelfStateEvent): boolean
 	emit(event: RundownViewEvents.REVEAL_IN_SHELF, e: RevealInShelfEvent): boolean
 	emit(event: RundownViewEvents.SWITCH_SHELF_TAB, e: SwitchToShelfTabEvent): boolean
+	emit(event: RundownViewEvents.MINI_SHELF_QUEUE_ADLIB, e: MiniShelfQueueAdLibEvent): boolean
 	emit(event: RundownViewEvents.GO_TO_PART, e: GoToPartEvent): boolean
 	emit(event: RundownViewEvents.GO_TO_PART_INSTANCE, e: GoToPartInstanceEvent): boolean
 	emit(event: RundownViewEvents.SELECT_PIECE, e: SelectPieceEvent): boolean
@@ -130,6 +136,7 @@ class RundownViewEventBus0 extends EventEmitter {
 	on(event: RundownViewEvents.REVEAL_IN_SHELF, listener: (e: RevealInShelfEvent) => void): this
 	on(event: RundownViewEvents.SHELF_STATE, listener: (e: ShelfStateEvent) => void): this
 	on(event: RundownViewEvents.SWITCH_SHELF_TAB, listener: (e: SwitchToShelfTabEvent) => void): this
+	on(event: RundownViewEvents.MINI_SHELF_QUEUE_ADLIB, listener: (e: MiniShelfQueueAdLibEvent) => void): this
 	on(event: RundownViewEvents.GO_TO_PART, listener: (e: GoToPartEvent) => void): this
 	on(event: RundownViewEvents.GO_TO_PART_INSTANCE, listener: (e: GoToPartInstanceEvent) => void): this
 	on(event: RundownViewEvents.SELECT_PIECE, listener: (e: SelectPieceEvent) => void): this

--- a/meteor/client/ui/RundownView/RundownViewEventBus.ts
+++ b/meteor/client/ui/RundownView/RundownViewEventBus.ts
@@ -9,6 +9,7 @@ import { IAdLibListItem } from '../Shelf/AdLibListItem'
 import { BucketAdLibItem } from '../Shelf/RundownViewBuckets'
 import { RundownId } from '../../../lib/collections/Rundowns'
 import { Bucket } from '../../../lib/collections/Buckets'
+import { TriggeredActionId } from '../../../lib/collections/TriggeredActions'
 
 export enum RundownViewEvents {
 	ACTIVATE_RUNDOWN_PLAYLIST = 'activateRundownPlaylist',
@@ -28,6 +29,7 @@ export enum RundownViewEvents {
 	GO_TO_PART_INSTANCE = 'goToPartInstance',
 	SELECT_PIECE = 'selectPiece',
 	HIGHLIGHT = 'highlight',
+	TRIGGER_ACTION = 'triggerAction',
 
 	RENAME_BUCKET_ADLIB = 'renameBucketAdLib',
 	DELETE_BUCKET_ADLIB = 'deleteBucketAdLib',
@@ -96,6 +98,10 @@ export interface BucketEvent extends IEventContext {
 	bucket: Bucket
 }
 
+export interface TriggerActionEvent extends IEventContext {
+	actionId: TriggeredActionId
+}
+
 class RundownViewEventBus0 extends EventEmitter {
 	emit(event: RundownViewEvents.ACTIVATE_RUNDOWN_PLAYLIST, e: ActivateRundownPlaylistEvent): boolean
 	emit(event: RundownViewEvents.RESYNC_RUNDOWN_PLAYLIST, e: BaseEvent): boolean
@@ -114,6 +120,7 @@ class RundownViewEventBus0 extends EventEmitter {
 	emit(event: RundownViewEvents.GO_TO_PART_INSTANCE, e: GoToPartInstanceEvent): boolean
 	emit(event: RundownViewEvents.SELECT_PIECE, e: SelectPieceEvent): boolean
 	emit(event: RundownViewEvents.HIGHLIGHT, e: HighlightEvent): boolean
+	emit(event: RundownViewEvents.TRIGGER_ACTION, e: TriggerActionEvent): boolean
 	emit(event: RundownViewEvents.EMPTY_BUCKET, e: BucketEvent): boolean
 	emit(event: RundownViewEvents.DELETE_BUCKET, e: BucketEvent): boolean
 	emit(event: RundownViewEvents.RENAME_BUCKET, e: BucketEvent): boolean
@@ -141,6 +148,7 @@ class RundownViewEventBus0 extends EventEmitter {
 	on(event: RundownViewEvents.GO_TO_PART_INSTANCE, listener: (e: GoToPartInstanceEvent) => void): this
 	on(event: RundownViewEvents.SELECT_PIECE, listener: (e: SelectPieceEvent) => void): this
 	on(event: RundownViewEvents.HIGHLIGHT, listener: (e: HighlightEvent) => void): this
+	on(event: RundownViewEvents.TRIGGER_ACTION, listener: (e: TriggerActionEvent) => void): this
 	on(event: RundownViewEvents.EMPTY_BUCKET, listener: (e: BucketEvent) => void): this
 	on(event: RundownViewEvents.DELETE_BUCKET, listener: (e: BucketEvent) => void): this
 	on(event: RundownViewEvents.RENAME_BUCKET, listener: (e: BucketEvent) => void): this

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -205,7 +205,6 @@ export class CustomLayerItemRenderer<
 		const innerPiece = uiPiece.instance.piece
 		const content = innerPiece.content
 		const duration = content && content.sourceDuration
-		console.log(this.props)
 		if (duration && this.props.showDurationSourceLayers?.has(innerPiece.sourceLayerId)) {
 			return (
 				<span className="segment-timeline__piece__label__duration">{`(${RundownUtils.formatDiffToTimecode(

--- a/meteor/client/ui/Settings/components/triggeredActions/actionEditors/actionSelector/ActionSelector.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/actionEditors/actionSelector/ActionSelector.tsx
@@ -85,6 +85,9 @@ function getArguments(t: TFunction, action: SomeAction): string[] {
 				result.push(t('Off'))
 			}
 			break
+		case ClientActions.miniShelfQueueAdLib:
+			result.push(t('Forward: {{forward}}', { forward: action.forward }))
+			break
 		default:
 			assertNever(action)
 			return action
@@ -124,6 +127,8 @@ function hasArguments(action: SomeAction): boolean {
 			return false
 		case ClientActions.showEntireCurrentSegment:
 			return true
+		case ClientActions.miniShelfQueueAdLib:
+			return true
 		default:
 			assertNever(action)
 			return action
@@ -162,6 +167,8 @@ function actionToLabel(t: TFunction, action: SomeAction['action']): string {
 			return t('Go to On Air line')
 		case ClientActions.showEntireCurrentSegment:
 			return t('Show entire On Air Segment')
+		case ClientActions.miniShelfQueueAdLib:
+			return t('MiniShelf queue AdLib')
 		default:
 			assertNever(action)
 			return action
@@ -351,6 +358,25 @@ function getActionParametersEditor(
 							onChange({
 								...action,
 								on: newVal,
+							})
+						}}
+					/>
+				</div>
+			)
+		case ClientActions.miniShelfQueueAdLib:
+			return (
+				<div className="mts">
+					<EditAttribute
+						className="form-control"
+						modifiedClassName="bghl"
+						type={'toggle'}
+						label={t('Forward')}
+						overrideDisplayValue={action.forward}
+						attribute={''}
+						updateFunction={(_e, newVal) => {
+							onChange({
+								...action,
+								forward: newVal,
 							})
 						}}
 					/>

--- a/meteor/client/ui/Settings/components/triggeredActions/triggerEditors/HotkeyEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/triggerEditors/HotkeyEditor.tsx
@@ -14,7 +14,7 @@ interface IProps {
 	onChange: (newVal: DBBlueprintTrigger) => void
 }
 
-const MODIFIER_MAP = {
+export const MODIFIER_MAP = {
 	ControlLeft: 'Control',
 	ControlRight: 'Control',
 	ShiftLeft: 'Shift',

--- a/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
@@ -13,6 +13,8 @@ import {
 	RundownLayoutKeyboardPreview,
 	DashboardLayoutKeyboardPreview,
 } from '../../../lib/collections/RundownLayouts'
+import { Sorensen } from '@sofie-automation/sorensen'
+import { SorensenContext } from '../../lib/SorensenContext'
 
 interface IProps {
 	visible?: boolean
@@ -25,8 +27,15 @@ const _isMacLike = navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) ? true : 
 
 export const KeyboardPreviewPanel = withTranslation()(
 	class KeyboardPreviewPanel extends React.Component<Translated<IProps>> {
+		static contextType = SorensenContext
+		sorensen: Sorensen | undefined
+
 		constructor(props: Translated<IProps>) {
 			super(props)
+		}
+
+		componentDidMount() {
+			this.sorensen = this.context
 		}
 
 		render() {
@@ -46,6 +55,7 @@ export const KeyboardPreviewPanel = withTranslation()(
 						<KeyboardPreview
 							physicalLayout={KeyboardLayouts.nameToPhysicalLayout(Settings.keyboardMapLayout)}
 							showStyleBase={this.props.showStyleBase}
+							sorensen={this.sorensen}
 						/>
 					</div>
 				)

--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -181,6 +181,7 @@ export namespace RundownLayoutsAPI {
 			RundownLayoutElementType.FILTER,
 			RundownLayoutElementType.PIECE_COUNTDOWN,
 			RundownLayoutElementType.NEXT_INFO,
+			RundownLayoutElementType.KEYBOARD_PREVIEW,
 		],
 	})
 	registry.registerShelfLayout(RundownLayoutType.DASHBOARD_LAYOUT, {
@@ -192,6 +193,7 @@ export namespace RundownLayoutsAPI {
 			RundownLayoutElementType.PIECE_COUNTDOWN,
 			RundownLayoutElementType.NEXT_INFO,
 			RundownLayoutElementType.TEXT_LABEL,
+			RundownLayoutElementType.KEYBOARD_PREVIEW,
 		],
 	})
 	registry.registerMiniShelfLayout(RundownLayoutType.DASHBOARD_LAYOUT, {

--- a/meteor/lib/api/triggers/actionFactory.ts
+++ b/meteor/lib/api/triggers/actionFactory.ts
@@ -321,6 +321,17 @@ function createShelfAction(filterChain: IGUIContextFilterLink[], state: boolean 
 	}
 }
 
+function createMiniShelfQueueAdLibAction(_filterChain: IGUIContextFilterLink[], forward: boolean): ExecutableAction {
+	return {
+		action: ClientActions.miniShelfQueueAdLib,
+		execute: () => {
+			RundownViewEventBus.emit(RundownViewEvents.MINI_SHELF_QUEUE_ADLIB, {
+				forward,
+			})
+		},
+	}
+}
+
 function createGoToOnAirLineAction(_filterChain: IGUIContextFilterLink[]): ExecutableAction {
 	return {
 		action: ClientActions.goToOnAirLine,
@@ -510,6 +521,8 @@ export function createAction(action: SomeAction, showStyleBase: ShowStyleBase): 
 			)
 		case ClientActions.showEntireCurrentSegment:
 			return createShowEntireCurrentSegmentAction(action.filterChain, action.on)
+		case ClientActions.miniShelfQueueAdLib:
+			return createMiniShelfQueueAdLibAction(action.filterChain, action.forward)
 		default:
 			assertNever(action)
 			break

--- a/meteor/lib/api/triggers/actionFactory.ts
+++ b/meteor/lib/api/triggers/actionFactory.ts
@@ -29,26 +29,50 @@ import {
 } from './actionFilterChainCompilers'
 import { ClientAPI } from '../client'
 import { RundownId, Rundowns } from '../../collections/Rundowns'
+import { ReactiveVar } from 'meteor/reactive-var'
 
 // as described in this issue: https://github.com/Microsoft/TypeScript/issues/14094
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }
 // eslint-disable-next-line @typescript-eslint/ban-types
 type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U
 
-export type ActionContext = XOR<
-	{
-		rundownPlaylist: RundownPlaylist
-		currentRundownId: RundownId | null
-		currentSegmentPartIds: PartId[]
-		nextSegmentPartIds: PartId[]
-		currentPartId: PartId | null
-		nextPartId: PartId | null
-	},
-	{
-		studio: Studio
-		showStyleBase: ShowStyleBase
+class DummyReactiveVar<T> implements ReactiveVar<T> {
+	constructor(private value: T) {}
+	public get(): T {
+		return this.value
 	}
->
+	public set(newValue: T): void {
+		this.value = newValue
+	}
+}
+
+export interface ReactivePlaylistActionContext {
+	rundownPlaylistId: ReactiveVar<RundownPlaylistId>
+	rundownPlaylist: ReactiveVar<RundownPlaylist>
+	currentRundownId: ReactiveVar<RundownId | null>
+	currentSegmentPartIds: ReactiveVar<PartId[]>
+	nextSegmentPartIds: ReactiveVar<PartId[]>
+	currentPartId: ReactiveVar<PartId | null>
+	nextPartId: ReactiveVar<PartId | null>
+}
+
+interface PlainPlaylistContext {
+	rundownPlaylist: RundownPlaylist
+	currentRundownId: RundownId | null
+	currentSegmentPartIds: PartId[]
+	nextSegmentPartIds: PartId[]
+	currentPartId: PartId | null
+	nextPartId: PartId | null
+}
+
+interface PlainStudioContext {
+	studio: Studio
+	showStyleBase: ShowStyleBase
+}
+
+type PlainActionContext = XOR<PlainPlaylistContext, PlainStudioContext>
+
+export type ActionContext = XOR<ReactivePlaylistActionContext, PlainActionContext>
 
 type ActionExecutor = (t: TFunction, e: any, ctx: ActionContext) => void
 
@@ -71,7 +95,7 @@ interface ExecutableAction {
  * @extends {ExecutableAction}
  */
 interface PreviewableAction extends ExecutableAction {
-	preview: (ctx: ActionContext) => IWrappedAdLib[]
+	preview: (ctx: ReactivePlaylistActionContext) => IWrappedAdLib[]
 }
 
 interface ExecutableAdLibAction extends PreviewableAction {
@@ -82,29 +106,22 @@ export function isPreviewableAction(action: ExecutableAction): action is Preview
 	return action.action && typeof action['preview'] === 'function'
 }
 
-interface InternalActionContext {
-	rundownPlaylistId: RundownPlaylistId
-	rundownPlaylist: RundownPlaylist
-	currentRundownId: RundownId | null
-	currentSegmentPartIds: PartId[]
-	nextSegmentPartIds: PartId[]
-	currentPartId: PartId | null
-	nextPartId: PartId | null
-}
-
 function createRundownPlaylistContext(
 	context: ActionContext,
 	filterChain: IBaseFilterLink[]
-): InternalActionContext | undefined {
-	if (filterChain[0].object === 'view' && context.rundownPlaylist) {
+): ReactivePlaylistActionContext | undefined {
+	if (filterChain[0].object === 'view' && context.rundownPlaylistId) {
+		return context as ReactivePlaylistActionContext
+	} else if (filterChain[0].object === 'view' && context.rundownPlaylist) {
+		const playlistContext = context as PlainPlaylistContext
 		return {
-			rundownPlaylistId: context.rundownPlaylist._id,
-			rundownPlaylist: context.rundownPlaylist,
-			currentRundownId: context.currentRundownId,
-			currentPartId: context.currentPartId,
-			nextPartId: context.nextPartId,
-			currentSegmentPartIds: context.currentSegmentPartIds,
-			nextSegmentPartIds: context.nextSegmentPartIds,
+			rundownPlaylistId: new DummyReactiveVar(playlistContext.rundownPlaylist._id),
+			rundownPlaylist: new DummyReactiveVar(playlistContext.rundownPlaylist),
+			currentRundownId: new DummyReactiveVar(playlistContext.currentRundownId),
+			currentPartId: new DummyReactiveVar(playlistContext.currentPartId),
+			nextPartId: new DummyReactiveVar(playlistContext.nextPartId),
+			currentSegmentPartIds: new DummyReactiveVar(playlistContext.currentSegmentPartIds),
+			nextSegmentPartIds: new DummyReactiveVar(playlistContext.nextSegmentPartIds),
 		}
 	} else if (filterChain[0].object === 'rundownPlaylist' && context.studio && Meteor.isServer) {
 		const playlist = rundownPlaylistFilter(
@@ -140,25 +157,26 @@ function createRundownPlaylistContext(
 			}
 
 			return {
-				rundownPlaylistId: playlist?._id,
-				rundownPlaylist: playlist,
-				currentRundownId:
+				rundownPlaylistId: new DummyReactiveVar(playlist?._id),
+				rundownPlaylist: new DummyReactiveVar(playlist),
+				currentRundownId: new DummyReactiveVar(
 					currentPartInstance?.rundownId ??
-					Rundowns.findOne(
-						{
-							playlistId: playlist._id,
-						},
-						{
-							sort: {
-								_rank: 1,
+						Rundowns.findOne(
+							{
+								playlistId: playlist._id,
 							},
-						}
-					)?._id ??
-					null,
-				currentPartId,
-				currentSegmentPartIds,
-				nextPartId,
-				nextSegmentPartIds,
+							{
+								sort: {
+									_rank: 1,
+								},
+							}
+						)?._id ??
+						null
+				),
+				currentPartId: new DummyReactiveVar(currentPartId),
+				currentSegmentPartIds: new DummyReactiveVar(currentSegmentPartIds),
+				nextPartId: new DummyReactiveVar(nextPartId),
+				nextSegmentPartIds: new DummyReactiveVar(nextSegmentPartIds),
 			}
 		}
 	} else {
@@ -184,14 +202,7 @@ function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: S
 
 			if (innerCtx) {
 				try {
-					return compiledAdLibFilter(
-						innerCtx.rundownPlaylistId,
-						innerCtx.currentRundownId,
-						innerCtx.currentSegmentPartIds || [],
-						innerCtx.nextSegmentPartIds || [],
-						innerCtx.currentPartId || null,
-						innerCtx.nextPartId || null
-					)
+					return compiledAdLibFilter(innerCtx)
 				} catch (e) {
 					logger.error(e)
 					return []
@@ -207,19 +218,10 @@ function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: S
 				logger.warn(`Could not create RundownPlaylist context for executable AdLib Action`, filterChain)
 				return
 			}
-			const currentPartInstanceId = innerCtx.rundownPlaylist.currentPartInstanceId
+			const currentPartInstanceId = innerCtx.rundownPlaylist.get().currentPartInstanceId
 
 			const sourceLayerIdsToClear: string[] = []
-			Tracker.nonreactive(() =>
-				compiledAdLibFilter(
-					innerCtx.rundownPlaylistId,
-					innerCtx.currentRundownId,
-					innerCtx.currentSegmentPartIds || [],
-					innerCtx.nextSegmentPartIds || [],
-					innerCtx.currentPartId || null,
-					innerCtx.nextPartId || null
-				)
-			).forEach((wrappedAdLib) => {
+			Tracker.nonreactive(() => compiledAdLibFilter(innerCtx)).forEach((wrappedAdLib) => {
 				switch (wrappedAdLib.type) {
 					case 'adLibPiece':
 						doUserAction(
@@ -230,7 +232,7 @@ function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: S
 								currentPartInstanceId &&
 								MeteorCall.userAction.segmentAdLibPieceStart(
 									e,
-									innerCtx.rundownPlaylistId,
+									innerCtx.rundownPlaylistId.get(),
 									currentPartInstanceId,
 									wrappedAdLib.item._id,
 									false
@@ -246,7 +248,7 @@ function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: S
 								currentPartInstanceId &&
 								MeteorCall.userAction.baselineAdLibPieceStart(
 									e,
-									innerCtx.rundownPlaylistId,
+									innerCtx.rundownPlaylistId.get(),
 									currentPartInstanceId,
 									wrappedAdLib.item._id,
 									false
@@ -257,7 +259,7 @@ function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: S
 						doUserAction(t, e, UserAction.START_ADLIB, async (e) =>
 							MeteorCall.userAction.executeAction(
 								e,
-								innerCtx.rundownPlaylistId,
+								innerCtx.rundownPlaylistId.get(),
 								wrappedAdLib._id,
 								wrappedAdLib.item.actionId,
 								wrappedAdLib.item.userData,
@@ -269,7 +271,7 @@ function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: S
 						doUserAction(t, e, UserAction.START_GLOBAL_ADLIB, async (e) =>
 							MeteorCall.userAction.executeAction(
 								e,
-								innerCtx.rundownPlaylistId,
+								innerCtx.rundownPlaylistId.get(),
 								wrappedAdLib._id,
 								wrappedAdLib.item.actionId,
 								wrappedAdLib.item.userData,
@@ -285,7 +287,7 @@ function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: S
 						doUserAction(t, e, UserAction.START_STICKY_PIECE, async (e) =>
 							MeteorCall.userAction.sourceLayerStickyPieceStart(
 								e,
-								innerCtx.rundownPlaylistId,
+								innerCtx.rundownPlaylistId.get(),
 								wrappedAdLib.sourceLayerId //
 							)
 						)
@@ -300,7 +302,7 @@ function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: S
 				doUserAction(t, e, UserAction.CLEAR_SOURCELAYER, async (e) =>
 					MeteorCall.userAction.sourceLayerOnPartStop(
 						e,
-						innerCtx.rundownPlaylistId,
+						innerCtx.rundownPlaylistId.get(),
 						currentPartInstanceId,
 						sourceLayerIdsToClear
 					)
@@ -423,7 +425,7 @@ function createRundownPlaylistSoftResetRundownAction(_filterChain: IGUIContextFi
 function createUserActionWithCtx(
 	action: SomeAction,
 	userAction: UserAction,
-	userActionExec: (e: string, ctx: InternalActionContext) => Promise<ClientAPI.ClientResponse<any>>
+	userActionExec: (e: string, ctx: ReactivePlaylistActionContext) => Promise<ClientAPI.ClientResponse<any>>
 ): ExecutableAction {
 	return {
 		action: action.action,
@@ -455,7 +457,11 @@ export function createAction(action: SomeAction, showStyleBase: ShowStyleBase): 
 		case PlayoutActions.activateRundownPlaylist:
 			if (action.force) {
 				return createUserActionWithCtx(action, UserAction.DEACTIVATE_OTHER_RUNDOWN_PLAYLIST, async (e, ctx) =>
-					MeteorCall.userAction.forceResetAndActivate(e, ctx.rundownPlaylistId, !!action.rehearsal || false)
+					MeteorCall.userAction.forceResetAndActivate(
+						e,
+						ctx.rundownPlaylistId.get(),
+						!!action.rehearsal || false
+					)
 				)
 			} else {
 				if (Meteor.isClient && action.filterChain.every((link) => link.object === 'view')) {
@@ -465,37 +471,37 @@ export function createAction(action: SomeAction, showStyleBase: ShowStyleBase): 
 					)
 				} else {
 					return createUserActionWithCtx(action, UserAction.ACTIVATE_RUNDOWN_PLAYLIST, async (e, ctx) =>
-						MeteorCall.userAction.activate(e, ctx.rundownPlaylistId, !!action.rehearsal || false)
+						MeteorCall.userAction.activate(e, ctx.rundownPlaylistId.get(), !!action.rehearsal || false)
 					)
 				}
 			}
 		case PlayoutActions.deactivateRundownPlaylist:
 			return createUserActionWithCtx(action, UserAction.DEACTIVATE_RUNDOWN_PLAYLIST, async (e, ctx) =>
-				MeteorCall.userAction.deactivate(e, ctx.rundownPlaylistId)
+				MeteorCall.userAction.deactivate(e, ctx.rundownPlaylistId.get())
 			)
 		case PlayoutActions.take:
 			if (Meteor.isClient && action.filterChain.every((link) => link.object === 'view')) {
 				return createRundownPlaylistSoftTakeAction(action.filterChain as IGUIContextFilterLink[])
 			} else {
 				return createUserActionWithCtx(action, UserAction.TAKE, async (e, ctx) =>
-					MeteorCall.userAction.take(e, ctx.rundownPlaylistId)
+					MeteorCall.userAction.take(e, ctx.rundownPlaylistId.get())
 				)
 			}
 		case PlayoutActions.hold:
 			return createUserActionWithCtx(action, UserAction.ACTIVATE_HOLD, async (e, ctx) =>
-				MeteorCall.userAction.activateHold(e, ctx.rundownPlaylistId, !!action.undo)
+				MeteorCall.userAction.activateHold(e, ctx.rundownPlaylistId.get(), !!action.undo)
 			)
 		case PlayoutActions.disableNextPiece:
 			return createUserActionWithCtx(action, UserAction.DISABLE_NEXT_PIECE, async (e, ctx) =>
-				MeteorCall.userAction.disableNextPiece(e, ctx.rundownPlaylistId, !!action.undo)
+				MeteorCall.userAction.disableNextPiece(e, ctx.rundownPlaylistId.get(), !!action.undo)
 			)
 		case PlayoutActions.createSnapshotForDebug:
 			return createUserActionWithCtx(action, UserAction.CREATE_SNAPSHOT_FOR_DEBUG, async (e, ctx) =>
-				MeteorCall.userAction.storeRundownSnapshot(e, ctx.rundownPlaylistId, `action`)
+				MeteorCall.userAction.storeRundownSnapshot(e, ctx.rundownPlaylistId.get(), `action`)
 			)
 		case PlayoutActions.moveNext:
 			return createUserActionWithCtx(action, UserAction.MOVE_NEXT, async (e, ctx) =>
-				MeteorCall.userAction.moveNext(e, ctx.rundownPlaylistId, action.parts ?? 0, action.segments ?? 0)
+				MeteorCall.userAction.moveNext(e, ctx.rundownPlaylistId.get(), action.parts ?? 0, action.segments ?? 0)
 			)
 		case PlayoutActions.reloadRundownPlaylistData:
 			if (Meteor.isClient && action.filterChain.every((link) => link.object === 'view')) {
@@ -504,7 +510,7 @@ export function createAction(action: SomeAction, showStyleBase: ShowStyleBase): 
 				return createUserActionWithCtx(action, UserAction.RELOAD_RUNDOWN_PLAYLIST_DATA, async (e, ctx) =>
 					// TODO: Needs some handling of the response. Perhaps this should switch to
 					// an event on the RundownViewEventBus, if ran on the client?
-					MeteorCall.userAction.resyncRundownPlaylist(e, ctx.rundownPlaylistId)
+					MeteorCall.userAction.resyncRundownPlaylist(e, ctx.rundownPlaylistId.get())
 				)
 			}
 		case PlayoutActions.resetRundownPlaylist:
@@ -512,12 +518,12 @@ export function createAction(action: SomeAction, showStyleBase: ShowStyleBase): 
 				return createRundownPlaylistSoftResetRundownAction(action.filterChain as IGUIContextFilterLink[])
 			} else {
 				return createUserActionWithCtx(action, UserAction.RESET_RUNDOWN_PLAYLIST, async (e, ctx) =>
-					MeteorCall.userAction.resetRundownPlaylist(e, ctx.rundownPlaylistId)
+					MeteorCall.userAction.resetRundownPlaylist(e, ctx.rundownPlaylistId.get())
 				)
 			}
 		case PlayoutActions.resyncRundownPlaylist:
 			return createUserActionWithCtx(action, UserAction.RESYNC_RUNDOWN_PLAYLIST, async (e, ctx) =>
-				MeteorCall.userAction.resyncRundownPlaylist(e, ctx.rundownPlaylistId)
+				MeteorCall.userAction.resyncRundownPlaylist(e, ctx.rundownPlaylistId.get())
 			)
 		case ClientActions.showEntireCurrentSegment:
 			return createShowEntireCurrentSegmentAction(action.filterChain, action.on)

--- a/meteor/server/migration/1_37_0.ts
+++ b/meteor/server/migration/1_37_0.ts
@@ -3,7 +3,7 @@ import { addMigrationSteps } from './databaseMigration'
 import { ensureCollectionProperty } from './lib'
 import { CustomizableRegions } from '../../lib/collections/RundownLayouts'
 import { RundownPlaylist, RundownPlaylists } from '../../lib/collections/RundownPlaylists'
-import { generateTranslation as t, objectPathGet, protectString } from '../../lib/lib'
+import { generateTranslation as t, getHash, objectPathGet, protectString } from '../../lib/lib'
 import {
 	ClientActions,
 	IBlueprintTriggeredActions,
@@ -492,7 +492,7 @@ export const addSteps = addMigrationSteps('1.37.0', [
 			DEFAULT_CORE_TRIGGERS.forEach((triggeredAction) => {
 				TriggeredActions.insert({
 					...triggeredAction,
-					_id: protectString(triggeredAction._id),
+					_id: protectString(getHash(triggeredAction._id)),
 					showStyleBaseId: null,
 					_rundownVersionHash: '',
 				})

--- a/packages/blueprints-integration/src/triggers.ts
+++ b/packages/blueprints-integration/src/triggers.ts
@@ -84,7 +84,7 @@ export enum ClientActions {
 	'goToOnAirLine' = 'goToOnAirLine',
 	'rewindSegments' = 'rewindSegments',
 	'showEntireCurrentSegment' = 'showEntireCurrentSegment',
-	// 'moveAdLibFocus' = 'moveAdLibFocus' // TV2 is working on a feature with "focusable ad libs"
+	'miniShelfQueueAdLib' = 'miniShelfQueueAdLib',
 }
 
 export interface ITriggeredActionBase {
@@ -252,6 +252,12 @@ export interface IShowEntireCurrentSegmentAction extends ITriggeredActionBase {
 	on: boolean
 }
 
+export interface IMiniShelfQueueAdLib extends ITriggeredActionBase {
+	action: ClientActions.miniShelfQueueAdLib
+	filterChain: IGUIContextFilterLink[]
+	forward: boolean
+}
+
 export type SomeAction =
 	| IAdlibPlayoutAction
 	| IRundownPlaylistActivateAction
@@ -268,6 +274,7 @@ export type SomeAction =
 	| IGoToOnAirLineAction
 	| IRewindSegmentsAction
 	| IShowEntireCurrentSegmentAction
+	| IMiniShelfQueueAdLib
 
 export interface IBlueprintTriggeredActions {
 	_id: string


### PR DESCRIPTION
Merges latest commits from nrkno/release37.

Improves performance and feature set of TriggersHandler:
- makes each property of rundownPlaylistContext a reactive var to make preview trackers depend only on the really needed properties
- adds rundown view event for triggering mounted actions by their ids
- adds extra MountedGenericTriggers and MountedAdLibTriggers properties to facilitate use in the keyboard preview

Makes the Keyboard Preview (Keyboard Map) use Action Triggers.