### PR TITLE
SOF-1175 Move Keyboard globals

### DIFF
--- a/meteor/client/ui/App.tsx
+++ b/meteor/client/ui/App.tsx
@@ -205,7 +205,6 @@ export const App = translateWithTracker(() => {
 					if ('keyboard' in navigator) {
 						// Keyboard Lock: https://wicg.github.io/keyboard-lock/
 						navigator.keyboard
-							// @ts-expect-error Use Keyboard API to lock the keyboard and disable all browser shortcuts, but we check for its availability, so it should be fine.
 							.lock()
 							.catch((e) => console.error('Could not get Keyboard Lock when running as a PWA', e))
 					}

--- a/meteor/client/ui/Shelf/Keyboard/KeyboardPreview.tsx
+++ b/meteor/client/ui/Shelf/Keyboard/KeyboardPreview.tsx
@@ -27,22 +27,6 @@ import { translateMessage } from '@sofie-automation/corelib/dist/TranslatableMes
 
 const _isMacLike = navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) ? true : false
 
-declare global {
-	type KeyboardLayoutMap = Map<string, string>
-
-	type KeyboardLayoutEvents = 'layoutchange'
-
-	interface Keyboard {
-		getLayoutMap(): Promise<KeyboardLayoutMap>
-		addEventListener(type: KeyboardLayoutEvents, listener: EventListener): void
-		removeEventListener(type: KeyboardLayoutEvents, listener: EventListener): void
-	}
-
-	interface Navigator {
-		keyboard: Keyboard
-	}
-}
-
 export enum SpecialKeyPositions {
 	BLANK_SPACE = '$space',
 }

--- a/meteor/client/ui/globals/keyboardGlobals.d.ts
+++ b/meteor/client/ui/globals/keyboardGlobals.d.ts
@@ -1,0 +1,14 @@
+declare type KeyboardLayoutMap = Map<string, string>
+
+declare type KeyboardLayoutEvents = 'layoutchange'
+
+declare interface Keyboard {
+	getLayoutMap(): Promise<KeyboardLayoutMap>
+	addEventListener(type: KeyboardLayoutEvents, listener: EventListener): void
+	removeEventListener(type: KeyboardLayoutEvents, listener: EventListener): void
+	lock(): Promise<undefined>
+}
+
+declare interface Navigator {
+	keyboard: Keyboard
+}

--- a/meteor/client/ui/globals/keyboardGlobals.d.ts
+++ b/meteor/client/ui/globals/keyboardGlobals.d.ts
@@ -6,7 +6,7 @@ declare interface Keyboard {
 	getLayoutMap(): Promise<KeyboardLayoutMap>
 	addEventListener(type: KeyboardLayoutEvents, listener: EventListener): void
 	removeEventListener(type: KeyboardLayoutEvents, listener: EventListener): void
-	lock(): Promise<undefined>
+	lock(keyCodes?: string[]): Promise<undefined>
 }
 
 declare interface Navigator {


### PR DESCRIPTION
Keyboard globals no longer reside in the KeyboardPreview.
Keyboard interface now includes .lock() definition

