### PR TITLE
fix(SOF-910): Use AnyEnter instead of Enter for modals.

### DIFF
--- a/meteor/client/lib/ModalDialog.tsx
+++ b/meteor/client/lib/ModalDialog.tsx
@@ -63,11 +63,11 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 
 	bindKeys = () => {
 		if (this.props.show) {
-			this.sorensen.bind('Enter', this.preventDefault, {
+			this.sorensen.bind('AnyEnter', this.preventDefault, {
 				up: false,
 				prepend: true,
 			})
-			this.sorensen.bind('Enter', this.handleKey, {
+			this.sorensen.bind('AnyEnter', this.handleKey, {
 				up: true,
 				prepend: true,
 			})
@@ -85,8 +85,8 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 	}
 
 	unbindKeys = () => {
-		this.sorensen.unbind('Enter', this.preventDefault)
-		this.sorensen.unbind('Enter', this.handleKey)
+		this.sorensen.unbind('AnyEnter', this.preventDefault)
+		this.sorensen.unbind('AnyEnter', this.handleKey)
 		this.sorensen.unbind('Escape', this.preventDefault)
 		this.sorensen.unbind('Escape', this.handleKey)
 	}

--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -318,7 +318,7 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 					ordered: false,
 					preventDefaultPartials: false,
 				})
-				localSorensen.bind(['Enter', 'NumpadEnter'], preventDefault, {
+				localSorensen.bind('AnyEnter', preventDefault, {
 					global: false,
 					exclusive: true,
 				})
@@ -345,8 +345,7 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 			}
 			localSorensen.unbind('Control+KeyF', preventDefault)
 			localSorensen.unbind('Control+F5', preventDefault)
-			localSorensen.unbind('Enter', preventDefault)
-			localSorensen.unbind('NumpadEnter', preventDefault)
+			localSorensen.unbind('AnyEnter', preventDefault)
 			fKeys.forEach((key) => localSorensen.unbind(key, preventDefault))
 			ctrlDigitKeys.forEach((key) => localSorensen.unbind(`Control+${key}`, preventDefault))
 		}

--- a/meteor/client/lib/ui/containers/modals/Modal.tsx
+++ b/meteor/client/lib/ui/containers/modals/Modal.tsx
@@ -35,11 +35,11 @@ export class Modal extends React.Component<IModalAttributes> {
 
 	bindKeys = () => {
 		if (this.props.show) {
-			this.sorensen.bind('Enter', this.preventDefault, {
+			this.sorensen.bind('AnyEnter', this.preventDefault, {
 				up: false,
 				prepend: true,
 			})
-			this.sorensen.bind('Enter', this.handleKey, {
+			this.sorensen.bind('AnyEnter', this.handleKey, {
 				up: true,
 				prepend: true,
 			})
@@ -57,8 +57,8 @@ export class Modal extends React.Component<IModalAttributes> {
 	}
 
 	unbindKeys = () => {
-		this.sorensen.unbind('Enter', this.preventDefault)
-		this.sorensen.unbind('Enter', this.handleKey)
+		this.sorensen.unbind('AnyEnter', this.preventDefault)
+		this.sorensen.unbind('AnyEnter', this.handleKey)
 		this.sorensen.unbind('Escape', this.preventDefault)
 		this.sorensen.unbind('Escape', this.handleKey)
 	}


### PR DESCRIPTION
Modal dialogs can now be accepted with both Enter and NumpadEnter, via AnyEnter.

