### PR TITLE
Sof 1094/automate maintenance mse playlist

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -229,7 +229,11 @@ const EditAttributeText = wrapEditAttribute(
 			this.handleEdit(event.target.value)
 		}
 		handleBlur(event) {
-			this.handleUpdate(event.target.value)
+			let value: string = event.target.value
+			if (value) {
+				value = value.trim()
+			}
+			this.handleUpdate(value)
 		}
 		handleEscape(event) {
 			const e = event as KeyboardEvent

--- a/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
+++ b/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
@@ -105,6 +105,12 @@ export const ConfigManifestEntryComponent = withTranslation()(
 						{t(configField.name)}
 						{this.renderEditAttribute(configField, obj, prefix)}
 						{configField.hint && <span className="text-s dimmed">{t(configField.hint)}</span>}
+						{configField.hint && configField && <span className="text-s dimmed"> - </span>}
+						{configField.defaultVal && (
+							<span className="text-s dimmed">
+								{t("Defaults to '{{defaultVal}}' if left empty", { defaultVal: configField.defaultVal })}
+							</span>
+						)}
 					</label>
 				</div>
 			)

--- a/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
+++ b/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
@@ -105,7 +105,7 @@ export const ConfigManifestEntryComponent = withTranslation()(
 						{t(configField.name)}
 						{this.renderEditAttribute(configField, obj, prefix)}
 						{configField.hint && <span className="text-s dimmed">{t(configField.hint)}</span>}
-						{configField.hint && configField && <span className="text-s dimmed"> - </span>}
+						{configField.hint && configField.defaultVal && <span className="text-s dimmed"> - </span>}
 						{configField.defaultVal && (
 							<span className="text-s dimmed">
 								{t("Defaults to '{{defaultVal}}' if left empty", { defaultVal: configField.defaultVal })}

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -376,6 +376,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 			id: 'options.playlistID',
 			name: '(Optional) Playlist ID',
 			type: ConfigManifestEntryType.STRING,
+			defaultVal: 'SOFIE',
 		},
 		{
 			id: 'options.preloadAllElements',

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -28,7 +28,7 @@ import * as crypto from 'crypto'
 import * as cp from 'child_process'
 
 import * as _ from 'underscore'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
+import { CoreConnection, TableConfigManifestEntry } from '@sofie-automation/server-core-integration'
 import { TimelineObjectCoreExt } from '@sofie-automation/blueprints-integration'
 import { Logger } from 'winston'
 import { disableAtemUpload } from './config'
@@ -43,6 +43,8 @@ import {
 	StatusObject,
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 import { assertNever } from '@sofie-automation/shared-lib/dist/lib/lib'
+import { PLAYOUT_DEVICE_CONFIG } from './configManifest'
+import { ConfigManifestEntry } from '@sofie-automation/shared-lib/dist/core/deviceConfigManifest'
 
 const debug = Debug('playout-gateway')
 
@@ -513,6 +515,7 @@ export class TSRHandler {
 				})
 		}, 10)
 	}
+
 	private async _updateDevices(): Promise<void> {
 		this.logger.debug('updateDevices start')
 
@@ -553,7 +556,7 @@ export class TSRHandler {
 						limitSlowFulfilledCommand: 100,
 						options: {},
 					},
-					orgDeviceOptions
+					this.populateDefaultValuesIfMissing(orgDeviceOptions)
 				)
 
 				if (this._multiThreaded !== null && deviceOptions.isMultiThreaded === undefined) {
@@ -671,6 +674,33 @@ export class TSRHandler {
 		this._triggerupdateExpectedPlayoutItems() // So that any recently created devices will get all the ExpectedPlayoutItems
 		this.logger.debug('updateDevices end')
 	}
+
+	private populateDefaultValuesIfMissing(deviceOptions: DeviceOptionsAny): DeviceOptionsAny {
+		const playoutGatewayDevicesConfig: ConfigManifestEntry | undefined = PLAYOUT_DEVICE_CONFIG.deviceConfig.find(
+			(deviceConfig) => deviceConfig.id === 'devices'
+		)
+		if (!deviceOptions.options || !playoutGatewayDevicesConfig) {
+			return deviceOptions
+		}
+		const deviceConfigs: ConfigManifestEntry[] = (playoutGatewayDevicesConfig as TableConfigManifestEntry).config[
+			deviceOptions.type
+		]
+		deviceConfigs.forEach((configManifestEntry: ConfigManifestEntry) => {
+			if (!configManifestEntry.defaultVal) {
+				return
+			}
+			const attribute = configManifestEntry.id.replace('options.', '')
+			const attributeValue = (deviceOptions.options as any)[attribute]
+			if (!attributeValue) {
+				deviceOptions.options = {
+					...deviceOptions.options,
+					[attribute]: configManifestEntry.defaultVal,
+				}
+			}
+		})
+		return deviceOptions
+	}
+
 	private getDeviceDebug(deviceOptions: DeviceOptionsAny): boolean {
 		return deviceOptions.debug || this._coreHandler.logDebug || false
 	}

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -169,6 +169,8 @@ export class TSRHandler {
 	private _triggerUpdateDevicesCheckAgain = false
 	private _triggerUpdateDevicesTimeout: NodeJS.Timeout | undefined
 
+	private defaultDeviceOptions: { [deviceType: string]: Record<string, any> } = {}
+
 	constructor(logger: Logger) {
 		this.logger = logger
 	}
@@ -193,6 +195,9 @@ export class TSRHandler {
 			useCacheWhenResolving: settings.useCacheWhenResolving === true,
 			proActiveResolve: true,
 		}
+
+		this.defaultDeviceOptions = this.loadSubdeviceConfigurations()
+
 		this.tsr = new Conductor(c)
 		this._triggerupdateTimelineAndMappings('TSRHandler.init()')
 
@@ -275,6 +280,28 @@ export class TSRHandler {
 		this._triggerUpdateDevices()
 		this.logger.debug('tsr init done')
 	}
+
+	private loadSubdeviceConfigurations(): { [deviceType: string]: Record<string, any> } {
+		const playoutGatewayDevicesConfig: ConfigManifestEntry | undefined = PLAYOUT_DEVICE_CONFIG.deviceConfig.find(
+			(deviceConfig: ConfigManifestEntry) => deviceConfig.id === 'devices'
+		)
+		if (!playoutGatewayDevicesConfig) {
+			return {}
+		}
+		const tableConfig: TableConfigManifestEntry = playoutGatewayDevicesConfig as TableConfigManifestEntry
+		const defaultDeviceOptions: { [deviceType: string]: Record<string, any> } = {}
+		for (const deviceType in tableConfig.config) {
+			const configEntries = tableConfig.config[deviceType]
+				.filter((configManifestEntry: ConfigManifestEntry) => configManifestEntry.defaultVal)
+				.map((configManifestEntry: ConfigManifestEntry) => [
+					configManifestEntry.id.replace('options.', ''),
+					configManifestEntry.defaultVal,
+				])
+			defaultDeviceOptions[deviceType] = Object.fromEntries(configEntries)
+		}
+		return defaultDeviceOptions
+	}
+
 	private setupObservers(): void {
 		if (this._observers.length) {
 			this.logger.debug('Clearing observers..')
@@ -676,28 +703,10 @@ export class TSRHandler {
 	}
 
 	private populateDefaultValuesIfMissing(deviceOptions: DeviceOptionsAny): DeviceOptionsAny {
-		const playoutGatewayDevicesConfig: ConfigManifestEntry | undefined = PLAYOUT_DEVICE_CONFIG.deviceConfig.find(
-			(deviceConfig) => deviceConfig.id === 'devices'
+		const options = Object.fromEntries(
+			Object.entries({ ...deviceOptions.options }).filter(([_key, value]) => value !== '')
 		)
-		if (!deviceOptions.options || !playoutGatewayDevicesConfig) {
-			return deviceOptions
-		}
-		const deviceConfigs: ConfigManifestEntry[] = (playoutGatewayDevicesConfig as TableConfigManifestEntry).config[
-			deviceOptions.type
-		]
-		deviceConfigs.forEach((configManifestEntry: ConfigManifestEntry) => {
-			if (!configManifestEntry.defaultVal) {
-				return
-			}
-			const attribute = configManifestEntry.id.replace('options.', '')
-			const attributeValue = (deviceOptions.options as any)[attribute]
-			if (!attributeValue) {
-				deviceOptions.options = {
-					...deviceOptions.options,
-					[attribute]: configManifestEntry.defaultVal,
-				}
-			}
-		})
+		deviceOptions.options = { ...this.defaultDeviceOptions[deviceOptions.type], ...options }
 		return deviceOptions
 	}
 


### PR DESCRIPTION
PlaylistID for VizMSE device now has 'SOFIE' as default.

`defaultVal` values specified in the config manifest for devices will now send those values to the devices if there is no value configured.

The UI will display a text saying "Defaults to {value} if left empty" next to configuration field.

EditAttributeTextComponent now trims its own value, so a value like " " is no longer permitted.