### PR TITLE
fix: SOF-1106 degraded UI performance due to staggered updates not wo…

### DIFF
--- a/meteor/client/ui/SegmentContainer/withResolvedSegment.ts
+++ b/meteor/client/ui/SegmentContainer/withResolvedSegment.ts
@@ -319,11 +319,11 @@ export function withResolvedSegment<T extends IProps, IState = {}>(
 				props.segmentRef !== nextProps.segmentRef ||
 				props.timeScale !== nextProps.timeScale ||
 				props.isFollowingOnAirSegment !== nextProps.isFollowingOnAirSegment ||
-				props.ownCurrentPartInstance !== nextProps.ownCurrentPartInstance ||
-				props.ownNextPartInstance !== nextProps.ownNextPartInstance ||
+				!_.isEqual(props.ownCurrentPartInstance, nextProps.ownCurrentPartInstance) ||
+				!_.isEqual(props.ownNextPartInstance, nextProps.ownNextPartInstance) ||
 				!equalSets(props.segmentsIdsBefore, nextProps.segmentsIdsBefore) ||
 				!_.isEqual(props.countdownToSegmentRequireLayers, nextProps.countdownToSegmentRequireLayers) ||
-				props.rundownViewLayout !== nextProps.rundownViewLayout ||
+				!_.isEqual(props.rundownViewLayout, nextProps.rundownViewLayout) ||
 				props.fixedSegmentDuration !== nextProps.fixedSegmentDuration ||
 				!_.isEqual(props.adLibSegmentUi?.pieces, nextProps.adLibSegmentUi?.pieces) ||
 				props.adLibSegmentUi?.showShelf !== nextProps.adLibSegmentUi?.showShelf
@@ -372,9 +372,7 @@ export function withResolvedSegment<T extends IProps, IState = {}>(
 				props.playlist.nextTimeOffset !== nextProps.playlist.nextTimeOffset ||
 				props.playlist.activationId !== nextProps.playlist.activationId ||
 				PlaylistTiming.getExpectedStart(props.playlist.timing) !==
-					PlaylistTiming.getExpectedStart(nextProps.playlist.timing) ||
-				props.ownCurrentPartInstance !== nextProps.ownCurrentPartInstance ||
-				props.ownNextPartInstance !== nextProps.ownNextPartInstance
+					PlaylistTiming.getExpectedStart(nextProps.playlist.timing)
 			) {
 				return true
 			}


### PR DESCRIPTION
Fixes some UI freezes occurring when part is being queued or taken, which were caused by immediate re-rendering of segments other than current and next, instead of using _staggered updates_.
(It was caused by shallow comparison of objects that might change their reference when fetched from mini-mongo, but still be identical, when parent component re-renders due to tracked dependencies update)