### PR TITLE
fix: SOF-1012 disappearing keyboard labels

### DIFF
--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -172,7 +172,7 @@ export interface MountedGenericTrigger {
 export const MountedGenericTriggers = new Mongo.Collection<MountedGenericTrigger>(null)
 
 function isolatedAutorunWithCleanup(autorun: () => void | (() => void)): Tracker.Computation {
-	const computation = Tracker.nonreactive(() =>
+	return Tracker.nonreactive(() =>
 		Tracker.autorun((computation) => {
 			const cleanUp = autorun()
 
@@ -181,12 +181,6 @@ function isolatedAutorunWithCleanup(autorun: () => void | (() => void)): Tracker
 			}
 		})
 	)
-	if (Tracker.currentComputation) {
-		Tracker.currentComputation.onStop(() => {
-			computation.stop()
-		})
-	}
-	return computation
 }
 
 /**


### PR DESCRIPTION
Fixes a bug causing labels to disappear from the keyboard preview in some scenarios e.g. when changing ShowStyle settings.

When `isolatedAutorunWithCleanup` is called within an effect, the `currentComputation` might be stopped and replaced, triggering the cleanup, but the effect might not rerun due to the dependencies being identical. Manually stop trackers made with `isolatedAutorunWithCleanup` when no longer needed.
