### PR TITLE
Feat/sof 774/qbox mini rundown view

### DIFF
--- a/meteor/client/styles/shelf/miniRundownPanel.scss
+++ b/meteor/client/styles/shelf/miniRundownPanel.scss
@@ -19,18 +19,6 @@
 	padding: 2px;
   }
 
-  .mini-rundown-panel__part {
-	padding: 2px;
-	&:before {
-	  content: ' (';
-	  display: inline;
-	}
-	&:after {
-	  content: ')';
-	  display: inline;
-	}
-  }
-
   .mini-rundown-panel__rank {
 	margin-right: 2px;
 	padding: 2px;

--- a/meteor/client/styles/shelf/miniRundownPanel.scss
+++ b/meteor/client/styles/shelf/miniRundownPanel.scss
@@ -1,0 +1,38 @@
+@import '../colorScheme';
+
+.mini-rundown-panel {
+  position: absolute;
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0.625rem;
+
+  .mini-rundown-panel__segment {
+	font-weight: 500;
+  }
+
+  .mini-rundown-panel__part {
+	&:before {
+	  content: ' (';
+	  display: inline;
+	}
+	&:after {
+	  content: ')';
+	  display: inline;
+	}
+  }
+
+  .mini-rundown-panel__rank {
+	margin-right: 2px;
+  }
+
+  .current-part {
+	background-color: red;
+  }
+
+  .next-part {
+	background-color: green;
+  }
+}
+

--- a/meteor/client/styles/shelf/miniRundownPanel.scss
+++ b/meteor/client/styles/shelf/miniRundownPanel.scss
@@ -28,11 +28,11 @@
   }
 
   .current-part {
-	background-color: red;
+	background-color: var(--general-live-color);
   }
 
   .next-part {
-	background-color: green;
+	background-color: var(--general-next-color);
   }
 }
 

--- a/meteor/client/styles/shelf/miniRundownPanel.scss
+++ b/meteor/client/styles/shelf/miniRundownPanel.scss
@@ -36,11 +36,11 @@
 	padding: 2px;
   }
 
