### PR TITLE
fix: made a custom funtion to find piece with script

### DIFF
--- a/meteor/client/ui/Shelf/EndWordsPanel.tsx
+++ b/meteor/client/ui/Shelf/EndWordsPanel.tsx
@@ -87,19 +87,19 @@ function getPieceWithManus(props: IEndsWordsPanelProps): PieceInstance | undefin
 		props.playlist,
 		props.showStyleBase
 	)
-	let highestStartedPlayback: Time = 0
-	const startedPiecesCount: number = 0
-	unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.forEach((pieceInstance: PieceInstance) => {
-		if (pieceInstance.startedPlayback && pieceInstance.startedPlayback > highestStartedPlayback) {
-			highestStartedPlayback = pieceInstance.startedPlayback
-		}
+
+	const startedPlaybackTimes = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.map((pieceInstance: PieceInstance) => {
+		return pieceInstance.startedPlayback || 0
 	})
+	let highestStartedPlayback: Time = Math.max(...startedPlaybackTimes)
+	// unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.forEach((pieceInstance: PieceInstance) => {
+	// 	if (pieceInstance.startedPlayback && pieceInstance.startedPlayback > highestStartedPlayback) {
+	// 		highestStartedPlayback = pieceInstance.startedPlayback
+	// 	}
+	// })
 
 	const unfinishedPieces = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.filter(
 		(pieceInstance: PieceInstance) => {
-			if (startedPiecesCount > 1 && pieceInstance.startedPlayback != highestStartedPlayback) {
-				return false
-			}
 			return !pieceInstance.startedPlayback || pieceInstance.startedPlayback == highestStartedPlayback
 		}
 	)

--- a/meteor/client/ui/Shelf/EndWordsPanel.tsx
+++ b/meteor/client/ui/Shelf/EndWordsPanel.tsx
@@ -12,7 +12,7 @@ import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/Reac
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { PieceInstance, PieceInstances } from '../../../lib/collections/PieceInstances'
-import { ScriptContent, Time } from '@sofie-automation/blueprints-integration'
+import { ScriptContent } from '@sofie-automation/blueprints-integration'
 import { GetScriptPreview } from '../scriptPreview'
 import { DBShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 import { getUnfinishedPieceInstancesReactive } from '../../lib/rundownLayouts'
@@ -89,7 +89,8 @@ function getPieceWithManus(props: IEndsWordsPanelProps): PieceInstance | undefin
 	)
 
 	const highestStartedPlayback = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.reduce(
-		(hsp, piece: PieceInstance) => Math.max(hsp, piece.startedPlayback ?? 0), 0
+		(hsp, piece: PieceInstance) => Math.max(hsp, piece.startedPlayback ?? 0),
+		0
 	)
 
 	const unfinishedPieces = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.filter(

--- a/meteor/client/ui/Shelf/EndWordsPanel.tsx
+++ b/meteor/client/ui/Shelf/EndWordsPanel.tsx
@@ -92,11 +92,6 @@ function getPieceWithManus(props: IEndsWordsPanelProps): PieceInstance | undefin
 		return pieceInstance.startedPlayback || 0
 	})
 	let highestStartedPlayback: Time = Math.max(...startedPlaybackTimes)
-	// unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.forEach((pieceInstance: PieceInstance) => {
-	// 	if (pieceInstance.startedPlayback && pieceInstance.startedPlayback > highestStartedPlayback) {
-	// 		highestStartedPlayback = pieceInstance.startedPlayback
-	// 	}
-	// })
 
 	const unfinishedPieces = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.filter(
 		(pieceInstance: PieceInstance) => {

--- a/meteor/client/ui/Shelf/EndWordsPanel.tsx
+++ b/meteor/client/ui/Shelf/EndWordsPanel.tsx
@@ -88,12 +88,9 @@ function getPieceWithManus(props: IEndsWordsPanelProps): PieceInstance | undefin
 		props.showStyleBase
 	)
 
-	const startedPlaybackTimes = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.map(
-		(pieceInstance: PieceInstance) => {
-			return pieceInstance.startedPlayback || 0
-		}
+	const highestStartedPlayback = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.reduce(
+		(hsp, piece: PieceInstance) => Math.max(hsp, piece.startedPlayback ?? 0), 0
 	)
-	const highestStartedPlayback: Time = Math.max(...startedPlaybackTimes)
 
 	const unfinishedPieces = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.filter(
 		(pieceInstance: PieceInstance) => {
@@ -102,7 +99,7 @@ function getPieceWithManus(props: IEndsWordsPanelProps): PieceInstance | undefin
 	)
 
 	const activeLayers = unfinishedPieces.map((p) => p.piece.sourceLayerId)
-	const hasAdditionalLayer: boolean = props.panel.additionalLayers?.some((s) => activeLayers.includes(s)) || false
+	const hasAdditionalLayer: boolean = props.panel.additionalLayers?.some((s) => activeLayers.includes(s)) ?? false
 
 	if (!hasAdditionalLayer) {
 		return undefined

--- a/meteor/client/ui/Shelf/EndWordsPanel.tsx
+++ b/meteor/client/ui/Shelf/EndWordsPanel.tsx
@@ -11,11 +11,11 @@ import { dashboardElementPosition } from './DashboardPanel'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
-import {PieceInstance, PieceInstances} from '../../../lib/collections/PieceInstances'
+import { PieceInstance, PieceInstances } from '../../../lib/collections/PieceInstances'
 import { ScriptContent, Time } from '@sofie-automation/blueprints-integration'
 import { GetScriptPreview } from '../scriptPreview'
 import { DBShowStyleBase } from '../../../lib/collections/ShowStyleBases'
-import {getUnfinishedPieceInstancesReactive} from '../../lib/rundownLayouts';
+import { getUnfinishedPieceInstancesReactive } from '../../lib/rundownLayouts'
 
 interface IEndsWordsPanelProps {
 	visible?: boolean
@@ -83,21 +83,26 @@ export const EndWordsPanel = translateWithTracker<IEndsWordsPanelProps, IState, 
 function getPieceWithManus(props: IEndsWordsPanelProps): PieceInstance | undefined {
 	const currentPartInstanceId: any = props.playlist.currentPartInstanceId
 
-	const unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet = getUnfinishedPieceInstancesReactive(props.playlist, props.showStyleBase)
+	const unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet = getUnfinishedPieceInstancesReactive(
+		props.playlist,
+		props.showStyleBase
+	)
 	let highestStartedPlayback: Time = 0
-	let startedPiecesCount: number = 0
+	const startedPiecesCount: number = 0
 	unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.forEach((pieceInstance: PieceInstance) => {
 		if (pieceInstance.startedPlayback && pieceInstance.startedPlayback > highestStartedPlayback) {
 			highestStartedPlayback = pieceInstance.startedPlayback
 		}
 	})
 
-	const unfinishedPieces = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.filter((pieceInstance: PieceInstance) => {
-		if (startedPiecesCount > 1 && pieceInstance.startedPlayback != highestStartedPlayback) {
-			return false
+	const unfinishedPieces = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.filter(
+		(pieceInstance: PieceInstance) => {
+			if (startedPiecesCount > 1 && pieceInstance.startedPlayback != highestStartedPlayback) {
+				return false
+			}
+			return !pieceInstance.startedPlayback || pieceInstance.startedPlayback == highestStartedPlayback
 		}
-		return !pieceInstance.startedPlayback || pieceInstance.startedPlayback == highestStartedPlayback;
-	})
+	)
 
 	const activeLayers = unfinishedPieces.map((p) => p.piece.sourceLayerId)
 	const hasAdditionalLayer: boolean = props.panel.additionalLayers?.some((s) => activeLayers.includes(s)) || false
@@ -114,10 +119,10 @@ function getPieceWithManus(props: IEndsWordsPanelProps): PieceInstance | undefin
 
 	return props.panel.requiredLayerIds && props.panel.requiredLayerIds.length
 		? _.flatten(Object.values(piecesInPart)).find((piece: PieceInstance) => {
-			return (
-				(props.panel.requiredLayerIds || []).indexOf(piece.piece.sourceLayerId) !== -1 &&
-				piece.partInstanceId === props.playlist.currentPartInstanceId
-			)
-		})
+				return (
+					(props.panel.requiredLayerIds || []).indexOf(piece.piece.sourceLayerId) !== -1 &&
+					piece.partInstanceId === props.playlist.currentPartInstanceId
+				)
+		  })
 		: undefined
 }

--- a/meteor/client/ui/Shelf/EndWordsPanel.tsx
+++ b/meteor/client/ui/Shelf/EndWordsPanel.tsx
@@ -88,10 +88,12 @@ function getPieceWithManus(props: IEndsWordsPanelProps): PieceInstance | undefin
 		props.showStyleBase
 	)
 
-	const startedPlaybackTimes = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.map((pieceInstance: PieceInstance) => {
-		return pieceInstance.startedPlayback || 0
-	})
-	let highestStartedPlayback: Time = Math.max(...startedPlaybackTimes)
+	const startedPlaybackTimes = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.map(
+		(pieceInstance: PieceInstance) => {
+			return pieceInstance.startedPlayback || 0
+		}
+	)
+	const highestStartedPlayback: Time = Math.max(...startedPlaybackTimes)
 
 	const unfinishedPieces = unfinishedPiecesIncludingFinishedPiecesWhereEndTimeHaveNotBeenSet.filter(
 		(pieceInstance: PieceInstance) => {


### PR DESCRIPTION
Fix/hack to make endwords work again.
getIsFilterActive in [rundownLayouts.ts ](https://github.com/tv2/tv-automation-server-core/blob/50bda8aaae1d2793a903b1043afe88648532bf3e/meteor/client/lib/rundownLayouts.ts#L15) does not as it used to.
getUnfinishedPieceInstancesReactive does not return pieces for the script source layer it only return e.g. the pieces for the cam source layer or the server source layer.
There is also a problem with the filtering in getUnfinishedPieceInstancesReactive as stoppedPlayback on a piece is no longer set when the piece ends but when the segment ends. So you end up with two pieces with a value in startedPlayback and 0 in stoppePlayback. That's why I had to do all the filtering in the beginning of the function.
There is most like a correct way to fix all of these issues, this is just a workaround