### PR TITLE
fix: selector preventing layout dropdown to show

### DIFF
--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -98,7 +98,7 @@ export const RundownList = translateWithTracker((): IRundownsListProps => {
 	const showStyleBases = ShowStyleBases.find().fetch()
 	const showStyleVariants = ShowStyleVariants.find().fetch()
 	const rundownLayouts = RundownLayouts.find({
-		$or: [{ exposeAsSelectableLayout: true }, { exposeAsShelf: true }],
+		$or: [{ exposeAsSelectableLayout: true }, { exposeAsStandalone: true }],
 	}).fetch()
 
 	return {


### PR DESCRIPTION
Was using an old property - `exposeAsShelf` - which does not exist anymore.
RundownView layouts now have `exposeAsSelectableLayout`, Shelf layouts now have `exposeAsStandalone`. 