-  .current-part {
+  .current-segment {
 	background-color: var(--general-live-color);
   }
 
-  .next-part {
+  .next-segment {
 	background-color: var(--general-next-color);
   }
 }

--- a/meteor/client/styles/shelf/miniRundownPanel.scss
+++ b/meteor/client/styles/shelf/miniRundownPanel.scss
@@ -4,9 +4,10 @@
   position: absolute;
   user-select: none;
   white-space: nowrap;
-  overflow: hidden;
   text-overflow: ellipsis;
   margin: 0.625rem;
+  overflow-x: hidden;
+  overflow-y: auto;
 
   .mini-rundown-panel__segment {
 	font-weight: 500;

--- a/meteor/client/styles/shelf/miniRundownPanel.scss
+++ b/meteor/client/styles/shelf/miniRundownPanel.scss
@@ -1,35 +1,35 @@
 @import '../colorScheme';
 
 .mini-rundown-panel {
-  position: absolute;
-  user-select: none;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  margin: 0.625rem;
+	position: absolute;
+	user-select: none;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	margin: 0.625rem;
 
-  .mini-rundown-panel__container {
-	width: 100%;
-	height: 95%;
-	overflow-x: hidden;
-	overflow-y: auto;
-  }
+	.mini-rundown-panel__container {
+		width: 100%;
+		height: 95%;
+		overflow-x: hidden;
+		overflow-y: auto;
+	}
 
-  .mini-rundown-panel__segment {
-	font-weight: 500;
-	padding: 2px;
-  }
+	.mini-rundown-panel__segment {
+		font-weight: 500;
+		padding: 2px;
+	}
 
-  .mini-rundown-panel__rank {
-	margin-right: 2px;
-	padding: 2px;
-  }
+	.mini-rundown-panel__rank {
+		margin-right: 2px;
+		padding: 2px;
+	}
 
-  .current-segment {
-	background-color: var(--general-live-color);
-  }
+	.current-segment {
+		background-color: var(--general-live-color);
+	}
 
-  .next-segment {
-	background-color: var(--general-next-color);
-  }
+	.next-segment {
+		background-color: var(--general-next-color);
+	}
 }
 

--- a/meteor/client/styles/shelf/miniRundownPanel.scss
+++ b/meteor/client/styles/shelf/miniRundownPanel.scss
@@ -6,14 +6,21 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   margin: 0.625rem;
-  overflow-x: hidden;
-  overflow-y: auto;
+
+  .mini-rundown-panel__container {
+	width: 100%;
+	height: 95%;
+	overflow-x: hidden;
+	overflow-y: auto;
+  }
 
   .mini-rundown-panel__segment {
 	font-weight: 500;
+	padding: 2px;
   }
 
   .mini-rundown-panel__part {
+	padding: 2px;
 	&:before {
 	  content: ' (';
 	  display: inline;
@@ -26,6 +33,7 @@
 
   .mini-rundown-panel__rank {
 	margin-right: 2px;
+	padding: 2px;
   }
 
   .current-part {

--- a/meteor/client/ui/Settings/components/FilterEditor.tsx
+++ b/meteor/client/ui/Settings/components/FilterEditor.tsx
@@ -34,7 +34,8 @@ import {
 	RundownLayoutTextLabel,
 	RundownLayoutTimeOfDay,
 	DashboardPanelUnit,
-	DashboardPanelBase, RundownLayoutMiniRundown,
+	DashboardPanelBase,
+	RundownLayoutMiniRundown,
 } from '../../../../lib/collections/RundownLayouts'
 import { EditAttribute } from '../../../lib/EditAttribute'
 import { Translated } from '../../../lib/ReactMeteorData/react-meteor-data'
@@ -1994,13 +1995,13 @@ export default withTranslation()(
 								isDashboardLayout
 						  )
 						: RundownLayoutsAPI.isMiniRundown(this.props.filter)
-							? this.renderMiniRundown(
+						? this.renderMiniRundown(
 								this.props.item,
 								this.props.filter,
 								this.props.index,
 								isRundownLayout,
 								isDashboardLayout
-							)
+						  )
 						: undefined}
 				</div>
 			)

--- a/meteor/client/ui/Settings/components/FilterEditor.tsx
+++ b/meteor/client/ui/Settings/components/FilterEditor.tsx
@@ -34,7 +34,7 @@ import {
 	RundownLayoutTextLabel,
 	RundownLayoutTimeOfDay,
 	DashboardPanelUnit,
-	DashboardPanelBase,
+	DashboardPanelBase, RundownLayoutMiniRundown,
 } from '../../../../lib/collections/RundownLayouts'
 import { EditAttribute } from '../../../lib/EditAttribute'
 import { Translated } from '../../../lib/ReactMeteorData/react-meteor-data'
@@ -1751,6 +1751,47 @@ export default withTranslation()(
 			)
 		}
 
+		renderMiniRundown(
+			item: RundownLayoutBase,
+			tab: RundownLayoutMiniRundown,
+			index: number,
+			isRundownLayout: boolean,
+			isDashboardLayout: boolean
+		) {
+			const { t } = this.props
+			return (
+				<React.Fragment>
+					<div className="mod mvs mhs">
+						<label className="field">
+							{t('Name')}
+							<EditAttribute
+								modifiedClassName="bghl"
+								attribute={`filters.${index}.name`}
+								obj={item}
+								type="text"
+								collection={RundownLayouts}
+								className="input text-input input-l"
+							/>
+						</label>
+					</div>
+					<div className="mod mvs mhs">
+						<label className="field">
+							{t('Hide for dynamically inserted parts')}
+							<EditAttribute
+								modifiedClassName="bghl"
+								attribute={`filters.${index}.hideForDynamicallyInsertedParts`}
+								obj={item}
+								type="checkbox"
+								collection={RundownLayouts}
+								className="mod mas"
+							/>
+						</label>
+					</div>
+					{isDashboardLayout && this.renderDashboardLayoutSettings(item, index)}
+				</React.Fragment>
+			)
+		}
+
 		render() {
 			const { t } = this.props
 
@@ -1952,6 +1993,14 @@ export default withTranslation()(
 								isRundownLayout,
 								isDashboardLayout
 						  )
+						: RundownLayoutsAPI.isMiniRundown(this.props.filter)
+							? this.renderMiniRundown(
+								this.props.item,
+								this.props.filter,
+								this.props.index,
+								isRundownLayout,
+								isDashboardLayout
+							)
 						: undefined}
 				</div>
 			)

--- a/meteor/client/ui/Settings/components/FilterEditor.tsx
+++ b/meteor/client/ui/Settings/components/FilterEditor.tsx
@@ -1775,19 +1775,6 @@ export default withTranslation()(
 							/>
 						</label>
 					</div>
-					<div className="mod mvs mhs">
-						<label className="field">
-							{t('Hide for dynamically inserted parts')}
-							<EditAttribute
-								modifiedClassName="bghl"
-								attribute={`filters.${index}.hideForDynamicallyInsertedParts`}
-								obj={item}
-								type="checkbox"
-								collection={RundownLayouts}
-								className="mod mas"
-							/>
-						</label>
-					</div>
 					{isDashboardLayout && this.renderDashboardLayoutSettings(item, index)}
 				</React.Fragment>
 			)

--- a/meteor/client/ui/Shelf/MiniRundownPanel.tsx
+++ b/meteor/client/ui/Shelf/MiniRundownPanel.tsx
@@ -56,15 +56,12 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 	render() {
 		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
 		const style = getElementStyle(this.props, isDashboardLayout)
-		const showAny = isShowAnyValues(this.props)
 
 		const current = getMiniRundownPart(
-			this.props,
-			showAny,
 			this.props.currentSegment,
 			this.props.currentPartInstance?.part
 		)
-		const next = getMiniRundownPart(this.props, showAny, this.props.nextSegment, this.props.nextPartInstance?.part)
+		const next = getMiniRundownPart(this.props.nextSegment, this.props.nextPartInstance?.part)
 
 		const allParts: Part[] = this.props.playlist.getAllOrderedParts()
 		const allSegments: Segment[] = this.props.playlist.getSegments()
@@ -72,13 +69,12 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 		const secondSegmentAndPart = getNextSegmentAndPart(
 			allParts,
 			allSegments,
-			showAny,
 			this.props.nextPartInstance?.part
 		)
-		const second = getMiniRundownPart(this.props, showAny, secondSegmentAndPart.segment, secondSegmentAndPart.part)
+		const second = getMiniRundownPart(secondSegmentAndPart.segment, secondSegmentAndPart.part)
 
-		const thirdSegmentAndPart = getNextSegmentAndPart(allParts, allSegments, showAny, secondSegmentAndPart.part)
-		const third = getMiniRundownPart(this.props, showAny, thirdSegmentAndPart.segment, thirdSegmentAndPart.part)
+		const thirdSegmentAndPart = getNextSegmentAndPart(allParts, allSegments, secondSegmentAndPart.part)
+		const third = getMiniRundownPart(thirdSegmentAndPart.segment, thirdSegmentAndPart.part)
 
 		return (
 			<div
@@ -86,7 +82,7 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 				style={getContainerStyle(this.props, isDashboardLayout)}
 			>
 				<span className="mini-rundown-panel__name" style={style}>
-					{showAny && this.props.panel.name}{' '}
+					{this.props.panel.name}{' '}
 				</span>
 				<div className="current-part">
 					<span className="mini-rundown-panel__rank">{current.identifier}</span>
@@ -178,14 +174,13 @@ function getElementStyle(props, isDashboardLayout: boolean) {
 	}
 }
 
-function isShowAnyValues(props): boolean {
-	return !props.panel.hideForDynamicallyInsertedParts || props.nextPartInstance?.orphaned !== 'adlib-part'
+function isShowAnyValues(props, partInstance: PartInstance): boolean {
+	return !props.panel.hideForDynamicallyInsertedParts || partInstance?.orphaned !== 'adlib-part'
 }
 
 function getNextSegmentAndPart(
 	allParts: Part[],
 	allSegments: Segment[],
-	showAny: boolean,
 	previousPart?: Part
 ): NextSegmentAndPart {
 	let getNext: boolean = false
@@ -216,26 +211,24 @@ function getNextSegmentAndPart(
 }
 
 function getMiniRundownPart(
-	props,
-	showAny: boolean,
 	segment: Segment | undefined,
 	part: Part | undefined
 ): MiniRundownPart {
 	return {
-		identifier: getSegmentIdentifier(showAny, segment),
-		segmentName: getSegmentName(props, showAny, segment),
-		partName: getPartTitle(props, showAny, part),
+		identifier: getSegmentIdentifier(segment),
+		segmentName: getSegmentName(segment),
+		partName: getPartTitle(part),
 	}
 }
 
-function getSegmentName(props, showAny: boolean, segment: Segment | undefined): string {
-	return showAny && segment?.name
+function getSegmentName(segment: Segment | undefined): string {
+	return segment?.name !== undefined ? segment?.name : ''
 }
 
-function getPartTitle(props, showAny: boolean, part: Part | undefined): string {
-	return showAny && part?.title !== undefined ? part?.title : ''
+function getPartTitle(part: Part | undefined): string {
+	return part?.title !== undefined ? part?.title : ''
 }
 
-function getSegmentIdentifier(showAny: boolean, segment: Segment | undefined): any {
-	return showAny && segment?.identifier
+function getSegmentIdentifier(segment: Segment | undefined): any {
+	return segment?.identifier !== undefined ? segment?.identifier : ''
 }

--- a/meteor/client/ui/Shelf/MiniRundownPanel.tsx
+++ b/meteor/client/ui/Shelf/MiniRundownPanel.tsx
@@ -12,7 +12,7 @@ import { withTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { PartInstance, PartInstanceId, PartInstances } from '../../../lib/collections/PartInstances'
-import { Segment, Segments } from '../../../lib/collections/Segments'
+import { Segment } from '../../../lib/collections/Segments'
 import { dashboardElementPosition } from './DashboardPanel'
 import { Meteor } from 'meteor/meteor'
 
@@ -25,17 +25,15 @@ interface IMiniRundownPanelProps {
 }
 
 interface IMiniRundownPanelTrackedProps {
-	currentSegment?: Segment
 	currentPartInstance?: PartInstance
 	nextPartInstance?: PartInstance
-	nextSegment?: Segment
 	allSegments?: Segment[]
 }
 
 interface IState {}
 
-interface MiniRundownPart {
-	identifier: any
+interface MiniRundownSegment {
+	identifier: string
 	segmentName: string
 	cssClass: string
 }
@@ -69,7 +67,7 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
 		const style = getElementStyle(this.props, isDashboardLayout)
 
-		const miniRundowns: MiniRundownPart[] = getMiniRundownList(
+		const miniRundowns: MiniRundownSegment[] = getMiniRundownList(
 			this.props.allSegments,
 			this.props.currentPartInstance,
 			this.props.nextPartInstance
@@ -86,7 +84,7 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 				</span>
 
 				<div className={MiniRundownPanelInner.panelContainerId} id={MiniRundownPanelInner.panelContainerId}>
-					{miniRundowns.map((miniRundown: MiniRundownPart, index: number) => (
+					{miniRundowns.map((miniRundown: MiniRundownSegment, index: number) => (
 						<div
 							className={miniRundown.cssClass}
 							{...getCurrentPartId(miniRundown.cssClass)}
@@ -116,30 +114,20 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 export const MiniRundownPanel = withTracker<IMiniRundownPanelProps, IState, IMiniRundownPanelTrackedProps>(
 	(props: IMiniRundownPanelProps & IMiniRundownPanelTrackedProps) => {
 		let currentPartInstance: PartInstance | undefined = undefined
-		let currentSegment: Segment | undefined = undefined
 		let nextPartInstance: PartInstance | undefined = undefined
-		let nextSegment: Segment | undefined = undefined
 
 		const currentPartInstanceId: PartInstanceId | null = props.playlist.currentPartInstanceId
 		if (currentPartInstanceId) {
 			currentPartInstance = PartInstances.findOne(currentPartInstanceId)
 		}
 
-		if (currentPartInstance) {
-			currentSegment = Segments.findOne(currentPartInstance.segmentId)
-		}
-
 		if (props.playlist.nextPartInstanceId) {
 			nextPartInstance = PartInstances.findOne(props.playlist.nextPartInstanceId)
 		}
 
-		if (nextPartInstance) {
-			nextSegment = Segments.findOne(nextPartInstance.segmentId)
-		}
-
 		const allSegments: Segment[] = props.playlist.getSegments()
 
-		return { currentSegment, currentPartInstance, nextPartInstance, nextSegment, allSegments }
+		return { currentPartInstance, nextPartInstance, allSegments }
 	},
 	(_data, props: IMiniRundownPanelProps, nextProps: IMiniRundownPanelProps) => {
 		return !_.isEqual(props, nextProps)
@@ -150,8 +138,8 @@ function getMiniRundownList(
 	allSegments?: Segment[],
 	currentPart?: PartInstance,
 	nextPart?: PartInstance
-): MiniRundownPart[] {
-	const miniRundownParts: MiniRundownPart[] = []
+): MiniRundownSegment[] {
+	const miniRundownParts: MiniRundownSegment[] = []
 
 	allSegments?.forEach((segment: Segment) => {
 		miniRundownParts.push({
@@ -160,7 +148,6 @@ function getMiniRundownList(
 			cssClass: getSegmentCssClass(segment, currentPart, nextPart),
 		})
 	})
-
 
 	return miniRundownParts
 }
@@ -197,7 +184,7 @@ function getSegmentName(segment: Segment | undefined): string {
 	return segment?.name !== undefined ? segment?.name : ''
 }
 
-function getSegmentIdentifier(segment: Segment | undefined): any {
+function getSegmentIdentifier(segment: Segment | undefined): string {
 	return segment?.identifier !== undefined ? segment?.identifier : ''
 }
 

--- a/meteor/client/ui/Shelf/MiniRundownPanel.tsx
+++ b/meteor/client/ui/Shelf/MiniRundownPanel.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react'
+import * as _ from 'underscore'
+import ClassNames from 'classnames'
+import {
+	RundownLayoutBase,
+	DashboardLayoutNextInfo,
+	RundownLayoutNextInfo,
+} from '../../../lib/collections/RundownLayouts'
+import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
+import { dashboardElementPosition } from './DashboardPanel'
+import { withTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
+import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
+import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import {PartInstance, PartInstanceId, PartInstances} from '../../../lib/collections/PartInstances'
+import { Segment, Segments } from '../../../lib/collections/Segments'
+interface IMiniRundownPanelProps {
+	visible?: boolean
+	layout: RundownLayoutBase
+	panel: RundownLayoutNextInfo
+	playlist: RundownPlaylist
+}
+
+interface IMiniRundownPanelTrackedProps {
+	currentSegment?: Segment
+	currentPartInstance?: PartInstance
+	nextPartInstance?: PartInstance
+	nextSegment?: Segment
+}
+
+interface IState {}
+
+export class MiniRundownPanelInner extends MeteorReactComponent<IMiniRundownPanelProps & IMiniRundownPanelTrackedProps, IState> {
+	constructor(props) {
+		super(props)
+		this.state = {}
+	}
+
+	render() {
+		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
+		const showAny = isShowAny()
+		const currentSegmentRank: any = getSegmentRank(showAny, this.props.currentSegment)
+		const currentSegmentName: string = getNextSegmentName(showAny, this.props.currentSegment)
+		const currentPartTitle = getNextPartTitle(showAny, this.props.currentPartInstance)
+		const nextSegmentRank: any = getSegmentRank(showAny, this.props.nextSegment)
+		const nextSegmentName: string = getNextSegmentName(showAny, this.props.nextSegment)
+		const nextPartTitle: string = getNextPartTitle(showAny, this.props.nextPartInstance)
+		const style = getElementStyle(isDashboardLayout)
+
+		return (
+			<div className={ClassNames('next-info-panel', getContainerClass(isDashboardLayout))}>
+				<div className="current-part">
+					<span className="mini-rundown-panel__rank">
+						{currentSegmentRank}
+					</span>
+					<span className="mini-rundown-panel__segment" style={style}>
+						{currentSegmentName}
+					</span>
+					<span className="mini-rundown-panel__part" style={style}>
+						{currentPartTitle}
+					</span>
+				</div>
+
+				<div  className="next-part">
+					<span className="mini-rundown-panel__rank">
+						{nextSegmentRank}
+					</span>
+					<span className="mini-rundown-panel__segment" style={style}>
+						{nextSegmentName}
+					</span>
+					<span className="mini-rundown-panel__part" style={style}>
+						{nextPartTitle}
+					</span>
+				</div>
+			</div>
+		)
+	}
+}
+
+export const MiniRundownPanel = withTracker<IMiniRundownPanelProps, IState, IMiniRundownPanelTrackedProps>(
+	(props: IMiniRundownPanelProps & IMiniRundownPanelTrackedProps) => {
+		let currentPartInstance: PartInstance | undefined = undefined
+		let currentSegment: Segment | undefined = undefined
+		let nextPartInstance: PartInstance | undefined = undefined
+		let nextSegment: Segment | undefined = undefined
+
+		const currentPartInstanceId: PartInstanceId | null = props.playlist.currentPartInstanceId
+		if (currentPartInstanceId) {
+			currentPartInstance = PartInstances.findOne(currentPartInstanceId)
+		}
+
+		if (currentPartInstance) {
+			currentSegment = Segments.findOne(currentPartInstance.segmentId)
+		}
+
+		if (props.playlist.nextPartInstanceId) {
+			nextPartInstance = PartInstances.findOne(props.playlist.nextPartInstanceId)
+		}
+
+		if (nextPartInstance) {
+			nextSegment = Segments.findOne(nextPartInstance.segmentId)
+		}
+		return { currentSegment, currentPartInstance, nextPartInstance, nextSegment }
+	},
+	(_data, props: IMiniRundownPanelProps, nextProps: IMiniRundownPanelProps) => {
+		return !_.isEqual(props, nextProps)
+	}
+)(MiniRundownPanelInner)
+
+function getContainerClass(isDashboardLayout: boolean): string[] | undefined {
+	return isDashboardLayout ? (this.props.panel as DashboardLayoutNextInfo).customClasses : undefined
+}
+
+function getElementStyle(isDashboardLayout: boolean) {
+	return {
+		fontSize: isDashboardLayout ? ((this.props.panel as DashboardLayoutNextInfo).scale || 1) * 1.5 + 'em' : undefined,
+	}
+}
+
+function isShowAny(): boolean {
+	return !this.props.panel.hideForDynamicallyInsertedParts || this.props.nextPartInstance?.orphaned !== 'adlib-part'
+}
+
+function getNextSegmentName(showAny: boolean, segment: Segment | undefined): string {
+	return showAny && this.props.panel.showSegmentName && segment?.name
+}
+
+function getNextPartTitle(showAny: boolean, partInstance: PartInstance | undefined): string {
+	return showAny && this.props.panel.showPartTitle && partInstance?.part.title
+}
+
+function getSegmentRank(showAny: boolean, segment: Segment | undefined): any {
+	return showAny && segment?._rank
+}
+

--- a/meteor/client/ui/Shelf/MiniRundownPanel.tsx
+++ b/meteor/client/ui/Shelf/MiniRundownPanel.tsx
@@ -48,12 +48,9 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 	IMiniRundownPanelProps & IMiniRundownPanelTrackedProps,
 	IState
 > {
-	private readonly currentPartReference: React.RefObject<HTMLDivElement>
-
 	constructor(props) {
 		super(props)
 		this.state = {}
-		this.currentPartReference = React.createRef()
 	}
 
 	componentDidUpdate() {

--- a/meteor/client/ui/Shelf/MiniRundownPanel.tsx
+++ b/meteor/client/ui/Shelf/MiniRundownPanel.tsx
@@ -4,19 +4,20 @@ import ClassNames from 'classnames'
 import {
 	RundownLayoutBase,
 	DashboardLayoutMiniRundown,
-	RundownLayoutMiniRundown, DashboardLayoutNextInfo,
+	RundownLayoutMiniRundown,
+	DashboardLayoutNextInfo,
 } from '../../../lib/collections/RundownLayouts'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { withTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
-import {PartInstance, PartInstanceId, PartInstances} from '../../../lib/collections/PartInstances'
+import { PartInstance, PartInstanceId, PartInstances } from '../../../lib/collections/PartInstances'
 import { Segment, Segments } from '../../../lib/collections/Segments'
-import {dashboardElementPosition} from './DashboardPanel';
-import {Part} from '../../../lib/collections/Parts';
-import {unprotectString} from '../../../lib/lib';
+import { dashboardElementPosition } from './DashboardPanel'
+import { Part } from '../../../lib/collections/Parts'
+import { unprotectString } from '../../../lib/lib'
 interface IMiniRundownPanelProps {
-	key: string,
+	key: string
 	visible?: boolean
 	layout: RundownLayoutBase
 	panel: RundownLayoutMiniRundown
@@ -33,17 +34,20 @@ interface IMiniRundownPanelTrackedProps {
 interface IState {}
 
 interface MiniRundownPart {
-	identifier: any,
-	segmentName: string,
+	identifier: any
+	segmentName: string
 	partName: string
 }
 
 interface NextSegmentAndPart {
-	segment: Segment | undefined,
-	part: Part | undefined,
+	segment: Segment | undefined
+	part: Part | undefined
 }
 
-export class MiniRundownPanelInner extends MeteorReactComponent<IMiniRundownPanelProps & IMiniRundownPanelTrackedProps, IState> {
+export class MiniRundownPanelInner extends MeteorReactComponent<
+	IMiniRundownPanelProps & IMiniRundownPanelTrackedProps,
+	IState
+> {
 	constructor(props) {
 		super(props)
 		this.state = {}
@@ -54,29 +58,38 @@ export class MiniRundownPanelInner extends MeteorReactComponent<IMiniRundownPane
 		const style = getElementStyle(this.props, isDashboardLayout)
 		const showAny = isShowAnyValues(this.props)
 
-		const current = getMiniRundownPart(this.props, showAny, this.props.currentSegment, this.props.currentPartInstance?.part)
+		const current = getMiniRundownPart(
+			this.props,
+			showAny,
+			this.props.currentSegment,
+			this.props.currentPartInstance?.part
+		)
 		const next = getMiniRundownPart(this.props, showAny, this.props.nextSegment, this.props.nextPartInstance?.part)
 
 		const allParts: Part[] = this.props.playlist.getAllOrderedParts()
 		const allSegments: Segment[] = this.props.playlist.getSegments()
 
-		const secondSegmentAndPart = getNextSegmentAndPart(allParts, allSegments, showAny, this.props.nextPartInstance?.part)
+		const secondSegmentAndPart = getNextSegmentAndPart(
+			allParts,
+			allSegments,
+			showAny,
+			this.props.nextPartInstance?.part
+		)
 		const second = getMiniRundownPart(this.props, showAny, secondSegmentAndPart.segment, secondSegmentAndPart.part)
 
 		const thirdSegmentAndPart = getNextSegmentAndPart(allParts, allSegments, showAny, secondSegmentAndPart.part)
 		const third = getMiniRundownPart(this.props, showAny, thirdSegmentAndPart.segment, thirdSegmentAndPart.part)
 
-
 		return (
-			<div className={ClassNames('dashboard-panel mini-rundown-panel', getContainerClass(this.props, isDashboardLayout))}
-				 style={getContainerStyle(this.props, isDashboardLayout)}>
+			<div
+				className={ClassNames('dashboard-panel mini-rundown-panel', getContainerClass(this.props, isDashboardLayout))}
+				style={getContainerStyle(this.props, isDashboardLayout)}
+			>
 				<span className="mini-rundown-panel__name" style={style}>
 					{showAny && this.props.panel.name}{' '}
 				</span>
 				<div className="current-part">
-					<span className="mini-rundown-panel__rank">
-						{current.identifier}
-					</span>
+					<span className="mini-rundown-panel__rank">{current.identifier}</span>
 					<span className="mini-rundown-panel__segment" style={style}>
 						{current.segmentName}
 					</span>
@@ -86,9 +99,7 @@ export class MiniRundownPanelInner extends MeteorReactComponent<IMiniRundownPane
 				</div>
 
 				<div className="next-part">
-					<span className="mini-rundown-panel__rank">
-						{next.identifier}
-					</span>
+					<span className="mini-rundown-panel__rank">{next.identifier}</span>
 					<span className="mini-rundown-panel__segment" style={style}>
 						{next.segmentName}
 					</span>
@@ -98,9 +109,7 @@ export class MiniRundownPanelInner extends MeteorReactComponent<IMiniRundownPane
 				</div>
 
 				<div className="second-part">
-					<span className="mini-rundown-panel__rank">
-						{second.identifier}
-					</span>
+					<span className="mini-rundown-panel__rank">{second.identifier}</span>
 					<span className="mini-rundown-panel__segment" style={style}>
 						{second.segmentName}
 					</span>
@@ -110,9 +119,7 @@ export class MiniRundownPanelInner extends MeteorReactComponent<IMiniRundownPane
 				</div>
 
 				<div className="third-part">
-					<span className="mini-rundown-panel__rank">
-						{third.identifier}
-					</span>
+					<span className="mini-rundown-panel__rank">{third.identifier}</span>
 					<span className="mini-rundown-panel__segment" style={style}>
 						{third.segmentName}
 					</span>
@@ -160,14 +167,9 @@ function getContainerClass(props, isDashboardLayout: boolean): string[] | undefi
 }
 
 function getContainerStyle(props, isDashboardLayout: boolean): any {
-	return _.extend(
-		isDashboardLayout
-			? dashboardElementPosition({ ...(props.panel as DashboardLayoutNextInfo) })
-			: {},
-		{
-			visibility: props.visible ? 'visible' : 'hidden',
-		}
-	)
+	return _.extend(isDashboardLayout ? dashboardElementPosition({ ...(props.panel as DashboardLayoutNextInfo) }) : {}, {
+		visibility: props.visible ? 'visible' : 'hidden',
+	})
 }
 
 function getElementStyle(props, isDashboardLayout: boolean) {
@@ -180,7 +182,12 @@ function isShowAnyValues(props): boolean {
 	return !props.panel.hideForDynamicallyInsertedParts || props.nextPartInstance?.orphaned !== 'adlib-part'
 }
 
-function getNextSegmentAndPart(allParts: Part[], allSegments: Segment[], showAny: boolean, previousPart?: Part): NextSegmentAndPart {
+function getNextSegmentAndPart(
+	allParts: Part[],
+	allSegments: Segment[],
+	showAny: boolean,
+	previousPart?: Part
+): NextSegmentAndPart {
 	let getNext: boolean = false
 	let nextPart: Part | undefined = undefined
 	allParts.every((part: Part) => {
@@ -205,15 +212,20 @@ function getNextSegmentAndPart(allParts: Part[], allSegments: Segment[], showAny
 		return true
 	})
 
-
-	return { segment: nextSegment,
-		 	 part: nextPart }
+	return { segment: nextSegment, part: nextPart }
 }
 
-function getMiniRundownPart(props, showAny: boolean, segment: Segment | undefined, part: Part | undefined): MiniRundownPart {
-	return { identifier: getSegmentIdentifier(showAny, segment),
-			 segmentName: getSegmentName(props, showAny, segment),
-			 partName: getPartTitle(props, showAny, part) }
+function getMiniRundownPart(
+	props,
+	showAny: boolean,
+	segment: Segment | undefined,
+	part: Part | undefined
+): MiniRundownPart {
+	return {
+		identifier: getSegmentIdentifier(showAny, segment),
+		segmentName: getSegmentName(props, showAny, segment),
+		partName: getPartTitle(props, showAny, part),
+	}
 }
 
 function getSegmentName(props, showAny: boolean, segment: Segment | undefined): string {
@@ -227,4 +239,3 @@ function getPartTitle(props, showAny: boolean, part: Part | undefined): string {
 function getSegmentIdentifier(showAny: boolean, segment: Segment | undefined): any {
 	return showAny && segment?.identifier
 }
-

--- a/meteor/client/ui/Shelf/MiniRundownPanel.tsx
+++ b/meteor/client/ui/Shelf/MiniRundownPanel.tsx
@@ -45,7 +45,7 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 	static currentSegmentCssClass: string = 'current-segment'
 	static nextSegmentCssClass: string = 'next-segment'
 	static panelContainerId: string = 'mini-rundown-panel__container'
-	static currentSegmentId: string = 'mini-rundown__current-segment'
+	static nextSegmentId: string = 'mini-rundown__next-segment'
 
 	constructor(props) {
 		super(props)
@@ -55,9 +55,9 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 	componentDidUpdate() {
 		Meteor.setTimeout(() => {
 			const container = document.getElementById(MiniRundownPanelInner.panelContainerId)
-			const element = document.getElementById(MiniRundownPanelInner.currentSegmentId)
+			const element = document.getElementById(MiniRundownPanelInner.nextSegmentId)
 			if (container && element) {
-				const magicLineHeight: number = 30
+				const magicLineHeight: number = 49
 				container.scrollTop = element.offsetTop - magicLineHeight
 			}
 		}, 500)
@@ -87,7 +87,7 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 					{miniRundowns.map((miniRundown: MiniRundownSegment, index: number) => (
 						<div
 							className={miniRundown.cssClass}
-							{...getCurrentPartId(miniRundown.cssClass)}
+							{...getIdAttributeForNextSegment(miniRundown.cssClass)}
 							key={getElementKey('miniRundownElement', miniRundown.identifier, index)}
 						>
 							<span
@@ -139,17 +139,17 @@ function getMiniRundownList(
 	currentPart?: PartInstance,
 	nextPart?: PartInstance
 ): MiniRundownSegment[] {
-	const miniRundownParts: MiniRundownSegment[] = []
+	const miniRundownSegments: MiniRundownSegment[] = []
 
 	allSegments?.forEach((segment: Segment) => {
-		miniRundownParts.push({
+		miniRundownSegments.push({
 			identifier: getSegmentIdentifier(segment),
 			segmentName: getSegmentName(segment),
 			cssClass: getSegmentCssClass(segment, currentPart, nextPart),
 		})
 	})
 
-	return miniRundownParts
+	return miniRundownSegments
 }
 
 function getSegmentCssClass(segment: Segment, currentPart?: PartInstance, nextPart?: PartInstance): string {
@@ -192,6 +192,6 @@ function getElementKey(prefix: string, identifier: string, index: number): strin
 	return prefix + identifier + 'index' + index
 }
 
-function getCurrentPartId(cssClass: string) {
-	return cssClass === MiniRundownPanelInner.currentSegmentCssClass ? { id: MiniRundownPanelInner.currentSegmentId } : {}
+function getIdAttributeForNextSegment(cssClass: string) {
+	return cssClass === MiniRundownPanelInner.nextSegmentCssClass ? { id: MiniRundownPanelInner.nextSegmentId } : {}
 }

--- a/meteor/client/ui/Shelf/MiniRundownPanel.tsx
+++ b/meteor/client/ui/Shelf/MiniRundownPanel.tsx
@@ -55,11 +55,11 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 
 	componentDidUpdate() {
 		Meteor.setTimeout(() => {
-			const el = document.getElementById(getCurrentPartIdName())
-			if (el) {
-				el.scrollIntoView({
-					behavior: 'smooth',
-				})
+			const container = document.getElementById('mini-rundown-panel__container')
+			const element = document.getElementById(getCurrentPartIdName())
+			if (container && element) {
+				const magicLineHeight: number = 30
+				container.scrollTop = element.offsetTop - magicLineHeight
 			}
 		}, 1000)
 	}
@@ -85,34 +85,36 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 					{this.props.panel.name}{' '}
 				</span>
 
-				{miniRundowns.map((miniRundown: MiniRundownPart, index: number) => (
-					<div
-						className={miniRundown.cssClass}
-						{...getCurrentPartId(miniRundown.cssClass)}
-						key={getElementKey('miniRundownElement', miniRundown.identifier, index)}
-					>
-						<span
-							className="mini-rundown-panel__rank"
-							key={getElementKey('miniRundownIdentifier', miniRundown.identifier, index)}
+				<div className="mini-rundown-panel__container" id={'mini-rundown-panel__container'}>
+					{miniRundowns.map((miniRundown: MiniRundownPart, index: number) => (
+						<div
+							className={miniRundown.cssClass}
+							{...getCurrentPartId(miniRundown.cssClass)}
+							key={getElementKey('miniRundownElement', miniRundown.identifier, index)}
 						>
-							{miniRundown.identifier}
-						</span>
-						<span
-							className="mini-rundown-panel__segment"
-							style={style}
-							key={getElementKey('miniRundownSegment', miniRundown.identifier, index)}
-						>
-							{miniRundown.segmentName}
-						</span>
-						<span
-							className="mini-rundown-panel__part"
-							style={style}
-							key={getElementKey('miniRundownPart', miniRundown.identifier, index)}
-						>
-							{miniRundown.partName}
-						</span>
-					</div>
-				))}
+							<span
+								className="mini-rundown-panel__rank"
+								key={getElementKey('miniRundownIdentifier', miniRundown.identifier, index)}
+							>
+								{miniRundown.identifier}
+							</span>
+							<span
+								className="mini-rundown-panel__segment"
+								style={style}
+								key={getElementKey('miniRundownSegment', miniRundown.identifier, index)}
+							>
+								{miniRundown.segmentName}
+							</span>
+							<span
+								className="mini-rundown-panel__part"
+								style={style}
+								key={getElementKey('miniRundownPart', miniRundown.identifier, index)}
+							>
+								{miniRundown.partName}
+							</span>
+						</div>
+					))}
+				</div>
 			</div>
 		)
 	}

--- a/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
@@ -31,6 +31,7 @@ import { SegmentNamePanel } from './SegmentNamePanel'
 import { PartNamePanel } from './PartNamePanel'
 import { ColoredBoxPanel } from './ColoredBoxPanel'
 import { AdLibPieceUi } from '../../lib/shelf'
+import {MiniRundownPanel} from './MiniRundownPanel';
 
 export interface IShelfDashboardLayoutProps {
 	rundownLayout: DashboardLayout
@@ -198,6 +199,14 @@ export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
 							/>
 						) : RundownLayoutsAPI.isNextInfo(panel) ? (
 							<NextInfoPanel
+								key={panel._id}
+								panel={panel}
+								layout={rundownLayout}
+								playlist={props.playlist}
+								visible={true}
+							/>
+						) : RundownLayoutsAPI.isMiniRundown(panel) ? (
+							<MiniRundownPanel
 								key={panel._id}
 								panel={panel}
 								layout={rundownLayout}

--- a/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
@@ -31,7 +31,7 @@ import { SegmentNamePanel } from './SegmentNamePanel'
 import { PartNamePanel } from './PartNamePanel'
 import { ColoredBoxPanel } from './ColoredBoxPanel'
 import { AdLibPieceUi } from '../../lib/shelf'
-import {MiniRundownPanel} from './MiniRundownPanel';
+import { MiniRundownPanel } from './MiniRundownPanel'
 
 export interface IShelfDashboardLayoutProps {
 	rundownLayout: DashboardLayout

--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -34,7 +34,8 @@ import {
 	RundownLayoutStudioName,
 	RundownLayoutSegmentName,
 	RundownLayoutPartName,
-	RundownLayoutColoredBox, RundownLayoutMiniRundown,
+	RundownLayoutColoredBox,
+	RundownLayoutMiniRundown,
 } from '../collections/RundownLayouts'
 import { ShowStyleBaseId } from '../collections/ShowStyleBases'
 import * as _ from 'underscore'

--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -320,6 +320,10 @@ export namespace RundownLayoutsAPI {
 		return element.type === RundownLayoutElementType.NEXT_INFO
 	}
 
+	export function isMiniRundown(element: RundownLayoutElementBase): element is RundownLayoutNextInfo {
+		return element.type === RundownLayoutElementType.MINI_RUNDOWN
+	}
+
 	export function isPlaylistStartTimer(
 		element: RundownLayoutElementBase
 	): element is RundownLayoutPlaylistStartTimer {

--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -34,7 +34,7 @@ import {
 	RundownLayoutStudioName,
 	RundownLayoutSegmentName,
 	RundownLayoutPartName,
-	RundownLayoutColoredBox,
+	RundownLayoutColoredBox, RundownLayoutMiniRundown,
 } from '../collections/RundownLayouts'
 import { ShowStyleBaseId } from '../collections/ShowStyleBases'
 import * as _ from 'underscore'
@@ -194,6 +194,7 @@ export namespace RundownLayoutsAPI {
 			RundownLayoutElementType.NEXT_INFO,
 			RundownLayoutElementType.TEXT_LABEL,
 			RundownLayoutElementType.KEYBOARD_PREVIEW,
+			RundownLayoutElementType.MINI_RUNDOWN,
 		],
 	})
 	registry.registerMiniShelfLayout(RundownLayoutType.DASHBOARD_LAYOUT, {
@@ -320,7 +321,7 @@ export namespace RundownLayoutsAPI {
 		return element.type === RundownLayoutElementType.NEXT_INFO
 	}
 
-	export function isMiniRundown(element: RundownLayoutElementBase): element is RundownLayoutNextInfo {
+	export function isMiniRundown(element: RundownLayoutElementBase): element is RundownLayoutMiniRundown {
 		return element.type === RundownLayoutElementType.MINI_RUNDOWN
 	}
 

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -66,6 +66,7 @@ export enum RundownLayoutElementType {
 	SEGMENT_NAME = 'segment_name',
 	PART_NAME = 'part_name',
 	COLORED_BOX = 'colored_box',
+	MINI_RUNDOWN = 'mini_rundown',
 }
 
 export interface RundownLayoutElementBase {

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -135,6 +135,11 @@ export interface RundownLayoutNextInfo extends RundownLayoutElementBase {
 	hideForDynamicallyInsertedParts: boolean
 }
 
+export interface RundownLayoutMiniRundown extends RundownLayoutElementBase {
+	type: RundownLayoutElementType.MINI_RUNDOWN
+	hideForDynamicallyInsertedParts: boolean
+}
+
 export interface RundownLayoutPlaylistStartTimer extends RundownLayoutElementBase {
 	type: RundownLayoutElementType.PLAYLIST_START_TIMER
 	plannedStartText: string
@@ -297,6 +302,7 @@ export type DashboardLayoutSegmentName = DashboardPanel<RundownLayoutSegmentName
 export type DashboardLayoutPartName = DashboardPanel<RundownLayoutPartName>
 export type DashboardLayoutColoredBox = DashboardPanel<RundownLayoutColoredBox>
 export type DashboardLayoutKeyboardPreview = DashboardPanel<RundownLayoutKeyboardPreview>
+export type DashboardLayoutMiniRundown = DashboardPanel<RundownLayoutMiniRundown>
 export type DashboardLayoutFilter = DashboardPanel<
 	RundownLayoutFilterBase & {
 		enableSearch: boolean

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -137,7 +137,6 @@ export interface RundownLayoutNextInfo extends RundownLayoutElementBase {
 
 export interface RundownLayoutMiniRundown extends RundownLayoutElementBase {
 	type: RundownLayoutElementType.MINI_RUNDOWN
-	hideForDynamicallyInsertedParts: boolean
 }
 
 export interface RundownLayoutPlaylistStartTimer extends RundownLayoutElementBase {


### PR DESCRIPTION
This change allows users to add a panel to their dashboard showing a mini rundown with the current playing part and the next 3 parts.

[SOF-774](https://tv2cms.atlassian.net/browse/SOF-774)

![image](https://user-images.githubusercontent.com/91883429/154082530-96afa01f-e098-48af-93a6-e6b9b371c22c.png)

Version 2

![image](https://user-images.githubusercontent.com/91883429/154478419-6dae473e-1ae1-4096-91b5-4d8178790fe4.png)
