### PR TITLE
SOF-1129: shortened names with use of ellipsis

### DIFF
--- a/meteor/client/styles/rundownSystemStatus.scss
+++ b/meteor/client/styles/rundownSystemStatus.scss
@@ -3,7 +3,7 @@
 .rundown-system-status {
 	position: absolute;
 	font-size: 0.8em;
-	width: 350px;
+	width: 100%;
 	height: 1em;
 	left: 50%;
 	top: 42px;

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -260,6 +260,10 @@ body.no-overflow {
 				text-align: left;
 			}
 
+			&.show-style {
+				width: 40%
+			}
+
 			&.time-now {
 				position: absolute;
 				top: 0.05em;

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -260,9 +260,6 @@ body.no-overflow {
 				text-align: left;
 			}
 
-			&.show-style {
-				width: 40%
-			}
 
 			&.time-now {
 				position: absolute;

--- a/meteor/client/styles/shelf/showStylePanel.scss
+++ b/meteor/client/styles/shelf/showStylePanel.scss
@@ -7,5 +7,12 @@
 
     .name {
         font-weight: 400;
+
+        &.overflow-ellipsis {
+            overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+			display: block;
+        }
     }
 }

--- a/meteor/client/styles/shelf/showStylePanel.scss
+++ b/meteor/client/styles/shelf/showStylePanel.scss
@@ -10,9 +10,9 @@
 
         &.overflow-ellipsis {
             overflow: hidden;
-			white-space: nowrap;
-			text-overflow: ellipsis;
-			display: block;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            display: block;
         }
     }
 }

--- a/meteor/client/styles/shelf/showStylePanel.scss
+++ b/meteor/client/styles/shelf/showStylePanel.scss
@@ -1,18 +1,30 @@
 .show-style-panel {
     position: absolute;
+    display: flex;
+    justify-content: flex-start;
 
-    .timing-clock {
-        margin-right: 1.2em;
-    }
+    .show-style-subpanel {
+        flex: 1;
+        overflow: hidden;
+        margin-right: 1em;
+        font-size: 1.5em;
+        font-family: 'Roboto', Helvetica Neue, Arial, sans-serif;
+        font-weight: 100; 
 
-    .name {
-        font-weight: 400;
-
-        &.overflow-ellipsis {
+        &__label {
+            margin-top: 6px;
+            color: #b8b8b8;
+            text-transform: uppercase;
+            white-space: nowrap;
+            font-weight: 300;
+            font-size: 0.5em;
+        }
+        
+        &__name {
             overflow: hidden;
+            font-weight: 400;
             white-space: nowrap;
             text-overflow: ellipsis;
-            display: block;
         }
     }
 }

--- a/meteor/client/ui/Shelf/ShowStylePanel.tsx
+++ b/meteor/client/ui/Shelf/ShowStylePanel.tsx
@@ -35,21 +35,21 @@ class ShowStylePanelInner extends MeteorReactComponent<Translated<IShowStylePane
 
 		return (
 			<div
-				className="show-style-panel timing"
+				className="show-style-panel"
 				style={isDashboardLayout ? dashboardElementStyle(this.props.panel as DashboardLayoutShowStyleDisplay) : {}}
 			>
-				<span className="timing-clock left show-style">
-					<span className="timing-clock-label">{t('Show Style')}</span>
-					<span className="name overflow-ellipsis" title={this.props.showStyleBase.name}>
+				<div className="show-style-subpanel">
+					<div className="show-style-subpanel__label">{t('Show Style')}</div>
+					<div className="show-style-subpanel__name" title={this.props.showStyleBase.name}>
 						{this.props.showStyleBase.name}
-					</span>
-				</span>
-				<span className="timing-clock left show-style">
-					<span className="timing-clock-label">{t('Show Style Variant')}</span>
-					<span className="name overflow-ellipsis" title={this.props.showStyleVariant.name}>
+					</div>
+				</div>
+				<div className="show-style-subpanel">
+					<div className="show-style-subpanel__label">{t('Show Style Variant')}</div>
+					<div className="show-style-subpanel__name" title={this.props.showStyleVariant.name}>
 						{this.props.showStyleVariant.name}
-					</span>
-				</span>
+					</div>
+				</div>
 			</div>
 		)
 	}

--- a/meteor/client/ui/Shelf/ShowStylePanel.tsx
+++ b/meteor/client/ui/Shelf/ShowStylePanel.tsx
@@ -38,13 +38,17 @@ class ShowStylePanelInner extends MeteorReactComponent<Translated<IShowStylePane
 				className="show-style-panel timing"
 				style={isDashboardLayout ? dashboardElementStyle(this.props.panel as DashboardLayoutShowStyleDisplay) : {}}
 			>
-				<span className="timing-clock left">
+				<span className="timing-clock left show-style">
 					<span className="timing-clock-label">{t('Show Style')}</span>
-					<span className="name">{this.props.showStyleBase.name}</span>
+					<span className="name overflow-ellipsis" title={this.props.showStyleBase.name}>
+						{this.props.showStyleBase.name}
+					</span>
 				</span>
-				<span className="timing-clock left">
+				<span className="timing-clock left show-style">
 					<span className="timing-clock-label">{t('Show Style Variant')}</span>
-					<span className="name">{this.props.showStyleVariant.name}</span>
+					<span className="name overflow-ellipsis" title={this.props.showStyleVariant.name}>
+						{this.props.showStyleVariant.name}
+					</span>
 				</span>
 			</div>
 		)


### PR DESCRIPTION
I am unsure if i have placed the css in fitting locations - so that might be something that need changes.
And yes, i did run Tests before the commit, Rasmus :)

- fix: added ellipsis to Show style and Show style variant.
- fix: set width of div containing system status to 100% instead of pixel value, allowing tooltips on Show style and Show style variant to work.