### PR TITLE
fix: SOF-858 mini rundown filtering and scrolling

### DIFF
--- a/meteor/client/styles/shelf/miniRundownPanel.scss
+++ b/meteor/client/styles/shelf/miniRundownPanel.scss
@@ -1,6 +1,7 @@
 @import '../colorScheme';
 
 .mini-rundown-panel {
+	--dashboard-panel-scale: 1;
 	position: absolute;
 	user-select: none;
 	white-space: nowrap;
@@ -9,9 +10,10 @@
 
 	.mini-rundown-panel__container {
 		width: 100%;
-		height: 95%;
+		height: calc(100% - var(--dashboard-panel-scale) * 1em);
 		overflow-x: hidden;
 		overflow-y: auto;
+		position: relative;
 	}
 
 	.mini-rundown-panel__segment {

--- a/meteor/client/ui/Shelf/MiniRundownPanel.tsx
+++ b/meteor/client/ui/Shelf/MiniRundownPanel.tsx
@@ -142,6 +142,7 @@ function getMiniRundownList(
 	const miniRundownSegments: MiniRundownSegment[] = []
 
 	allSegments?.forEach((segment: Segment) => {
+		if (segment.isHidden) return
 		miniRundownSegments.push({
 			identifier: getSegmentIdentifier(segment),
 			segmentName: getSegmentName(segment),

--- a/meteor/client/ui/Shelf/MiniRundownPanel.tsx
+++ b/meteor/client/ui/Shelf/MiniRundownPanel.tsx
@@ -46,19 +46,31 @@ export class MiniRundownPanelInner extends MeteorReactComponent<
 	static nextSegmentCssClass: string = 'next-segment'
 	static panelContainerId: string = 'mini-rundown-panel__container'
 	static nextSegmentId: string = 'mini-rundown__next-segment'
+	static currentSegmentId: string = 'mini-rundown__current-segment'
 
 	constructor(props) {
 		super(props)
 		this.state = {}
 	}
 
+	componentDidMount() {
+		this.scrollIntoView()
+	}
+
 	componentDidUpdate() {
+		this.scrollIntoView()
+	}
+
+	scrollIntoView() {
 		Meteor.setTimeout(() => {
 			const container = document.getElementById(MiniRundownPanelInner.panelContainerId)
-			const element = document.getElementById(MiniRundownPanelInner.nextSegmentId)
-			if (container && element) {
-				const magicLineHeight: number = 49
-				container.scrollTop = element.offsetTop - magicLineHeight
+			if (!container) return
+			const nextElement = document.getElementById(MiniRundownPanelInner.nextSegmentId)
+			const currentElement = document.getElementById(MiniRundownPanelInner.currentSegmentId)
+			if (nextElement) {
+				container.scrollTop = nextElement.offsetTop - nextElement.clientHeight
+			} else if (currentElement) {
+				container.scrollTop = currentElement.offsetTop
 			}
 		}, 500)
 	}
@@ -194,5 +206,12 @@ function getElementKey(prefix: string, identifier: string, index: number): strin
 }
 
 function getIdAttributeForNextSegment(cssClass: string) {
-	return cssClass === MiniRundownPanelInner.nextSegmentCssClass ? { id: MiniRundownPanelInner.nextSegmentId } : {}
+	switch (cssClass) {
+		case MiniRundownPanelInner.nextSegmentCssClass:
+			return { id: MiniRundownPanelInner.nextSegmentId }
+		case MiniRundownPanelInner.currentSegmentCssClass:
+			return { id: MiniRundownPanelInner.currentSegmentId }
+		default:
+			return {}
+	}
 }


### PR DESCRIPTION
Fixes the following issues:

- Segments with `isHidden: true`(e.g. segments with no parts or floated segments) were shown
- When refreshing the page, current/next segment would not be scrolled into view
- It used a magic number that made the offset right only for one scale value
