### PR TITLE
fix: segment countdown was only calculated for the first part in a se…

### DIFF
--- a/meteor/lib/rundown/__tests__/rundownTiming.test.ts
+++ b/meteor/lib/rundown/__tests__/rundownTiming.test.ts
@@ -604,9 +604,9 @@ describe('rundown Timing Calculator', () => {
 				},
 				partCountdown: {
 					part1: 0,
-					part2: 1000,
-					part3: 5000,
-					part4: 6000,
+					part2: 5000,
+					part3: 10000,
+					part4: 13000,
 				},
 				partDisplayDurations: {
 					part1: 1000,
@@ -645,7 +645,9 @@ describe('rundown Timing Calculator', () => {
 					part4: 3000,
 				},
 				remainingPlaylistDuration: 8000,
+				remainingTimeOnCurrentPart: undefined,
 				totalPlaylistDuration: 8000,
+				rundownsBeforeNextBreak: undefined,
 				segmentBudgetDurations: {
 					segment1: 5000,
 					segment2: 3000,

--- a/meteor/lib/rundown/__tests__/rundownTiming.test.ts
+++ b/meteor/lib/rundown/__tests__/rundownTiming.test.ts
@@ -604,9 +604,9 @@ describe('rundown Timing Calculator', () => {
 				},
 				partCountdown: {
 					part1: 0,
-					part2: 5000,
-					part3: 10000,
-					part4: 13000,
+					part2: 1000,
+					part3: 5000,
+					part4: 6000,
 				},
 				partDisplayDurations: {
 					part1: 1000,
@@ -645,9 +645,7 @@ describe('rundown Timing Calculator', () => {
 					part4: 3000,
 				},
 				remainingPlaylistDuration: 8000,
-				remainingTimeOnCurrentPart: undefined,
 				totalPlaylistDuration: 8000,
-				rundownsBeforeNextBreak: undefined,
 				segmentBudgetDurations: {
 					segment1: 5000,
 					segment2: 3000,

--- a/meteor/lib/rundown/rundownTiming.ts
+++ b/meteor/lib/rundown/rundownTiming.ts
@@ -181,12 +181,12 @@ export class RundownTimingCalculator {
 				if (partInstance.segmentId !== lastSegmentId) {
 					this.untimedSegments.add(partInstance.segmentId)
 					lastSegmentId = partInstance.segmentId
-					segmentDisplayDuration = 0
-					if (segmentBudgetDurationLeft > 0) {
-						waitAccumulator += segmentBudgetDurationLeft
-					}
-					segmentBudgetDurationLeft = this.segmentBudgetDurations[unprotectString(partInstance.segmentId)]
 				}
+				segmentDisplayDuration = 0
+				if (segmentBudgetDurationLeft > 0) {
+					waitAccumulator += segmentBudgetDurationLeft
+				}
+				segmentBudgetDurationLeft = this.segmentBudgetDurations[unprotectString(partInstance.segmentId)]
 
 				// add piece to accumulator
 				const aIndex = this.linearParts.push([partInstance.part._id, waitAccumulator]) - 1

--- a/meteor/lib/rundown/rundownTiming.ts
+++ b/meteor/lib/rundown/rundownTiming.ts
@@ -122,7 +122,6 @@ export class RundownTimingCalculator {
 		let currentRemaining = 0
 		let startsAtAccumulator = 0
 		let displayStartsAtAccumulator = 0
-		let segmentDisplayDuration = 0
 		let segmentBudgetDurationLeft = 0
 
 		const rundownExpectedDurations: Record<string, number> = {}
@@ -182,7 +181,6 @@ export class RundownTimingCalculator {
 					this.untimedSegments.add(partInstance.segmentId)
 					lastSegmentId = partInstance.segmentId
 				}
-				segmentDisplayDuration = 0
 				if (segmentBudgetDurationLeft > 0) {
 					waitAccumulator += segmentBudgetDurationLeft
 				}
@@ -303,7 +301,6 @@ export class RundownTimingCalculator {
 						currentRemaining = Math.max(
 							0,
 							this.segmentBudgetDurations[unprotectString(partInstance.segmentId)] -
-								segmentDisplayDuration -
 								(now - lastStartedPlayback)
 						)
 						segmentBudgetDurationLeft = 0


### PR DESCRIPTION
Segment countdown was only calculated for the first part in the previous segments.
The duration of the 2nd, 3rd, 4th, etc. parts in a segment were not used when adding up the countdown