### PR TITLE
feat: SOF-978 add `ConfigManifestEntrySelectFromColumn`

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -530,6 +530,18 @@ const EditAttributeSwitch = wrapEditAttribute(
 		}
 	}
 )
+
+interface EditAttributeDropdownOption {
+	value: any
+	name: string
+	i?: number
+}
+
+interface EditAttributeDropdownOptionsResult {
+	options: EditAttributeDropdownOption[]
+	currentOptionMissing: boolean
+}
+
 const EditAttributeDropdown = wrapEditAttribute(
 	class EditAttributeDropdown extends EditAttributeBase {
 		constructor(props) {
@@ -547,11 +559,8 @@ const EditAttributeDropdown = wrapEditAttribute(
 
 			this.handleUpdate(this.props.optionsAreNumbers ? parseInt(value, 10) : value)
 		}
-		getOptions(addOptionForCurrentValue?: boolean): {
-			options: Array<{ value: any; name: string; i?: number }>
-			currentOptionMissing: boolean
-		} {
-			const options: Array<{ value: any; name: string; i?: number }> = []
+		getOptions(addOptionForCurrentValue?: boolean): EditAttributeDropdownOptionsResult {
+			const options: EditAttributeDropdownOption[] = []
 
 			if (Array.isArray(this.props.options)) {
 				// is it an enum?
@@ -604,12 +613,9 @@ const EditAttributeDropdown = wrapEditAttribute(
 			}
 
 			const currentValue = this.getAttribute()
-			const currentOption = _.find(options, (o) => {
-				if (Array.isArray(o.value)) {
-					return _.contains(o.value, currentValue)
-				}
-				return o.value === currentValue
-			})
+			const currentOption = options.find((o) =>
+				Array.isArray(o.value) ? o.value.includes(currentValue) : o.value === currentValue
+			)
 
 			if (addOptionForCurrentValue) {
 				if (!currentOption) {
@@ -752,12 +758,9 @@ const EditAttributeDropdownText = wrapEditAttribute(
 
 			if (addOptionForCurrentValue) {
 				const currentValue = this.getAttribute()
-				const currentOption = _.find(options, (o) => {
-					if (Array.isArray(o.value)) {
-						return _.contains(o.value, currentValue)
-					}
-					return o.value === currentValue
-				})
+				const currentOption = options.find((o) =>
+					Array.isArray(o.value) ? o.value.includes(currentValue) : o.value === currentValue
+				)
 				if (!currentOption) {
 					// if currentOption not found, then add it to the list:
 					options.push({
@@ -816,6 +819,12 @@ const EditAttributeDropdownText = wrapEditAttribute(
 		}
 	}
 )
+
+interface EditAttributeMultiSelectOptionsResult {
+	options: MultiSelectOptions
+	currentOptionMissing: boolean
+}
+
 const EditAttributeMultiSelect = wrapEditAttribute(
 	class EditAttributeMultiSelect extends EditAttributeBase {
 		constructor(props) {
@@ -826,10 +835,7 @@ const EditAttributeMultiSelect = wrapEditAttribute(
 		handleChange(event: MultiSelectEvent) {
 			this.handleUpdate(event.selectedValues)
 		}
-		getOptions(addOptionsForCurrentValue?: boolean): {
-			options: MultiSelectOptions
-			currentOptionMissing: boolean
-		} {
+		getOptions(addOptionsForCurrentValue?: boolean): EditAttributeMultiSelectOptionsResult {
 			const options: MultiSelectOptions = {}
 
 			if (Array.isArray(this.props.options)) {

--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -4,7 +4,7 @@ import { withTracker } from './ReactMeteorData/react-meteor-data'
 import { faCheckSquare, faSquare } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
-import { MultiSelect, MultiSelectEvent } from './multiSelect'
+import { MultiSelect, MultiSelectEvent, MultiSelectOptions } from './multiSelect'
 import { TransformedCollection } from '../../lib/typings/meteor'
 import ClassNames from 'classnames'
 import { ColorPickerEvent, ColorPicker } from './colorPicker'
@@ -539,7 +539,7 @@ const EditAttributeDropdown = wrapEditAttribute(
 		}
 		handleChange(event) {
 			// because event.target.value is always a string, use the original value instead
-			const option = _.find(this.getOptions(), (o) => {
+			const option = _.find(this.getOptions().options, (o) => {
 				return o.value + '' === event.target.value + ''
 			})
 
@@ -547,7 +547,10 @@ const EditAttributeDropdown = wrapEditAttribute(
 
 			this.handleUpdate(this.props.optionsAreNumbers ? parseInt(value, 10) : value)
 		}
-		getOptions(addOptionForCurrentValue?: boolean) {
+		getOptions(addOptionForCurrentValue?: boolean): {
+			options: Array<{ value: any; name: string; i?: number }>
+			currentOptionMissing: boolean
+		} {
 			const options: Array<{ value: any; name: string; i?: number }> = []
 
 			if (Array.isArray(this.props.options)) {
@@ -600,14 +603,15 @@ const EditAttributeDropdown = wrapEditAttribute(
 				}
 			}
 
+			const currentValue = this.getAttribute()
+			const currentOption = _.find(options, (o) => {
+				if (Array.isArray(o.value)) {
+					return _.contains(o.value, currentValue)
+				}
+				return o.value === currentValue
+			})
+
 			if (addOptionForCurrentValue) {
-				const currentValue = this.getAttribute()
-				const currentOption = _.find(options, (o) => {
-					if (Array.isArray(o.value)) {
-						return _.contains(o.value, currentValue)
-					}
-					return o.value === currentValue
-				})
 				if (!currentOption) {
 					// if currentOption not found, then add it to the list:
 					options.push({
@@ -621,23 +625,23 @@ const EditAttributeDropdown = wrapEditAttribute(
 				options[i].i = i
 			}
 
-			return options
+			return { options, currentOptionMissing: !currentOption }
 		}
 		render() {
+			const options = this.getOptions(true)
 			return (
 				<select
-					className={
-						'form-control' +
-						' ' +
-						(this.props.className || '') +
-						' ' +
-						(this.state.editing ? this.props.modifiedClassName || '' : '')
-					}
+					className={ClassNames(
+						'form-control',
+						this.props.className,
+						this.state.editing && this.props.modifiedClassName,
+						options.currentOptionMissing && 'option-missing'
+					)}
 					value={this.getAttributeText()}
 					onChange={this.handleChange}
 					disabled={this.props.disabled}
 				>
-					{this.getOptions(true).map((o, j) =>
+					{options.options.map((o, j) =>
 						Array.isArray(o.value) ? (
 							<optgroup key={j} label={o.name}>
 								{o.value.map((v, i) => (
@@ -822,16 +826,19 @@ const EditAttributeMultiSelect = wrapEditAttribute(
 		handleChange(event: MultiSelectEvent) {
 			this.handleUpdate(event.selectedValues)
 		}
-		getOptions() {
-			const options: _.Dictionary<string | string[]> = {}
+		getOptions(addOptionsForCurrentValue?: boolean): {
+			options: MultiSelectOptions
+			currentOptionMissing: boolean
+		} {
+			const options: MultiSelectOptions = {}
 
 			if (Array.isArray(this.props.options)) {
 				// is it an enum?
 				for (const val of this.props.options) {
 					if (typeof val === 'object') {
-						options[val.value] = val.name
+						options[val.value] = { value: val.name }
 					} else {
-						options[val] = val
+						options[val] = { value: val }
 					}
 				}
 			} else if (typeof this.props.options === 'object') {
@@ -845,28 +852,38 @@ const EditAttributeMultiSelect = wrapEditAttribute(
 							// key is a number (the key)
 							const enumValue = this.props.options[key]
 							const enumKey = this.props.options[enumValue]
-							options[enumKey] = enumValue
+							options[enumKey] = { value: enumValue }
 						}
 					}
 				} else {
 					for (const key in this.props.options) {
 						const val = this.props.options[key]
 						if (Array.isArray(val)) {
-							options[key] = val
+							options[key] = { value: val }
 						} else {
-							options[val] = key + ': ' + val
+							options[val] = { value: key + ': ' + val }
 						}
 					}
 				}
 			}
 
-			return options
+			const currentValue = this.getAttribute()
+			const missingOptions = Array.isArray(currentValue) ? currentValue.filter((v) => !(v in options)) : []
+
+			if (addOptionsForCurrentValue) {
+				missingOptions.forEach((option) => {
+					options[option] = { value: `${option}`, className: 'option-missing' }
+				})
+			}
+
+			return { options, currentOptionMissing: !!missingOptions.length }
 		}
 		render() {
+			const options = this.getOptions(true)
 			return (
 				<MultiSelect
-					className={this.props.className}
-					availableOptions={this.getOptions()}
+					className={ClassNames(this.props.className, options.currentOptionMissing && 'option-missing')}
+					availableOptions={options.options}
 					value={this.getAttribute()}
 					placeholder={this.props.label}
 					onChange={this.handleChange}

--- a/meteor/client/styles/multiSelect.scss
+++ b/meteor/client/styles/multiSelect.scss
@@ -1,3 +1,5 @@
+@import 'colorScheme';
+
 .expco {
 	user-select: none;
 
@@ -24,6 +26,10 @@
 		}
 	}
 
+	.expco-title span:not(:last-child):after {
+		content: ', ';
+	}
+
 	&:not(.expco-expanded) {
 		.action-btn.expco-expand {
 			transform: rotate(180deg);
@@ -47,6 +53,10 @@
 
 	&.expco-popper.expco-popper-rounded {
 		border-radius: 4px;
+	}
+
+	&.option-missing {
+		border-color: $color-status-fatal;
 	}
 }
 

--- a/meteor/client/styles/settings.scss
+++ b/meteor/client/styles/settings.scss
@@ -209,6 +209,14 @@
 			color: $color-status-warning;
 		}
 	}
+
+	.option-missing {
+		text-decoration: line-through;
+	}
+
+	select.option-missing {
+		border-color: $color-status-fatal;
+	}
 }
 
 .btn-add-new {

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -555,7 +555,7 @@ export class ConfigManifestTable<
 						<tbody>
 							{_.map(vals, (val, i) => (
 								<tr key={sortedIndices[i]}>
-									{_.map(configEntry.columns, (col) => (
+									{_.map(this.state.resolvedColumns, (col) => (
 										<td key={col.id}>
 											{getEditAttribute(
 												this.props.collection,

--- a/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
@@ -1443,6 +1443,7 @@ const ShowStyleVariantsSettings = withTranslation()(
 												collection={ShowStyleVariants}
 												configPath={'blueprintConfig'}
 												object={showStyleVariant}
+												alternateObject={this.props.showStyleBase}
 												layerMappings={this.props.layerMappings}
 												sourceLayers={this.props.sourceLayers}
 												subPanel={true}

--- a/packages/blueprints-integration/src/config.ts
+++ b/packages/blueprints-integration/src/config.ts
@@ -15,6 +15,7 @@ export enum ConfigManifestEntryType {
 	SELECT = 'select',
 	SOURCE_LAYERS = 'source_layers',
 	LAYER_MAPPINGS = 'layer_mappings',
+	SELECT_FROM_COLUMN = 'select_from_column',
 	JSON = 'json',
 }
 
@@ -28,6 +29,8 @@ export type BasicConfigManifestEntry =
 	| ConfigManifestEntryEnum
 	| ConfigManifestEntrySelectFromOptions<true>
 	| ConfigManifestEntrySelectFromOptions<false>
+	| ConfigManifestEntrySelectFromColumn<true>
+	| ConfigManifestEntrySelectFromColumn<false>
 	| ConfigManifestEntrySourceLayers<true>
 	| ConfigManifestEntrySourceLayers<false>
 	| ConfigManifestEntryLayerMappings<true>
@@ -107,6 +110,15 @@ export interface ConfigManifestEntrySelectFromOptions<Multiple extends boolean>
 	extends ConfigManifestEntrySelectBase<Multiple> {
 	type: ConfigManifestEntryType.SELECT
 	options: string[]
+}
+
+export interface ConfigManifestEntrySelectFromColumn<Multiple extends boolean>
+	extends ConfigManifestEntrySelectBase<Multiple> {
+	type: ConfigManifestEntryType.SELECT_FROM_COLUMN
+	/** The id of a ConfigManifestEntryTable in the same config manifest */
+	tableId: string
+	/** The id of a BasicConfigManifestEntry in the table */
+	columnId: string
 }
 
 export interface ConfigManifestEntrySourceLayers<Multiple extends boolean>


### PR DESCRIPTION
Adds new config manifest entry type, called `ConfigManifestEntrySelectFromColumn`, which allows populating dropdowns (single or multiple choice) with all values from a column in a different (or the same) config table. 
for Show Style Variants, if the variant does not override the source table, values from the Base Show Style are used. 

### An example (with a multiselect):
For a table with the following text values,
![image](https://user-images.githubusercontent.com/9103996/192490615-77e57009-6910-4d50-8217-12e6353e0efb.png)
the following dropdowns can be automatically populated in another table (or as a single config field)
![image](https://user-images.githubusercontent.com/9103996/192491027-e057ed15-bd24-43e0-861c-38cdb83034b7.png)
If a value that was previously selected no longer exists in the source column, the dropdown will have a red border, and the option will be crossed out
![image](https://user-images.githubusercontent.com/9103996/192491687-009745ff-ea4d-4cc0-a281-e90dfacef9b6.png)
