### PR TITLE
feat: SOF-767 add option to hide default Start/Execute context menu options for adlibs

### DIFF
--- a/meteor/client/ui/Settings/components/rundownLayouts/ShelfLayoutSettings.tsx
+++ b/meteor/client/ui/Settings/components/rundownLayouts/ShelfLayoutSettings.tsx
@@ -71,6 +71,21 @@ export default withTranslation()(
 							></EditAttribute>
 						</label>
 					</div>
+					<div className="mod mvs mhs">
+						<label className="field">
+							{t('Hide default AdLib Start/Execute options')}
+							<EditAttribute
+								modifiedClassName="bghl"
+								attribute={'hideDefaultStartExecute'}
+								obj={this.props.item}
+								options={RundownLayoutType}
+								type="checkbox"
+								collection={RundownLayouts}
+								className="mod mas"
+							></EditAttribute>
+							<span className="text-s dimmed">{t('Only custom trigger modes will be shown')}</span>
+						</label>
+					</div>
 				</React.Fragment>
 			)
 		}

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -403,7 +403,10 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 				ref={this.setRef}
 			>
 				{!this.props.rundownLayout?.disableContextMenu && (
-					<ShelfContextMenu shelfDisplayOptions={this.props.shelfDisplayOptions} />
+					<ShelfContextMenu
+						shelfDisplayOptions={this.props.shelfDisplayOptions}
+						hideDefaultStartExecute={!!this.props.rundownLayout?.hideDefaultStartExecute}
+					/>
 				)}
 				{!fullViewport && (
 					<div

--- a/meteor/client/ui/Shelf/ShelfContextMenu.tsx
+++ b/meteor/client/ui/Shelf/ShelfContextMenu.tsx
@@ -21,6 +21,7 @@ export enum ContextType {
 
 interface ShelfContextMenuProps {
 	shelfDisplayOptions: ShelfDisplayOptions
+	hideDefaultStartExecute: boolean
 }
 
 interface ShelfContextMenuContextBase {
@@ -86,7 +87,7 @@ export default function ShelfContextMenu(props: ShelfContextMenuProps) {
 		adLib: T
 		onToggle?: (adLib: T, queue: boolean, e: any, mode?: IBlueprintActionTriggerMode) => void
 		disabled?: boolean
-	}) {
+	}): JSX.Element | JSX.Element[] | null {
 		if (isActionItem(item.adLib)) {
 			const adLibAction = getActionItem(item.adLib)
 			const triggerModes = adLibAction?.triggerModes
@@ -108,7 +109,8 @@ export default function ShelfContextMenu(props: ShelfContextMenuProps) {
 					</MenuItem>
 				))
 			return (
-				(triggerModes !== undefined && triggerModes.length > 0 && triggerModes) || (
+				(triggerModes !== undefined && triggerModes.length > 0 && triggerModes) ||
+				(!props.hideDefaultStartExecute ? (
 					<MenuItem
 						onClick={(e) => {
 							e.persist()
@@ -119,10 +121,10 @@ export default function ShelfContextMenu(props: ShelfContextMenuProps) {
 						{(adLibAction?.display.triggerLabel && translateMessage(adLibAction?.display.triggerLabel, t)) ??
 							t('Execute')}
 					</MenuItem>
-				)
+				) : null)
 			)
 		} else {
-			return (
+			return !props.hideDefaultStartExecute ? (
 				<>
 					<MenuItem
 						onClick={(e) => {
@@ -145,9 +147,16 @@ export default function ShelfContextMenu(props: ShelfContextMenuProps) {
 						</MenuItem>
 					)}
 				</>
-			)
+			) : null
 		}
 	}
+
+	const startExecuteMenuItems =
+		context?.type === ContextType.ADLIB
+			? renderStartExecuteAdLib(context.details)
+			: context?.type === ContextType.BUCKET_ADLIB
+			? renderStartExecuteAdLib(context.details)
+			: null
 
 	return (
 		<Escape to="viewport">
@@ -157,13 +166,15 @@ export default function ShelfContextMenu(props: ShelfContextMenuProps) {
 				)}
 				{context && (context.type === ContextType.BUCKET_ADLIB || context.type === ContextType.ADLIB) && (
 					<>
-						<div className="react-contextmenu-label">{context.details.adLib.name}</div>
-						{context.type === ContextType.ADLIB
-							? renderStartExecuteAdLib(context.details)
-							: context.type === ContextType.BUCKET_ADLIB
-							? renderStartExecuteAdLib(context.details)
-							: null}
-						<hr />
+						{(startExecuteMenuItems !== null ||
+							props.shelfDisplayOptions.enableInspector ||
+							context.type === ContextType.BUCKET_ADLIB) && (
+							<>
+								<div className="react-contextmenu-label">{context.details.adLib.name}</div>
+								{startExecuteMenuItems}
+								<hr />
+							</>
+						)}
 						{props.shelfDisplayOptions.enableInspector && (
 							<MenuItem
 								onClick={(e) => {

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -380,6 +380,7 @@ export interface RundownLayoutShelfBase extends RundownLayoutWithFilters {
 	openByDefault: boolean
 	startingHeight?: number
 	disableContextMenu: boolean
+	hideDefaultStartExecute: boolean
 	/* Customizable region that the layout modifies. */
 	regionId: CustomizableRegions
 }

--- a/meteor/server/api/__tests__/rundownLayouts.test.ts
+++ b/meteor/server/api/__tests__/rundownLayouts.test.ts
@@ -63,6 +63,7 @@ describe('Rundown Layouts', () => {
 				iconColor: '',
 				openByDefault: false,
 				disableContextMenu: true,
+				hideDefaultStartExecute: false,
 				regionId: CustomizableRegions.Shelf,
 			})
 			return { rundownLayout: mockLayout, rundownLayoutId }


### PR DESCRIPTION
Adds a Shelf Layout option called _Hide default AdLib Start/Execute options_.
When enabled, the default items from AdLib's context menu (‘Start this AdLib’, ‘Queue this AdLib’ or ‘Execute’) will not be shown. Trigger modes for AdLib Actions will be shown, if defined. Other options related to buckets or the inspector will be shown if these features are enabled. If there are no options to be shown, the menu will not appear at all.

![image](https://user-images.githubusercontent.com/9103996/188836736-d5568dc7-1a5f-4630-888c-852641eb15f7.png)
Example with buckets and inspector enabled, and no trigger modes:
![image](https://user-images.githubusercontent.com/9103996/188836659-145ee0c6-86f1-461f-91dc-f441a7196366.png)
Example with buckets and inspector disabled, and two trigger modes defined:
![image](https://user-images.githubusercontent.com/9103996/188837698-56c25fa2-c419-41f5-8685-ded334bd35ba.png)
Example with buckets and inspector disabled, and no trigger modes: (no menu)
![image](https://user-images.githubusercontent.com/9103996/188838330-92da5c90-a8f3-4e53-bfcc-a3bbd504ed5d.png)




