### PR TITLE
Sof 1119/Copy Import Export Variants

### DIFF
--- a/meteor/client/ui/Settings/ShowStyle/VariantSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/VariantSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ClassNames from 'classnames'
-import { faPencilAlt, faTrash, faCheck, faPlus } from '@fortawesome/free-solid-svg-icons'
+import { faPencilAlt, faTrash, faCheck, faPlus, faDownload, faUpload, faCopy } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ConfigManifestEntry, SourceLayerType } from '@sofie-automation/blueprints-integration'
 import { MappingsExt } from '@sofie-automation/corelib/dist/dataModel/Studio'
@@ -13,6 +13,7 @@ import { EditAttribute } from '../../../lib/EditAttribute'
 import { doModalDialog } from '../../../lib/ModalDialog'
 import { Translated } from '../../../lib/ReactMeteorData/ReactMeteorData'
 import { ConfigManifestSettings } from '../ConfigManifestSettings'
+import { UploadButton } from '../../../lib/uploadButton'
 
 interface IShowStyleVariantsProps {
 	showStyleBase: ShowStyleBase
@@ -36,6 +37,28 @@ export const ShowStyleVariantsSettings = withTranslation()(
 			this.state = {
 				editedMappings: [],
 			}
+		}
+		downloadVariant = (showstyleVariant: ShowStyleVariant) => {
+			const jsonStr = JSON.stringify(showstyleVariant)
+
+			const element = document.createElement('a')
+			element.href = URL.createObjectURL(new Blob([jsonStr], { type: 'application/json' }))
+			element.download = `${showstyleVariant.name}_showstyleVariant_${showstyleVariant._id}.json`
+
+			document.body.appendChild(element) // Required for this to work in FireFox
+			element.click()
+			document.body.removeChild(element) // Required for this to work in FireFox
+		}
+		downloadAllVariants = () => {
+			const jsonStr = JSON.stringify(this.props.showStyleVariants)
+
+			const element = document.createElement('a')
+			element.href = URL.createObjectURL(new Blob([jsonStr], { type: 'application/json' }))
+			element.download = `All variants_${this.props.showStyleBase._id}.json`
+
+			document.body.appendChild(element) // Required for this to work in FireFox
+			element.click()
+			document.body.removeChild(element) // Required for this to work in FireFox
 		}
 		isItemEdited = (layerId: ProtectedString<any>) => {
 			return this.state.editedMappings.indexOf(layerId) >= 0
@@ -94,10 +117,16 @@ export const ShowStyleVariantsSettings = withTranslation()(
 								hl: this.isItemEdited(showStyleVariant._id),
 							})}
 						>
-							<th className="settings-studio-showStyleVariant__name c3">
+							<th className="draghandle settings-studio-showStyleVariant__name c3">
 								{showStyleVariant.name || t('Unnamed variant')}
 							</th>
 							<td className="settings-studio-showStyleVariant__actions table-item-actions c3">
+								<button className="action-btn" onClick={() => this.downloadVariant(showStyleVariant)}>
+									<FontAwesomeIcon icon={faDownload} />
+								</button>
+								<button className="action-btn">
+									<FontAwesomeIcon icon={faCopy} />
+								</button>
 								<button className="action-btn" onClick={() => this.editItem(showStyleVariant._id)}>
 									<FontAwesomeIcon icon={faPencilAlt} />
 								</button>
