### PR TITLE
fix: SOF-769 adlib toggling with toggleOnSingleClick enabled

### DIFF
--- a/meteor/client/styles/tv2/customInstallation.scss
+++ b/meteor/client/styles/tv2/customInstallation.scss
@@ -1,8 +1,3 @@
-:root {
-  // Set to force single-click to toggle adlibs
-  --pointer: 'no-pointer';
-}
-
 body.tv2 {
   --general-live-color: #c40000;
   //--general-next-color: #FF0000;

--- a/meteor/client/ui/RundownView/RundownViewShelf.tsx
+++ b/meteor/client/ui/RundownView/RundownViewShelf.tsx
@@ -10,7 +10,11 @@ import { DashboardPieceButton } from '../Shelf/DashboardPieceButton'
 import { IBlueprintActionTriggerMode, IOutputLayer, ISourceLayer } from '@sofie-automation/blueprints-integration'
 import { Studio } from '../../../lib/collections/Studios'
 import { ensureHasTrailingSlash, UserAgentPointer, USER_AGENT_POINTER_PROPERTY } from '../../lib/lib'
-import { PieceDisplayStyle } from '../../../lib/collections/RundownLayouts'
+import {
+	DashboardLayoutFilter,
+	PieceDisplayStyle,
+	RundownLayoutFilterBase,
+} from '../../../lib/collections/RundownLayouts'
 import { NoticeLevel, Notification, NotificationCenter } from '../../lib/notifications/notifications'
 import { memoizedIsolatedAutorun } from '../../lib/reactiveData/reactiveDataHelper'
 import { PartInstanceId } from '../../../lib/collections/PartInstances'
@@ -34,6 +38,7 @@ interface IRundownViewShelfProps {
 	adLibSegmentUi: AdlibSegmentUi
 	hotkeyGroup: string
 	studioMode: boolean
+	miniShelfFilter: RundownLayoutFilterBase | undefined
 }
 
 interface IRundownViewShelfTrackedProps {
@@ -224,7 +229,10 @@ class RundownViewShelfInner extends MeteorReactComponent<
 								displayStyle={PieceDisplayStyle.BUTTONS}
 								widthScale={3.27} // @todo: css
 								isSelected={false}
-								toggleOnSingleClick={this.state.singleClickMode}
+								toggleOnSingleClick={
+									(this.props.miniShelfFilter as DashboardLayoutFilter)?.toggleOnSingleClick ||
+									this.state.singleClickMode
+								}
 							>
 								{adLibPiece.name}
 							</DashboardPieceButton>

--- a/meteor/client/ui/SegmentContainer/withResolvedSegment.ts
+++ b/meteor/client/ui/SegmentContainer/withResolvedSegment.ts
@@ -28,7 +28,7 @@ import { memoizedIsolatedAutorun, slowDownReactivity } from '../../lib/reactiveD
 import { ScanInfoForPackages } from '../../../lib/mediaObjects'
 import { getBasicNotesForSegment } from '../../../lib/rundownNotifications'
 import { getIsFilterActive } from '../../lib/rundownLayouts'
-import { RundownViewLayout } from '../../../lib/collections/RundownLayouts'
+import { RundownLayoutFilterBase, RundownViewLayout } from '../../../lib/collections/RundownLayouts'
 import { getMinimumReactivePieceNotesForPart } from './getMinimumReactivePieceNotesForPart'
 import { SegmentViewMode } from './SegmentViewModes'
 import { SegmentNote, TrackedNote } from '@sofie-automation/corelib/dist/dataModel/Notes'
@@ -86,6 +86,7 @@ export interface IProps {
 	ownCurrentPartInstance: PartInstance | undefined
 	ownNextPartInstance: PartInstance | undefined
 	adLibSegmentUi?: AdlibSegmentUi
+	miniShelfFilter: RundownLayoutFilterBase | undefined
 	isFollowingOnAirSegment: boolean
 	rundownViewLayout: RundownViewLayout | undefined
 	countdownToSegmentRequireLayers: string[] | undefined

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -748,6 +748,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 							showStyleBase={this.props.showStyleBase}
 							adLibSegmentUi={this.props.adLibSegmentUi}
 							hotkeyGroup={unprotectString(this.props.segmentui._id) + '_RundownViewShelf'}
+							miniShelfFilter={this.props.miniShelfFilter}
 							studioMode={this.props.studioMode}
 						/>
 					)}

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -369,13 +369,14 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 	private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
 		const { toggleOnSingleClick } = this.props
 		// if pointerId is not set, it means we are dealing with a mouse and not an emulated mouse event
-		if (this.pointerId === null && e.button === 0) {
-			// this is a main-button-click
-			if (toggleOnSingleClick) {
-				this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
-			} else {
-				this.props.onSelectAdLib(this.props.piece, e)
-			}
+		if (this.pointerId !== null || e.button !== 0) {
+			return
+		}
+		// this is a main-button-click
+		if (toggleOnSingleClick) {
+			this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
+		} else {
+			this.props.onSelectAdLib(this.props.piece, e)
 		}
 	}
 
@@ -396,9 +397,8 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 		const { toggleOnSingleClick } = this.props
 		if (toggleOnSingleClick) {
 			return
-		} else {
-			this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
 		}
+		this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
 	}
 
 	private handleOnPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -418,12 +418,13 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 
 	private handleOnPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
 		const { toggleOnSingleClick } = this.props
-		if (e.pointerId === this.pointerId) {
-			if (!toggleOnSingleClick) {
-				this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
-			}
-			e.preventDefault()
+		if (e.pointerId !== this.pointerId) {
+			return
 		}
+		if (!toggleOnSingleClick) {
+			this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
+		}
+		e.preventDefault()
 	}
 
 	renderHotkey = () => {

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -417,8 +417,11 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 	}
 
 	private handleOnPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+		const { toggleOnSingleClick } = this.props
 		if (e.pointerId === this.pointerId) {
-			this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
+			if (!toggleOnSingleClick) {
+				this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
+			}
 			e.preventDefault()
 		}
 	}

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -147,7 +147,7 @@ export const TimelineDashboardPanel = translateWithTracker<
 													heightScale={filter.buttonHeightScale}
 													displayStyle={PieceDisplayStyle.BUTTONS}
 													showThumbnailsInList={filter.showThumbnailsInList}
-													toggleOnSingleClick={this.state.singleClickMode}
+													toggleOnSingleClick={filter.toggleOnSingleClick || this.state.singleClickMode}
 												>
 													{adLibListItem.name}
 												</DashboardPieceButton>
@@ -210,7 +210,7 @@ export const TimelineDashboardPanel = translateWithTracker<
 														showThumbnailsInList={filter.showThumbnailsInList}
 														canOverflowHorizontally={filter.overflowHorizontally}
 														displayStyle={filter.displayStyle}
-														toggleOnSingleClick={this.state.singleClickMode}
+														toggleOnSingleClick={filter.toggleOnSingleClick || this.state.singleClickMode}
 													>
 														{adLibListItem.name}
 													</DashboardPieceButton>


### PR DESCRIPTION
Make a single tap on a dashboard button toggle the adlib once. (Before, when `toggleOnSingleClick` was `true`, it toggled it twice, leading to a piece starting and almost immediately stopping afterwards)
Make the MiniShelf and TimelineDashboardPanel respect their filter's `toggleOnSingleClick` option.
Removes the `no-pointer` hack in favour of enabling `toggleOnSingleClick` on our dashboard panels, which was the intended way of making a single click/tap toggle adlibs (will come in a separate PR for the blueprints).
