### PR TITLE
chore: Fix package scope overriding for npm packages

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  # set only if you want to override the @sofie-automation scope
+  PACKAGE_SCOPE_OVERRIDE: "@tv2media"
+
 jobs:
   lint-core:
     name: Typecheck and Lint Core
@@ -420,7 +424,7 @@ jobs:
 
             cd packages/${{ matrix.package-name }}
             PACKAGE_NAME=$(yarn info -s . name)
-            PACKAGE_NAME=${PACKAGE_NAME/@sofie-automation/@tv2media}
+            [[ -n "$PACKAGE_SCOPE_OVERRIDE" ]] && PACKAGE_NAME=${PACKAGE_NAME/@sofie-automation/"$PACKAGE_SCOPE_OVERRIDE"}
             PUBLISHED_VERSION=$(yarn info -s $PACKAGE_NAME version)
             THIS_VERSION=$(node -p "require('./package.json').version")
             NPM_TAG=$(node ../../scripts/determine-npm-tag.js $PUBLISHED_VERSION $THIS_VERSION)
@@ -437,14 +441,13 @@ jobs:
         env:
           CI: true
       - name: Modify dependencies to use npm packages
-        run: node scripts/prepublish.js
+        run: node scripts/prepublish.js $PACKAGE_SCOPE_OVERRIDE
       - name: Publish to NPM
         if: ${{ steps.do-publish.outputs.tag }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
           cd packages/${{ matrix.package-name }}
           NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "`jq '.name |= sub("@sofie-automation";"@tv2media")' package.json --tab`" > package.json
           yarn publish --access=public --new-version=$NEW_VERSION --network-timeout 100000 --tag ${{ steps.do-publish.outputs.tag }}
         env:
           CI: true

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/blueprints-integration",
-	"version": "46.0.0",
+	"version": "46.0.1",
 	"description": "Library to define the interaction between core and the blueprints.",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",

--- a/packages/server-core-integration/package.json
+++ b/packages/server-core-integration/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/server-core-integration",
-	"version": "46.0.0",
+	"version": "46.0.1",
 	"description": "Library for connecting to Core",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -8,13 +8,13 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/nrkno/tv-automation-server-core.git",
+		"url": "git+https://github.com/tv2/tv-automation-server-core.git",
 		"directory": "packages/sharelib"
 	},
 	"bugs": {
-		"url": "https://github.com/nrkno/tv-automation-server-core/issues"
+		"url": "https://github.com/tv2/tv-automation-server-core/issues"
 	},
-	"homepage": "https://github.com/nrkno/tv-automation-server-core/blob/master/packages/sharelib#readme",
+	"homepage": "https://github.com/tv2/tv-automation-server-core/blob/master/packages/shared-lib#readme",
 	"scripts": {
 		"build": "rimraf dist && yarn build:main",
 		"build:main": "tsc -p tsconfig.build.json",

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3092,7 +3092,7 @@
     webpack-sources "^3.2.2"
 
 "@sofie-automation/blueprints-integration@link:blueprints-integration":
-  version "46.0.0"
+  version "46.0.1"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
     timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@2.2.2"
@@ -3136,7 +3136,7 @@
     underscore "^1.13.4"
 
 "@sofie-automation/server-core-integration@link:server-core-integration":
-  version "46.0.0"
+  version "46.0.1"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
     ejson "^2.2.3"

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -12,6 +12,11 @@ const path = require('path')
 
 const basePath = path.resolve('./packages')
 
+/**
+ * Argument allowing to override the default package scope in forks
+ * Will change the package names from @sofie-automation/<package-name> to <scopeOverride>/<package-name>
+ */
+const scopeOverride = process.argv[2]
 
 ;(async() => {
 
@@ -29,30 +34,36 @@ const basePath = path.resolve('./packages')
         // exists?
         if (!await exists(packagePath)) continue
 
+        const package = require(packagePath)
         packages.push({
             packagePath,
-            package: require(packagePath)
+            package,
+            originalName: package.name
         })
     }
 
 
     for (const p of packages) {
-
         let changed = false
         // Rewrite internal dependencies to target the correct version, so that it works when published to npm:
-        for (const dep of Object.keys(p.package.dependencies || {})) {
+        for (const depName of Object.keys(p.package.dependencies || {})) {
 
-            const foundPackage = packages.find(p => p.package.name === dep)
+            const foundPackage = packages.find(p => p.originalName === depName)
             if (foundPackage) {
-                if (p.package.dependencies[dep] !== foundPackage.package.version) {
-                    p.package.dependencies[dep] = foundPackage.package.version
+                if (p.package.dependencies[depName] !== foundPackage.package.version) {
+                    modifyDependency(depName, p.package.dependencies, foundPackage.package.version)
                     changed = true
                 }
             }
         }
+        const packageName = p.package.name.split('/')
+        if (scopeOverride && packageName.length === 2) {
+            p.package.name = `${scopeOverride}/${packageName[1]}`
+            changed = true
+        }
         if (changed) {
             await fsp.writeFile(p.packagePath, JSON.stringify(p.package, null, '\t')+'\n')
-            console.log(`Updated ${p.package.name}`)
+            console.log(`Updated ${p.originalName !== p.package.name ? p.originalName + ' -> ' : ''}${p.package.name}`)
         }
     }
 
@@ -63,6 +74,13 @@ const basePath = path.resolve('./packages')
 })
 
 
+
+function modifyDependency(depName, dependencies, version) {
+    const oldDepName = depName.split('/')
+    dependencies[depName] = scopeOverride && oldDepName.length === 2
+        ? `npm:${scopeOverride}/${oldDepName[1]}@${version}`
+        : version
+}
 
 async function exists(checkPath) {
     try {


### PR DESCRIPTION
Adds optional argument for overriding package scope in the prepublish.js script.
Updates some versions that I broke by pushing to npm libs dependent on the wrong shared-lib.