### PR TITLE
fix: Include transition pieces in primary piece lookup

### DIFF
--- a/meteor/client/ui/PieceIcons/PieceIcon.tsx
+++ b/meteor/client/ui/PieceIcons/PieceIcon.tsx
@@ -73,6 +73,7 @@ export const pieceIconSupportedLayers = new Set([
 	SourceLayerType.SPLITS,
 	SourceLayerType.VT,
 	SourceLayerType.CAMERA,
+	SourceLayerType.TRANSITION,
 ])
 
 export const PieceIconContainerNoSub = withTracker(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

Parts containing a transition as the primary piece (e.g. KAM CS 3, Intros) are given an orange background in the presenter screen / part preview panel. This is due to transition layers not being included in the list of piece icon layers, so the first valid layer found ends up being a (hidden) graphics layer.

* **What is the new behavior (if this is a feature change)?**

Transition layers are now allowed as primary layers, so pieces on these layers will be found and used as the primary piece.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
