### PR TITLE
fix: stuck Parts.expectedDurationWithPreroll migration

### DIFF
--- a/meteor/server/migration/1_39_0.ts
+++ b/meteor/server/migration/1_39_0.ts
@@ -17,6 +17,9 @@ export const addSteps = addMigrationSteps('1.39.0', [
 		canBeRunAutomatically: true,
 		validate: () => {
 			const objects = Parts.find({
+				expectedDuration: {
+					$exists: true,
+				},
 				expectedDurationWithPreroll: {
 					$exists: false,
 				},
@@ -28,6 +31,9 @@ export const addSteps = addMigrationSteps('1.39.0', [
 		},
 		migrate: () => {
 			const objects = Parts.find({
+				expectedDuration: {
+					$exists: true,
+				},
 				expectedDurationWithPreroll: {
 					$exists: false,
 				},


### PR DESCRIPTION
Fixes a migration that was bothering me after Resetting All Versions. 
`expectedDuration` and `expectedDurationWithPreroll` can be undefined, but the migration did not consider that valid