### PR TITLE
feat: Set log level from LOG_LEVEL env var.

### DIFF
--- a/meteor/client/ui/Settings/SystemManagement.tsx
+++ b/meteor/client/ui/Settings/SystemManagement.tsx
@@ -93,7 +93,7 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((_props: IProps) 
 									attribute="logLevel"
 									obj={this.props.coreSystem}
 									type="dropdown"
-									options={LogLevel}
+									options={{ ...LogLevel, 'Use fallback': undefined }}
 									collection={CoreSystem}
 									className="mdinput"
 								/>

--- a/meteor/server/coreSystem.ts
+++ b/meteor/server/coreSystem.ts
@@ -19,7 +19,7 @@ import { Blueprints, Blueprint } from '../lib/collections/Blueprints'
 import * as _ from 'underscore'
 import { ShowStyleBases } from '../lib/collections/ShowStyleBases'
 import { Studios, StudioId } from '../lib/collections/Studios'
-import { logger, LogLevel, setLogLevel } from './logging'
+import { getEnvLogLevel, logger, LogLevel, setLogLevel } from './logging'
 import { findMissingConfigs } from './api/blueprints/config'
 import { ShowStyleVariants } from '../lib/collections/ShowStyleVariants'
 const PackageInfo = require('../package.json')
@@ -428,7 +428,7 @@ function updateLoggerLevel(startup: boolean) {
 	const coreSystem = getCoreSystem()
 
 	if (coreSystem) {
-		setLogLevel(coreSystem.logLevel || LogLevel.SILLY, startup)
+		setLogLevel(coreSystem.logLevel ?? getEnvLogLevel() ?? LogLevel.SILLY, startup)
 	} else {
 		logger.error('updateLoggerLevel: CoreSystem not found')
 	}

--- a/meteor/server/logging.ts
+++ b/meteor/server/logging.ts
@@ -24,6 +24,10 @@ export function setLogLevel(level: LogLevel, startup = false) {
 	}
 }
 
+export function getEnvLogLevel(): LogLevel | undefined {
+	return Object.values(LogLevel).find((level) => level === process.env.LOG_LEVEL)
+}
+
 // @todo: remove this and do a PR to https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/winston
 // because there's an error in the typings logging.debug() takes any, not only string
 interface LoggerInstanceFixed extends Winston.Logger {
@@ -105,12 +109,12 @@ if (logToFile || logPath !== '') {
 		}
 	}
 	const transportConsole = new Winston.transports.Console({
-		level: 'verbose',
+		level: getEnvLogLevel() ?? 'verbose',
 		handleExceptions: true,
 		handleRejections: true,
 	})
 	const transportFile = new Winston.transports.File({
-		level: 'silly',
+		level: getEnvLogLevel() ?? 'silly',
 		handleExceptions: true,
 		handleRejections: true,
 		filename: logPath,
@@ -127,7 +131,7 @@ if (logToFile || logPath !== '') {
 	console.log('Logging to ' + logPath)
 } else {
 	const transportConsole = new Winston.transports.Console({
-		level: 'silly',
+		level: getEnvLogLevel() ?? 'silly',
 		handleExceptions: true,
 		handleRejections: true,
 	})


### PR DESCRIPTION
In order to set a log level, instead of `silly`, at startup, setting log level from `LOG_LEVEL` env var was introduced.
The value set in the core system settings overrides this behaviour.
Silly log level is used if no other log level is specified.