@@ -159,12 +188,21 @@ export const ShowStyleVariantsSettings = withTranslation()(
 			return (
 				<div>
 					<h2 className="mhn">{t('Variants')}</h2>
+					<div className="mod mhs"></div>
 					<table className="table expando settings-studio-showStyleVariants-table">
 						<tbody>{this.renderShowStyleVariants()}</tbody>
 					</table>
 					<div className="mod mhs">
 						<button className="btn btn-primary" onClick={this.onAddShowStyleVariant}>
 							<FontAwesomeIcon icon={faPlus} />
+						</button>
+						<UploadButton className="btn btn-secondary mls" accept="application/json,.json">
+							<FontAwesomeIcon icon={faUpload} />
+							&nbsp;{t('Import')}
+						</UploadButton>
+						<button className="btn btn-secondary mls" onClick={this.downloadAllVariants}>
+							<FontAwesomeIcon icon={faDownload} />
+							&nbsp;{t('Export')}
 						</button>
 					</div>
 				</div>

--- a/meteor/client/ui/Settings/ShowStyle/VariantSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/VariantSettings.tsx
@@ -38,6 +38,15 @@ export const ShowStyleVariantsSettings = withTranslation()(
 				editedMappings: [],
 			}
 		}
+		copyVariant = (showStyleVariant: ShowStyleVariant) => {
+			MeteorCall.showstyles
+				.insertShowStyleVariantWithBlueprint(
+					showStyleVariant.showStyleBaseId,
+					showStyleVariant.blueprintConfig,
+					showStyleVariant.name
+				)
+				.catch(console.error)
+		}
 		downloadVariant = (showstyleVariant: ShowStyleVariant) => {
 			const jsonStr = JSON.stringify(showstyleVariant)
 
@@ -117,14 +126,14 @@ export const ShowStyleVariantsSettings = withTranslation()(
 								hl: this.isItemEdited(showStyleVariant._id),
 							})}
 						>
-							<th className="draghandle settings-studio-showStyleVariant__name c3">
+							<th className="settings-studio-showStyleVariant__name c3">
 								{showStyleVariant.name || t('Unnamed variant')}
 							</th>
 							<td className="settings-studio-showStyleVariant__actions table-item-actions c3">
 								<button className="action-btn" onClick={() => this.downloadVariant(showStyleVariant)}>
 									<FontAwesomeIcon icon={faDownload} />
 								</button>
-								<button className="action-btn">
+								<button className="action-btn" onClick={() => this.copyVariant(showStyleVariant)}>
 									<FontAwesomeIcon icon={faCopy} />
 								</button>
 								<button className="action-btn" onClick={() => this.editItem(showStyleVariant._id)}>

--- a/meteor/client/ui/Settings/ShowStyle/VariantSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/VariantSettings.tsx
@@ -109,8 +109,8 @@ export const ShowStyleVariantsSettings = withTranslation()(
 		}
 
 		private downloadShowStyleVariant = (showStyleVariant: ShowStyleVariant): void => {
-			const variantArray = [showStyleVariant]
-			const jsonStr = JSON.stringify(variantArray)
+			const showStyleVariants = [showStyleVariant]
+			const jsonStr = JSON.stringify(showStyleVariants)
 			const fileName = `${showStyleVariant.name}_showstyleVariant_${showStyleVariant._id}.json`
 			this.download(jsonStr, fileName)
 		}

