### PR TITLE
chore: bump blueprints-integration to 46.0.3

### DIFF
--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/blueprints-integration",
-	"version": "46.0.2",
+	"version": "46.0.3",
 	"description": "Library to define the interaction between core and the blueprints.",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",


### PR DESCRIPTION
Does not contain any code changes, but we need a new version because 46.0.2 got broken on NPM