### PR TITLE
fix: Live segment removed when floated

### DIFF
--- a/meteor/server/api/ingest/commit.ts
+++ b/meteor/server/api/ingest/commit.ts
@@ -192,17 +192,45 @@ export async function CommitIngestOperation(
 						newPlaylistId[1]
 					)
 
-					// Do the segment removals
-					if (data.removedSegmentIds.length > 0) {
-						const { currentPartInstance, nextPartInstance } = newPlaylist.getSelectedPartInstances()
+					const { currentPartInstance, nextPartInstance } = newPlaylist.getSelectedPartInstances()
 
+					let aChangedSegmentIsHidden = ingestCache.Segments.findFetch({
+						_id: { $in: data.changedSegmentIds as SegmentId[] },
+					}).some((s) => s.isHidden)
+
+					// Do the segment removals
+					if (data.removedSegmentIds.length > 0 || aChangedSegmentIsHidden) {
 						const purgeSegmentIds = new Set<SegmentId>()
 						const orphanSegmentIds = new Set<SegmentId>()
 						for (const segmentId of data.removedSegmentIds) {
 							if (canRemoveSegment(currentPartInstance, nextPartInstance, segmentId)) {
 								purgeSegmentIds.add(segmentId)
 							} else {
+								logger.warn(
+									`Not allowing removal of current playing segment "${segmentId}", making segment unsynced instead`
+								)
 								orphanSegmentIds.add(segmentId)
+							}
+						}
+
+						// Protect live segment from being hidden
+						for (const [segmentId, segment] of ingestCache.Segments.documents) {
+							if (segment?.document.isHidden) {
+								if (!canRemoveSegment(currentPartInstance, nextPartInstance, segmentId)) {
+									logger.warn(`Cannot hide live segment ${segmentId}, it will be orphaned`)
+									ingestCache.Segments.update(segmentId, {
+										$set: { isHidden: false },
+									})
+								} else {
+									// This ensures that it doesn't accidently get played while hidden
+									ingestCache.Parts.update({ segmentId }, { $set: { invalid: true } })
+								}
+								orphanSegmentIds.add(segmentId)
+							} else if (ingestCache.Parts.findFetch({ segmentId }).length === 0) {
+								// No parts in segment, hide it
+								ingestCache.Segments.update(segmentId, {
+									$set: { isHidden: true },
+								})
 							}
 						}
 
@@ -407,7 +435,6 @@ function canRemoveSegment(
 		(nextPartInstance?.segmentId === segmentId && isTooCloseToAutonext(currentPartInstance, false))
 	) {
 		// Don't allow removing an active rundown
-		logger.warn(`Not allowing removal of current playing segment "${segmentId}", making segment unsynced instead`)
 		return false
 	}
 

--- a/meteor/server/api/ingest/generation.ts
+++ b/meteor/server/api/ingest/generation.ts
@@ -208,11 +208,6 @@ export async function calculateSegmentsFromIngestData(
 				})
 				res.parts.push(part)
 
-				// This ensures that it doesn't accidently get played while hidden
-				if (blueprintRes.segment.isHidden) {
-					part.invalid = true
-				}
-
 				// Update pieces
 				res.pieces.push(
 					...postProcessPieces(

--- a/meteor/server/api/ingest/generation.ts
+++ b/meteor/server/api/ingest/generation.ts
@@ -291,11 +291,6 @@ export async function calculateSegmentsFromIngestData(
 					cache.Segments.update({ _id: orphanedSegment._id }, { $set: { _rank: newRank } })
 				}
 			}
-
-			// If the segment has no parts, then hide it
-			if (blueprintRes.parts.length === 0) {
-				newSegment.isHidden = true
-			}
 		}
 
 		span?.end()
@@ -698,19 +693,6 @@ export async function resolveSegmentChangesForUpdatedRundown(
 			...oldSegment,
 			orphaned: SegmentOrphanedReason.DELETED,
 		})
-	}
-
-	if (Settings.preserveUnsyncedPlayingSegmentContents && removedSegments.length > 0) {
-		// Preserve any old content, unless the part is referenced in another segment
-		const retainSegments = new Set(removedSegments.map((s) => s._id))
-		const newPartIds = new Set(segmentChanges.parts.map((p) => p._id))
-		const oldParts = cache.Parts.findFetch((p) => retainSegments.has(p.segmentId) && !newPartIds.has(p._id))
-		segmentChanges.parts.push(...oldParts)
-
-		const oldPartIds = new Set(oldParts.map((p) => p._id))
-		segmentChanges.pieces.push(...cache.Pieces.findFetch((p) => oldPartIds.has(p.startPartId)))
-		segmentChanges.adlibPieces.push(...cache.AdLibPieces.findFetch((p) => p.partId && oldPartIds.has(p.partId)))
-		segmentChanges.adlibActions.push(...cache.AdLibActions.findFetch((p) => p.partId && oldPartIds.has(p.partId)))
 	}
 
 	return { segmentChanges, removedSegments }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

When the live segment is floated, it is removed from the Sofie UI, and the underlying data is deleted.

* **What is the new behavior (if this is a feature change)?**

The floated segment will be treated as "unsynced", with the contents preserved if `preserveUnsyncedPlayingSegmentContents` is set as a core config. If this setting is not set, only the current part instance will be preserved, in line with the current removal logic.

In either case, the live segment will remain visible until the user takes another segment, at which point it will be cleaned up.

Some logic has been moved from the generation stage to the commit stage so that we can enforce certain behaviours, such as making all parts in a hidden segment invalid.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