--- a/meteor/client/ui/Settings/ShowStyle/VariantSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/VariantSettings.tsx
@@ -61,9 +61,9 @@ export const ShowStyleVariantsSettings = withTranslation()(
 
 				const uploadFileContents = (progressEvent.target as any).result
 
-				let newVariants: ShowStyleVariant[]
+				const newVariants: ShowStyleVariant[] = []
 				try {
-					newVariants = JSON.parse(uploadFileContents)
+					JSON.parse(uploadFileContents).map((variant) => newVariants.push(variant))
 					if (!_.isArray(newVariants)) {
 						throw new Error('Imported file did not contain an array')
 					}
@@ -87,14 +87,12 @@ export const ShowStyleVariantsSettings = withTranslation()(
 		importVariantsFromArray = (variants: ShowStyleVariant[]) => {
 			const { t } = this.props
 			_.forEach(variants, (entry: ShowStyleVariant) => {
-				MeteorCall.showstyles.insertShowStyleVariantWithBlueprint(entry, entry._id).catch((error) => {
+				MeteorCall.showstyles.insertShowStyleVariantWithBlueprint(entry, entry._id).catch(() => {
 					NotificationCenter.push(
 						new Notification(
 							undefined,
 							NoticeLevel.WARNING,
-							t(`Failed to import Variant ${entry.name}. Make sure it is not already imported.`, {
-								errorMessage: error + '',
-							}),
+							t('Failed to import Variant {{name}}. Make sure it is not already imported.', { name: entry.name }),
 							'VariantSettings'
 						)
 					)

--- a/meteor/lib/api/showStyles.ts
+++ b/meteor/lib/api/showStyles.ts
@@ -1,9 +1,15 @@
 import { ShowStyleBaseId } from '../collections/ShowStyleBases'
 import { ShowStyleVariantId } from '../collections/ShowStyleVariants'
+import { IBlueprintConfig } from '@sofie-automation/blueprints-integration'
 
 export interface NewShowStylesAPI {
 	insertShowStyleBase(): Promise<ShowStyleBaseId>
 	insertShowStyleVariant(showStyleBaseId: ShowStyleBaseId): Promise<ShowStyleVariantId>
+	insertShowStyleVariantWithBlueprint(
+		showStyleBaseId: ShowStyleBaseId,
+		blueprintConfig: IBlueprintConfig,
+		name: string
+	): Promise<ShowStyleVariantId>
 	removeShowStyleBase(showStyleBaseId: ShowStyleBaseId): Promise<void>
 	removeShowStyleVariant(showStyleVariantId: ShowStyleVariantId): Promise<void>
 }
@@ -11,6 +17,7 @@ export interface NewShowStylesAPI {
 export enum ShowStylesAPIMethods {
 	'insertShowStyleBase' = 'showstyles.insertShowStyleBase',
 	'insertShowStyleVariant' = 'showstyles.insertShowStyleVariant',
+	'insertShowStyleVariantWithBlueprint' = 'showstyles.insertShowStyleVariantWithBlueprint',
 	'removeShowStyleBase' = 'showstyles.removeShowStyleBase',
 	'removeShowStyleVariant' = 'showstyles.removeShowStyleVariant',
 }

--- a/meteor/lib/api/showStyles.ts
+++ b/meteor/lib/api/showStyles.ts
@@ -1,16 +1,12 @@
 import { ShowStyleBaseId } from '../collections/ShowStyleBases'
-import { ShowStyleVariantId } from '../collections/ShowStyleVariants'
-import { IBlueprintConfig } from '@sofie-automation/blueprints-integration'
+import { ShowStyleVariant, ShowStyleVariantId } from '../collections/ShowStyleVariants'
 
 export interface NewShowStylesAPI {
 	insertShowStyleBase(): Promise<ShowStyleBaseId>
 	insertShowStyleVariant(showStyleBaseId: ShowStyleBaseId): Promise<ShowStyleVariantId>
 	insertShowStyleVariantWithBlueprint(
-		showStyleBaseId: ShowStyleBaseId,
-		blueprintConfig: IBlueprintConfig,
-		_id: ShowStyleVariantId,
-		rundownVersionHash: string,
-		name: string
+		showStyleVariant: ShowStyleVariant,
+		id?: ShowStyleVariantId
 	): Promise<ShowStyleVariantId>
 	removeShowStyleBase(showStyleBaseId: ShowStyleBaseId): Promise<void>
 	removeShowStyleVariant(showStyleVariantId: ShowStyleVariantId): Promise<void>

--- a/meteor/lib/api/showStyles.ts
+++ b/meteor/lib/api/showStyles.ts
@@ -4,7 +4,7 @@ import { ShowStyleVariant, ShowStyleVariantId } from '../collections/ShowStyleVa
 export interface NewShowStylesAPI {
 	insertShowStyleBase(): Promise<ShowStyleBaseId>
 	insertShowStyleVariant(showStyleBaseId: ShowStyleBaseId): Promise<ShowStyleVariantId>
-	insertShowStyleVariantWithBlueprint(
+	insertShowStyleVariantWithProperties(
 		showStyleVariant: ShowStyleVariant,
 		id?: ShowStyleVariantId
 	): Promise<ShowStyleVariantId>
@@ -15,7 +15,7 @@ export interface NewShowStylesAPI {
 export enum ShowStylesAPIMethods {
 	'insertShowStyleBase' = 'showstyles.insertShowStyleBase',
 	'insertShowStyleVariant' = 'showstyles.insertShowStyleVariant',
-	'insertShowStyleVariantWithBlueprint' = 'showstyles.insertShowStyleVariantWithBlueprint',
+	'insertShowStyleVariantWithProperties' = 'showstyles.insertShowStyleVariantWithProperties',
 	'removeShowStyleBase' = 'showstyles.removeShowStyleBase',
 	'removeShowStyleVariant' = 'showstyles.removeShowStyleVariant',
 }

--- a/meteor/lib/api/showStyles.ts
+++ b/meteor/lib/api/showStyles.ts
@@ -8,6 +8,8 @@ export interface NewShowStylesAPI {
 	insertShowStyleVariantWithBlueprint(
 		showStyleBaseId: ShowStyleBaseId,
 		blueprintConfig: IBlueprintConfig,
+		_id: ShowStyleVariantId,
+		rundownVersionHash: string,
 		name: string
 	): Promise<ShowStyleVariantId>
 	removeShowStyleBase(showStyleBaseId: ShowStyleBaseId): Promise<void>

--- a/meteor/server/api/showStyles.ts
+++ b/meteor/server/api/showStyles.ts
@@ -83,36 +83,29 @@ export async function insertShowStyleVariant(
 
 	return insertShowStyleVariantInner(showStyleBase, name)
 }
-export async function insertShowStyleVariantInner(
-	showStyleBase: ShowStyleBaseLight,
-	name?: string
-): Promise<ShowStyleVariantId> {
-	return ShowStyleVariants.insertAsync({
-		_id: getRandomId(),
-		showStyleBaseId: showStyleBase._id,
-		name: name || 'Variant',
-		blueprintConfig: {},
-		_rundownVersionHash: '',
-	})
-}
 export async function insertShowStyleVariantWithBlueprint(
 	context: MethodContext | Credentials,
-	showStyleBaseId: ShowStyleBaseId,
-	blueprintConfig: IBlueprintConfig,
-	_id: ShowStyleVariantId,
-	_rundownVersionHash: string,
-	name?: string
+	showStyleVariant: ShowStyleVariant,
+	id?: ShowStyleVariantId
 ): Promise<ShowStyleVariantId> {
-	const access = await ShowStyleContentWriteAccess.anyContent(context, showStyleBaseId)
+	const access = await ShowStyleContentWriteAccess.anyContent(context, showStyleVariant.showStyleBaseId)
 	const showStyleBase = access.showStyleBase
-	if (!showStyleBase) throw new Meteor.Error(404, `showStyleBase "${showStyleBaseId}" not found`)
+	if (!showStyleBase) throw new Meteor.Error(404, `showStyleBase "${showStyleVariant.showStyleBaseId}" not found`)
 
+	return insertShowStyleVariantInner(showStyleBase, showStyleVariant.name, id, showStyleVariant.blueprintConfig)
+}
+export async function insertShowStyleVariantInner(
+	showStyleBase: ShowStyleBaseLight,
+	name?: string,
+	id?: ShowStyleVariantId,
+	blueprintConfig?: IBlueprintConfig
+): Promise<ShowStyleVariantId> {
 	return ShowStyleVariants.insertAsync({
-		_id: _id,
-		showStyleBaseId: showStyleBaseId,
-		name: name || 'Copied variant',
-		blueprintConfig: blueprintConfig,
-		_rundownVersionHash: _rundownVersionHash,
+		_id: id || getRandomId(),
+		showStyleBaseId: showStyleBase._id,
+		name: name || 'Variant',
+		blueprintConfig: blueprintConfig || {},
+		_rundownVersionHash: '',
 	})
 }
 export async function removeShowStyleBase(context: MethodContext, showStyleBaseId: ShowStyleBaseId): Promise<void> {
@@ -151,21 +144,8 @@ class ServerShowStylesAPI extends MethodContextAPI implements NewShowStylesAPI {
 	async insertShowStyleVariant(showStyleBaseId: ShowStyleBaseId) {
 		return insertShowStyleVariant(this, showStyleBaseId)
 	}
-	async insertShowStyleVariantWithBlueprint(
-		showStyleBaseId: ShowStyleBaseId,
-		blueprintConfig: IBlueprintConfig,
-		_id: ShowStyleVariantId,
-		_rundownVersionHash: string,
-		name: string
-	) {
-		return insertShowStyleVariantWithBlueprint(
-			this,
-			showStyleBaseId,
-			blueprintConfig,
-			_id,
-			_rundownVersionHash,
-			name
-		)
+	async insertShowStyleVariantWithBlueprint(showStyleVariant: ShowStyleVariant, id?: ShowStyleVariantId) {
+		return insertShowStyleVariantWithBlueprint(this, showStyleVariant, id)
 	}
 	async removeShowStyleBase(showStyleBaseId: ShowStyleBaseId) {
 		return removeShowStyleBase(this, showStyleBaseId)

--- a/meteor/server/api/showStyles.ts
+++ b/meteor/server/api/showStyles.ts
@@ -18,6 +18,7 @@ import { Credentials } from '../security/lib/credentials'
 import { OrganizationId } from '../../lib/collections/Organization'
 import deepmerge from 'deepmerge'
 import { ShowStyleBaseLight } from '../../lib/collections/optimizations'
+import { IBlueprintConfig } from '@sofie-automation/blueprints-integration'
 
 export async function getShowStyleCompound(
 	showStyleVariantId: ShowStyleVariantId
@@ -94,6 +95,24 @@ export async function insertShowStyleVariantInner(
 		_rundownVersionHash: '',
 	})
 }
+export async function insertShowStyleVariantWithBlueprint(
+	context: MethodContext | Credentials,
+	showStyleBaseId: ShowStyleBaseId,
+	blueprintConfig: IBlueprintConfig,
+	name?: string
+): Promise<ShowStyleVariantId> {
+	const access = await ShowStyleContentWriteAccess.anyContent(context, showStyleBaseId)
+	const showStyleBase = access.showStyleBase
+	if (!showStyleBase) throw new Meteor.Error(404, `showStyleBase "${showStyleBaseId}" not found`)
+
+	return ShowStyleVariants.insertAsync({
+		_id: getRandomId(),
+		showStyleBaseId: showStyleBaseId,
+		name: 'Copy of ' + name || 'Copied variant',
+		blueprintConfig: blueprintConfig,
+		_rundownVersionHash: '',
+	})
+}
 export async function removeShowStyleBase(context: MethodContext, showStyleBaseId: ShowStyleBaseId): Promise<void> {
 	check(showStyleBaseId, String)
 	const access = await ShowStyleContentWriteAccess.anyContent(context, showStyleBaseId)
@@ -129,6 +148,13 @@ class ServerShowStylesAPI extends MethodContextAPI implements NewShowStylesAPI {
 	}
 	async insertShowStyleVariant(showStyleBaseId: ShowStyleBaseId) {
 		return insertShowStyleVariant(this, showStyleBaseId)
+	}
+	async insertShowStyleVariantWithBlueprint(
+		showStyleBaseId: ShowStyleBaseId,
+		blueprintConfig: IBlueprintConfig,
+		name: string
+	) {
+		return insertShowStyleVariantWithBlueprint(this, showStyleBaseId, blueprintConfig, name)
 	}
 	async removeShowStyleBase(showStyleBaseId: ShowStyleBaseId) {
 		return removeShowStyleBase(this, showStyleBaseId)

--- a/meteor/server/api/showStyles.ts
+++ b/meteor/server/api/showStyles.ts
@@ -99,6 +99,8 @@ export async function insertShowStyleVariantWithBlueprint(
 	context: MethodContext | Credentials,
 	showStyleBaseId: ShowStyleBaseId,
 	blueprintConfig: IBlueprintConfig,
+	_id: ShowStyleVariantId,
+	_rundownVersionHash: string,
 	name?: string
 ): Promise<ShowStyleVariantId> {
 	const access = await ShowStyleContentWriteAccess.anyContent(context, showStyleBaseId)
@@ -106,11 +108,11 @@ export async function insertShowStyleVariantWithBlueprint(
 	if (!showStyleBase) throw new Meteor.Error(404, `showStyleBase "${showStyleBaseId}" not found`)
 
 	return ShowStyleVariants.insertAsync({
-		_id: getRandomId(),
+		_id: _id,
 		showStyleBaseId: showStyleBaseId,
-		name: 'Copy of ' + name || 'Copied variant',
+		name: name || 'Copied variant',
 		blueprintConfig: blueprintConfig,
-		_rundownVersionHash: '',
+		_rundownVersionHash: _rundownVersionHash,
 	})
 }
 export async function removeShowStyleBase(context: MethodContext, showStyleBaseId: ShowStyleBaseId): Promise<void> {
@@ -152,9 +154,18 @@ class ServerShowStylesAPI extends MethodContextAPI implements NewShowStylesAPI {
 	async insertShowStyleVariantWithBlueprint(
 		showStyleBaseId: ShowStyleBaseId,
 		blueprintConfig: IBlueprintConfig,
+		_id: ShowStyleVariantId,
+		_rundownVersionHash: string,
 		name: string
 	) {
-		return insertShowStyleVariantWithBlueprint(this, showStyleBaseId, blueprintConfig, name)
+		return insertShowStyleVariantWithBlueprint(
+			this,
+			showStyleBaseId,
+			blueprintConfig,
+			_id,
+			_rundownVersionHash,
+			name
+		)
 	}
 	async removeShowStyleBase(showStyleBaseId: ShowStyleBaseId) {
 		return removeShowStyleBase(this, showStyleBaseId)

--- a/meteor/server/api/showStyles.ts
+++ b/meteor/server/api/showStyles.ts
@@ -83,7 +83,7 @@ export async function insertShowStyleVariant(
 
 	return insertShowStyleVariantInner(showStyleBase, name)
 }
-export async function insertShowStyleVariantWithBlueprint(
+export async function insertShowStyleVariantWithProperties(
 	context: MethodContext | Credentials,
 	showStyleVariant: ShowStyleVariant,
 	id?: ShowStyleVariantId
@@ -144,8 +144,8 @@ class ServerShowStylesAPI extends MethodContextAPI implements NewShowStylesAPI {
 	async insertShowStyleVariant(showStyleBaseId: ShowStyleBaseId) {
 		return insertShowStyleVariant(this, showStyleBaseId)
 	}
-	async insertShowStyleVariantWithBlueprint(showStyleVariant: ShowStyleVariant, id?: ShowStyleVariantId) {
-		return insertShowStyleVariantWithBlueprint(this, showStyleVariant, id)
+	async insertShowStyleVariantWithProperties(showStyleVariant: ShowStyleVariant, id?: ShowStyleVariantId) {
+		return insertShowStyleVariantWithProperties(this, showStyleVariant, id)
 	}
 	async removeShowStyleBase(showStyleBaseId: ShowStyleBaseId) {
 		return removeShowStyleBase(this, showStyleBaseId)


### PR DESCRIPTION
Showstyle variants can now be copied to the bottom of the list, downloaded either as a single variant or all variants together, and imported as well. Imports also work with single variants as well as multiple. 