### PR TITLE
Fix/sof 678/disable hoverscrub popup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ settings.json
 meteor/.coverage/
 node_modules
 tv-automation-server-core
+
+# Exclude JetBrains IDE specific files
+.idea

--- a/meteor/client/styles/customInstallation.scss
+++ b/meteor/client/styles/customInstallation.scss
@@ -1,5 +1,5 @@
 :root {
-	// Set to force single-click to toggle adlibs	
+	// Set to force single-click to toggle adlibs
 	--pointer: 'no-pointer';
 }
 
@@ -14,8 +14,8 @@ body.tv2 {
 
 	--segment-layer-background-camera: #005919;
 	--segment-layer-background-camera--second: lighten(#005919, 20%);
-	--segment-layer-background-lower-third: #af4900;
-	--segment-layer-background-lower-third--second: darken(#af4900, 20%);
+	--segment-layer-background-lower-third: #ca9d00;
+	--segment-layer-background-lower-third--second: darken(#ca9d00, 20%);
 	--segment-layer-background-graphics: #ca9d00;
 	--segment-layer-background-graphics--second: darken(#ca9d00, 20%);
 	--segment-layer-background-live-speak: #370020;
@@ -302,8 +302,10 @@ body.tv2 {
 
 			&.live-speak {
 				background: linear-gradient(
-					180deg
-					,var(--segment-layer-background-vt) 50%,var(--segment-layer-background-camera) 50.0001%) !important;
+					180deg,
+					var(--segment-layer-background-vt) 50%,
+					var(--segment-layer-background-camera) 50.0001%
+				) !important;
 			}
 		}
 
@@ -312,7 +314,6 @@ body.tv2 {
 				color: unset;
 			}
 		}
-	
 	}
 	.segment-timeline.next,
 	.segment-timeline.live {
@@ -472,8 +473,10 @@ body.tv2 {
 
 		&.live-speak {
 			background: linear-gradient(
-				180deg
-				,var(--segment-layer-background-vt) 50%,var(--segment-layer-background-camera) 50.0001%) !important;
+				180deg,
+				var(--segment-layer-background-vt) 50%,
+				var(--segment-layer-background-camera) 50.0001%
+			) !important;
 		}
 
 		&.piece-tag--no_next_highlight.selected {
@@ -522,7 +525,8 @@ body.tv2 {
 						color: var(--text-label-color);
 					}
 
-					> .part-remaining, > .part-elapsed {
+					> .part-remaining,
+					> .part-elapsed {
 						display: block;
 						width: 100%;
 						text-align: center;
@@ -626,7 +630,9 @@ body.tv2 {
 					}
 				}
 
-				&.playlist_name, &.expected_end, &.local_time {
+				&.playlist_name,
+				&.expected_end,
+				&.local_time {
 					.wrapper {
 						.text {
 							color: var(--text-label-color);

--- a/meteor/client/ui/FloatingInspectors/FloatingInspectorHelpers/FloatingInspectorTimeInformationRow.tsx
+++ b/meteor/client/ui/FloatingInspectors/FloatingInspectorHelpers/FloatingInspectorTimeInformationRow.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { PieceInstancePiece } from '../../../../lib/collections/PieceInstances'
+import { RundownUtils } from '../../../lib/rundown'
+import { IBlueprintPiece, IBlueprintPieceGeneric, PieceLifespan } from '@sofie-automation/blueprints-integration'
+import * as _ from 'underscore'
+import { useTranslation } from 'react-i18next'
+import { Time } from '../../../../lib/lib'
+import Moment from 'react-moment'
+
+interface IProps {
+	piece: PieceInstancePiece
+	pieceRenderedDuration: number | null
+	pieceRenderedIn: number | null
+	changed?: Time
+}
+
+export const FloatingInspectorTimeInformationRow: React.FunctionComponent<IProps> = (props: IProps) => {
+	const durationText: string =
+		!props.pieceRenderedDuration && !props.piece.enable.duration
+			? getLifeSpanText(props.piece)
+			: getDuration(props.piece as IBlueprintPiece, props.pieceRenderedDuration)
+
+	return (
+		<tr>
+			<td className="mini-inspector__row--timing" />
+			<td className="mini-inspector__row--timing">
+				<span className="mini-inspector__in-point">
+					{RundownUtils.formatTimeToShortTime(props.pieceRenderedIn || 0)}
+				</span>
+				<span className="mini-inspector__duration">{durationText}</span>
+
+				{props.changed && (
+					<span className="mini-inspector__changed">
+						<Moment date={props.changed} calendar={true} />
+					</span>
+				)}
+			</td>
+		</tr>
+	)
+}
+
+function getLifeSpanText(piece: IBlueprintPieceGeneric): string {
+	const { t } = useTranslation()
+	switch (piece.lifespan) {
+		case PieceLifespan.WithinPart:
+			return t('Until next take')
+		case PieceLifespan.OutOnSegmentChange:
+			return t('Until next segment')
+		case PieceLifespan.OutOnSegmentEnd:
+			return t('Until end of segment')
+		case PieceLifespan.OutOnRundownChange:
+			return t('Until next rundown')
+		case PieceLifespan.OutOnRundownEnd:
+			return t('Until next rundown')
+		case PieceLifespan.OutOnShowStyleEnd:
+			return t('Until end of showstyle')
+		default:
+			return ''
+	}
+}
+
+function getDuration(piece: IBlueprintPiece, pieceRenderedDuration: number | null): string {
+	return RundownUtils.formatTimeToShortTime(
+		pieceRenderedDuration ||
+			(_.isNumber(piece.enable.duration) ? parseFloat(piece.enable.duration as any as string) : 0)
+	)
+}

--- a/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import * as _ from 'underscore'
-// import { useTranslation } from 'react-i18next'
 
-import { NoraContent, GraphicsContent } from '@sofie-automation/blueprints-integration'
+import { GraphicsContent, NoraContent } from '@sofie-automation/blueprints-integration'
 
 import { NoraFloatingInspector } from './NoraFloatingInspector'
 import { FloatingInspector } from '../FloatingInspector'
-// import { Time } from '../../../lib/lib'
+import { Time } from '../../../lib/lib'
 import { PieceInstancePiece } from '../../../lib/collections/PieceInstances'
+import { FloatingInspectorTimeInformationRow } from './FloatingInspectorHelpers/FloatingInspectorTimeInformationRow'
 
 interface IProps {
 	piece: PieceInstancePiece
@@ -29,14 +29,11 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 	showMiniInspector,
 	itemElement,
 	piece,
-	// pieceRenderedIn,
-	// pieceRenderedDuration,
+	pieceRenderedIn,
+	pieceRenderedDuration,
 	typeClass,
 	displayOn,
 }) => {
-	// const { t } = useTranslation()
-	// const innerPiece = piece
-
 	const noraContent = (content as NoraContent)?.payload?.content ? (content as NoraContent | undefined) : undefined
 
 	let properties: Array<KeyValue> = []
@@ -73,7 +70,7 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 		) as Array<KeyValue>
 	}
 
-	// const changed: Time | undefined = noraContent?.payload?.changed ?? undefined
+	const changed: Time | undefined = noraContent?.payload?.changed ?? undefined
 
 	const graphicContent = (content as GraphicsContent)?.fileName ? (content as GraphicsContent | undefined) : undefined
 
@@ -108,50 +105,12 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 								<td className="mini-inspector__value">{item.value}</td>
 							</tr>
 						))}
-						{/* Disable the timing information for now, since it's not being used.
-							To be eventually removed, if noone complains -- Jan Starzak, 2021/09/30
-							<tr>
-							<td className="mini-inspector__row--timing"></td>
-							<td className="mini-inspector__row--timing">
-								<span className="mini-inspector__in-point">
-									{RundownUtils.formatTimeToShortTime(pieceRenderedIn || 0)}
-								</span>
-								{!pieceRenderedDuration && !innerPiece.enable.duration ? (
-									(innerPiece.lifespan === PieceLifespan.WithinPart && (
-										<span className="mini-inspector__duration">{t('Until next take')}</span>
-									)) ||
-									(innerPiece.lifespan === PieceLifespan.OutOnSegmentChange && (
-										<span className="mini-inspector__duration">{t('Until next segment')}</span>
-									)) ||
-									(innerPiece.lifespan === PieceLifespan.OutOnSegmentEnd && (
-										<span className="mini-inspector__duration">{t('Until end of segment')}</span>
-									)) ||
-									(innerPiece.lifespan === PieceLifespan.OutOnRundownChange && (
-										<span className="mini-inspector__duration">{t('Until next rundown')}</span>
-									)) ||
-									(innerPiece.lifespan === PieceLifespan.OutOnRundownEnd && (
-										<span className="mini-inspector__duration">{t('Until end of rundown')}</span>
-									)) ||
-									(innerPiece.lifespan === PieceLifespan.OutOnShowStyleEnd && (
-										<span className="mini-inspector__duration">{t('Until end of showstyle')}</span>
-									))
-								) : (
-									<span className="mini-inspector__duration">
-										{RundownUtils.formatTimeToShortTime(
-											pieceRenderedDuration ||
-												(_.isNumber(innerPiece.enable.duration)
-													? parseFloat(innerPiece.enable.duration as any as string)
-													: 0)
-										)}
-									</span>
-								)}
-								{changed && (
-									<span className="mini-inspector__changed">
-										<Moment date={changed} calendar={true} />
-									</span>
-								)}
-							</td>
-						</tr> */}
+						<FloatingInspectorTimeInformationRow
+							piece={piece}
+							pieceRenderedDuration={pieceRenderedDuration}
+							pieceRenderedIn={pieceRenderedIn}
+							changed={changed}
+						/>
 					</tbody>
 				</table>
 			</div>

--- a/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
@@ -20,6 +20,7 @@ import { ensureHasTrailingSlash } from '../../lib/lib'
 import { RundownAPI } from '../../../lib/api/rundown'
 import { getPackageContainerPackageStatus } from '../../../lib/globalStores'
 import { PieceId } from '../../../lib/collections/Pieces'
+import PieceStatusCode = RundownAPI.PieceStatusCode
 
 interface IProps {
 	status: RundownAPI.PieceStatusCode
@@ -138,6 +139,10 @@ function renderNotice(noticeLevel: NoticeLevel, noticeMessage: string | null): J
 	)
 }
 
+function shouldShowContent(props: IProps): boolean {
+	return props.status !== PieceStatusCode.SOURCE_NOT_SET && !!props.content?.fileName
+}
+
 export const VTFloatingInspector: React.FunctionComponent<IProps> = (props: IProps) => {
 	const { t } = useTranslation()
 	const { timePosition } = props
@@ -212,7 +217,7 @@ export const VTFloatingInspector: React.FunctionComponent<IProps> = (props: IPro
 						</div>
 					) : null}
 				</div>
-			) : (
+			) : shouldShowContent(props) || !!props.noticeLevel ? (
 				<div
 					className={
 						'segment-timeline__mini-inspector ' +
@@ -226,15 +231,15 @@ export const VTFloatingInspector: React.FunctionComponent<IProps> = (props: IPro
 					}
 					style={props.floatingInspectorStyle}
 				>
-					{props.noticeLevel !== null ? renderNotice(props.noticeLevel, props.noticeMessage) : null}
-					{props.status !== RundownAPI.PieceStatusCode.SOURCE_NOT_SET ? (
+					{props.noticeLevel ? renderNotice(props.noticeLevel, props.noticeMessage) : null}
+					{shouldShowContent(props) ? (
 						<div className="segment-timeline__mini-inspector__properties">
 							<span className="mini-inspector__label">{t('Clip:')}</span>
 							<span className="mini-inspector__value">{props.content && props.content.fileName}</span>
 						</div>
 					) : null}
 				</div>
-			)}
+			) : null}
 		</FloatingInspector>
 	)
 }


### PR DESCRIPTION
Bugfix SOF-678
Graphics hoverscrub no longer shows an empty "Clip:" if there is no information to be displayed.
The sourceLayerType "lower-third" now has the same colour as the "graphic" sourceLayerType for Tv2 and the hoverscrub for "lower-third" now displays time information about the piece