### PR TITLE
chore: Enable workflow_dispath for publishing to npm & bump to 46.0.0

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -7,6 +7,7 @@ on:
     tags:
       - "v**"
   pull_request:
+  workflow_dispatch:
 
 jobs:
   lint-core:
@@ -381,7 +382,7 @@ jobs:
     timeout-minutes: 15
 
     # only run for tags
-    if: contains(github.ref, 'refs/tags/')
+    if: contains(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
 
     needs:
       - test-packages

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -420,6 +420,7 @@ jobs:
 
             cd packages/${{ matrix.package-name }}
             PACKAGE_NAME=$(yarn info -s . name)
+            PACKAGE_NAME=${PACKAGE_NAME/@sofie-automation/@tv2media}
             PUBLISHED_VERSION=$(yarn info -s $PACKAGE_NAME version)
             THIS_VERSION=$(node -p "require('./package.json').version")
             NPM_TAG=$(node ../../scripts/determine-npm-tag.js $PUBLISHED_VERSION $THIS_VERSION)

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -381,7 +381,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
-    # only run for tags
+    # only run for tags or manual triggers
     if: contains(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
 
     needs:

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "automation-core",
-	"version": "42.0.0",
+	"version": "46.0.0",
 	"private": true,
 	"engines": {
 		"node": ">=14.19.1"

--- a/meteor/server/migration/currentSystemVersion.ts
+++ b/meteor/server/migration/currentSystemVersion.ts
@@ -49,4 +49,4 @@
  */
 
 // Note: Only set this to release versions, (ie X.Y.Z), not pre-releases (ie X.Y.Z-0-pre-release)
-export const CURRENT_SYSTEM_VERSION = '42.0.0'
+export const CURRENT_SYSTEM_VERSION = '46.0.0'

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/blueprints-integration",
-	"version": "42.0.2",
+	"version": "46.0.0",
 	"description": "Library to define the interaction between core and the blueprints.",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",

--- a/packages/corelib/package.json
+++ b/packages/corelib/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/corelib",
-	"version": "42.0.0",
+	"version": "46.0.0",
 	"private": true,
 	"description": "Internal library for some types shared by core and workers",
 	"main": "dist/index.js",

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sofie-documentation",
-	"version": "42.0.0",
+	"version": "46.0.0",
 	"private": true,
 	"scripts": {
 		"docusaurus": "docusaurus",

--- a/packages/job-worker/package.json
+++ b/packages/job-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/job-worker",
-	"version": "42.0.0",
+	"version": "46.0.0",
 	"description": "Worker for things",
 	"main": "dist/index.js",
 	"license": "MIT",

--- a/packages/lerna.json
+++ b/packages/lerna.json
@@ -1,5 +1,5 @@
 {
-	"version": "42.0.0",
+	"version": "46.0.0",
 	"npmClient": "yarn",
 	"useWorkspaces": true
 }

--- a/packages/mos-gateway/package.json
+++ b/packages/mos-gateway/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mos-gateway",
-	"version": "42.0.0",
+	"version": "46.0.0",
 	"private": true,
 	"description": "MOS-Gateway for the Sofie project",
 	"license": "MIT",

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "playout-gateway",
-	"version": "42.0.0",
+	"version": "46.0.0",
 	"private": true,
 	"description": "Connect to Core, play stuff",
 	"license": "MIT",

--- a/packages/server-core-integration/package.json
+++ b/packages/server-core-integration/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/server-core-integration",
-	"version": "42.0.0",
+	"version": "46.0.0",
 	"description": "Library for connecting to Core",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/shared-lib",
-	"version": "1.46.0-in-testing",
+	"version": "46.0.0",
 	"private": false,
 	"description": "Library for types & values shared by core, workers and gateways",
 	"main": "dist/index.js",

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3092,12 +3092,8 @@
     webpack-sources "^3.2.2"
 
 "@sofie-automation/blueprints-integration@link:blueprints-integration":
-  version "42.0.1"
-  dependencies:
-    "@sofie-automation/shared-lib" "link:shared-lib"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@2.2.1"
-    tslib "^2.4.0"
-    type-fest "^2.19.0"
+  version "0.0.0"
+  uid ""
 
 "@sofie-automation/code-standard-preset@~2.0.2":
   version "2.0.2"


### PR DESCRIPTION
Fixes the release-libs job to use our scope override hack in the `Check release is desired` step. Makes this job run on the workflow_dispath event (manualy by pressing the button on GitHub) so that we don't have to push to npm from local machines.
Sets version numbers to 46.0.0 so that we roughly know what we're using.