### PR TITLE
fix: Queued segment bugs

### DIFF
--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -186,6 +186,7 @@ export async function deactivateRundownPlaylistInner(cache: CacheForPlayout): Pr
 			currentPartInstanceId: null,
 			holdState: RundownHoldState.NONE,
 			activeInstanceId: undefined,
+			nextSegmentId: undefined,
 		},
 		$unset: {
 			activationId: 1,

--- a/meteor/server/api/playout/pieces.ts
+++ b/meteor/server/api/playout/pieces.ts
@@ -257,6 +257,17 @@ export function getResolvedPiecesFromFullTimeline(
 
 	if (currentPartInstance && currentPartInstance.part.autoNext && playlist.nextPartInstanceId) {
 		pieceInstances.push(...cache.PieceInstances.findFetch((p) => p.partInstanceId === playlist.nextPartInstanceId))
+
+		// If a segment is queued and we're about to consume it, remove nextSegmentId from playlist
+		if (playlist.nextSegmentId) {
+			const consumedPartsInstancesInNextSegment = cache.PartInstances.findFetch({
+				_id: { $in: pieceInstances.map((p) => p.partInstanceId) },
+				segmentId: playlist.nextSegmentId,
+			})
+			if (consumedPartsInstancesInNextSegment.length) {
+				cache.Playlist.update({ $unset: { nextSegmentId: true } })
+			}
+		}
 	}
 
 	const replaceNows = (obj: TimelineContentObject, parentAbsoluteStart: number) => {

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -363,6 +363,17 @@ export namespace ServerPlayoutAPI {
 			if (!nextPart) throw new Meteor.Error(404, `Part "${nextPartId}" not found!`)
 		}
 
+		// If we're setting the next point to somewhere other than the current segment, and in the queued segment, clear the queued segment
+		const { currentPartInstance } = playlist.getSelectedPartInstances()
+		if (
+			currentPartInstance &&
+			nextPart &&
+			currentPartInstance.segmentId !== nextPart.segmentId &&
+			playlist.nextSegmentId === nextPart.segmentId
+		) {
+			clearNextSegment = true
+		}
+
 		if (clearNextSegment) {
 			libSetNextSegment(cache, null)
 		}

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -166,28 +166,6 @@ export async function setNextSegment(
 	if (nextSegmentId) {
 		nextSegment = (await Segments.findOneAsync(nextSegmentId)) || null
 		if (!nextSegment) throw new Meteor.Error(404, `Segment "${nextSegmentId}" not found!`)
-
-		const rundownIds = playlist.getRundownIDs()
-		if (rundownIds.indexOf(nextSegment.rundownId) === -1) {
-			throw new Meteor.Error(
-				404,
-				`Segment "${nextSegmentId}" does not belong to Rundown Playlist "${rundownPlaylistId}"!`
-			)
-		}
-
-		const partsInSegment = await Parts.findFetchAsync({
-			rundownId: nextSegment.rundownId,
-			segmentId: nextSegment._id,
-		})
-		const firstValidPartInSegment = partsInSegment.find((p) => p.isPlayable())
-
-		if (!firstValidPartInSegment) return ClientAPI.responseError('Segment contains no valid parts')
-
-		const { currentPartInstance, nextPartInstance } = playlist.getSelectedPartInstances()
-		if (!currentPartInstance || !nextPartInstance || nextPartInstance.segmentId !== currentPartInstance.segmentId) {
-			// Special: in this case, the user probably dosen't want to setNextSegment, but rather just setNextPart and clear previous nextSegmentId
-			return ServerPlayoutAPI.setNextPart(access, rundownPlaylistId, firstValidPartInSegment._id, true, 0, true)
-		}
 	}
 
 	return ServerPlayoutAPI.setNextSegment(access, rundownPlaylistId, nextSegmentId)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

- If you queue the currently live segment, there is not indicator that it is next/queued.
- Deactivating a rundown does not clear the queued segment point.
- Setting the queued segment as next does not clear the queued segment.

* **What is the new behavior (if this is a feature change)?**

The issues above are fixed.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
