### PR TITLE
fix: fixed duplicated shoutcuts

### DIFF
--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -705,7 +705,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): AdLibFetchA
 				const keyboardHotkeysList = sourceLayer.activateKeyboardHotkeys.split(',')
 				const sourceHotKeyUseLayerId =
 					sharedHotkeyList[sourceLayer.activateKeyboardHotkeys][0]._id || piece.sourceLayerId
-				if ((sourceHotKeyUse[sourceHotKeyUseLayerId] || 0) < keyboardHotkeysList.length) {
+				if ((sourceHotKeyUse[sourceHotKeyUseLayerId] || 0) < keyboardHotkeysList.length && !piece.noHotKey) {
 					// clone the AdLibPieceUi object, so that it doesn't affect any memoized autoruns that may have
 					// inserted pieces to this list
 					piece = {


### PR DESCRIPTION
Bundter were created as duplicated keyboard shortcuts.
Looks like it was caused by a merge error