### PR TITLE
fix: lowered logging level for a pair of log calls.

### DIFF
--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -514,7 +514,7 @@ export class TSRHandler {
 		}
 	}
 	private async _updateDevices(): Promise<void> {
-		this.logger.info('updateDevices start')
+		this.logger.debug('updateDevices start')
 
 		const peripheralDevices = this._coreHandler.core.getCollection('peripheralDevices')
 		const peripheralDevice = peripheralDevices.findOne(this._coreHandler.core.deviceId)
@@ -629,7 +629,7 @@ export class TSRHandler {
 		await Promise.all(ps)
 
 		this._triggerupdateExpectedPlayoutItems() // So that any recently created devices will get all the ExpectedPlayoutItems
-		this.logger.info('updateDevices end')
+		this.logger.debug('updateDevices end')
 	}
 	private getDeviceDebug(deviceOptions: DeviceOptionsAny): boolean {
 		return deviceOptions.debug || this._coreHandler.logDebug || false


### PR DESCRIPTION
- Logging when _updateDevices() starts and stop created ~5000ish logs a day.
	- Lowered it from Info to Debug, as it is only really useful during development, from what i can gather.
	- Was about 45% of the logs in the 24 hours file i checked.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Reduced 2 logging statements from info level to debug, cutting away a large part of unnecessary logs in production.


* **What is the current behavior?** (You can also link to an open issue here)
Currently the changed lines logged with info level.


* **What is the new behavior (if this is a feature change)?**
Now the chaged lines log with debug level, which is ignored in production.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
