### PR TITLE
Sof 1196/userdefined label on action trigger

### DIFF
--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -514,7 +514,7 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 								keys: hotkeyTriggers,
 								finalKeys: hotkeyFinalKeys,
 								name: pair.name,
-								targetName: adLib.label,
+								targetName: pair.useLabelAsName && pair.name ? pair.name : adLib.label,
 								sourceLayerId: adLib.sourceLayerId,
 							},
 						})

--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -514,7 +514,7 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 								keys: hotkeyTriggers,
 								finalKeys: hotkeyFinalKeys,
 								name: pair.name,
-								targetName: pair.useLabelAsName && pair.name ? pair.name : adLib.label,
+								targetName: pair.useNameForDisplay && pair.name ? pair.name : adLib.label,
 								sourceLayerId: adLib.sourceLayerId,
 							},
 						})

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
@@ -386,6 +386,8 @@ export const TriggeredActionEntry: React.FC<IProps> = React.memo(function Trigge
 							}
 						/>
 						<span className="mls text-s dimmed">{t('Optional description of the action')}</span>
+					</label>
+					<label className="mln mts mbs">
 						<EditAttribute
 							type="checkbox"
 							className="mls"
@@ -393,7 +395,7 @@ export const TriggeredActionEntry: React.FC<IProps> = React.memo(function Trigge
 							collection={TriggeredActions}
 							attribute="useLabelAsName"
 						></EditAttribute>
-						<span className="text-s dimmed">{t('Use label as name')}</span>
+						<span className="text-s">{t('Use label as name')}</span>
 					</label>
 				</>
 			) : null}

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
@@ -386,6 +386,14 @@ export const TriggeredActionEntry: React.FC<IProps> = React.memo(function Trigge
 							}
 						/>
 						<span className="mls text-s dimmed">{t('Optional description of the action')}</span>
+						<EditAttribute
+							type="checkbox"
+							className="mls"
+							obj={triggeredAction}
+							collection={TriggeredActions}
+							attribute="useLabelAsName"
+						></EditAttribute>
+						<span className="text-s dimmed">{t('Use label as name')}</span>
 					</label>
 				</>
 			) : null}

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
@@ -393,7 +393,7 @@ export const TriggeredActionEntry: React.FC<IProps> = React.memo(function Trigge
 							className="mls"
 							obj={triggeredAction}
 							collection={TriggeredActions}
-							attribute="useLabelAsName"
+							attribute="useNameForDisplay"
 						></EditAttribute>
 						<span className="text-s">{t('Use label as name')}</span>
 					</label>

--- a/meteor/lib/collections/TriggeredActions.ts
+++ b/meteor/lib/collections/TriggeredActions.ts
@@ -23,6 +23,8 @@ export interface DBTriggeredActions extends ProtectedStringProperties<IBlueprint
 	triggers: DBBlueprintTrigger[]
 
 	_rundownVersionHash: string
+
+	useLabelAsName?: boolean
 }
 
 /** Note: Use DBTriggeredActions instead */

--- a/meteor/lib/collections/TriggeredActions.ts
+++ b/meteor/lib/collections/TriggeredActions.ts
@@ -24,7 +24,7 @@ export interface DBTriggeredActions extends ProtectedStringProperties<IBlueprint
 
 	_rundownVersionHash: string
 
-	useLabelAsName?: boolean
+	useNameForDisplay?: boolean
 }
 
 /** Note: Use DBTriggeredActions instead */

--- a/meteor/server/migration/X_X_X.ts
+++ b/meteor/server/migration/X_X_X.ts
@@ -38,18 +38,18 @@ export const addSteps = addMigrationSteps(CURRENT_SYSTEM_VERSION, [
 		},
 	},
 	{
-		id: 'Add "useLabelAsName" attribute to TriggeredActions',
+		id: 'Add "useNameForDisplay" attribute to TriggeredActions',
 		canBeRunAutomatically: true,
 		validate: () => {
 			return (
 				TriggeredActions.find({
-					useLabelAsName: { $exists: false },
+					useNameForDisplay: { $exists: false },
 				}).count() > 0
 			)
 		},
 		migrate: () => {
 			TriggeredActions.find({}).forEach((action) => {
-				TriggeredActions.update(action._id, { $set: { useLabelAsName: false } })
+				TriggeredActions.update(action._id, { $set: { useNameForDisplay: false } })
 			})
 		},
 	},

--- a/meteor/server/migration/X_X_X.ts
+++ b/meteor/server/migration/X_X_X.ts
@@ -1,5 +1,6 @@
 import { addMigrationSteps } from './databaseMigration'
 import { CURRENT_SYSTEM_VERSION } from './currentSystemVersion'
+import { TriggeredActions } from '../../lib/collections/TriggeredActions'
 
 /*
  * **************************************************************************************
@@ -13,4 +14,20 @@ import { CURRENT_SYSTEM_VERSION } from './currentSystemVersion'
 
 export const addSteps = addMigrationSteps(CURRENT_SYSTEM_VERSION, [
 	// Add some migrations!
+	{
+		id: 'Add "useLabelAsName" attribute to TriggeredActions',
+		canBeRunAutomatically: true,
+		validate: () => {
+			return (
+				TriggeredActions.find({
+					useLabelAsName: { $exists: false },
+				}).count() > 0
+			)
+		},
+		migrate: () => {
+			TriggeredActions.find({}).forEach((action) => {
+				TriggeredActions.update(action._id, { $set: { useLabelAsName: false } })
+			})
+		},
+	},
 ])

--- a/packages/blueprints-integration/src/triggers.ts
+++ b/packages/blueprints-integration/src/triggers.ts
@@ -299,4 +299,6 @@ export interface IBlueprintTriggeredActions {
 	triggers: SomeBlueprintTrigger[]
 	/** A list of actions to execute */
 	actions: SomeAction[]
+
+	useLabelAsName?: boolean
 }


### PR DESCRIPTION
Possible to use the label of the actionTrigger for the name shown in the keyboard layout of the shelf.
This is selected by ticking a new checkbox next to the label in the configuration of actiontriggers.

Due to how generic the action triggers are and the many possible different ways of creating actions triggers, just only works for most of them (But close to all).