### PR TITLE
SOF-859: Removes need for matching version numbers for tests

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -42,7 +42,13 @@ import {
 	ShowStyleVariantId,
 } from '../../lib/collections/ShowStyleVariants'
 import { Blueprint, BlueprintId } from '../../lib/collections/Blueprints'
-import { ICoreSystem, CoreSystem, SYSTEM_ID, stripVersion, parseCoreIntegrationCompatabilityRange } from '../../lib/collections/CoreSystem'
+import {
+	ICoreSystem,
+	CoreSystem,
+	SYSTEM_ID,
+	stripVersion,
+	parseCoreIntegrationCompatabilityRange,
+} from '../../lib/collections/CoreSystem'
 import { internalUploadBlueprint } from '../../server/api/blueprints/api'
 import { literal, getCurrentTime, protectString, unprotectString, getRandomId, getRandomString } from '../../lib/lib'
 import { DBRundown, Rundowns, RundownId } from '../../lib/collections/Rundowns'
@@ -83,7 +89,7 @@ function getBlueprintDependencyVersions(): { TSR_VERSION: string; INTEGRATION_VE
 	const version = integrationVersionRange.substring(1)
 
 	const INTEGRATION_VERSION = version
-	const TSR_VERSION = version	
+	const TSR_VERSION = version
 
 	return {
 		INTEGRATION_VERSION,

--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -42,7 +42,7 @@ import {
 	ShowStyleVariantId,
 } from '../../lib/collections/ShowStyleVariants'
 import { Blueprint, BlueprintId } from '../../lib/collections/Blueprints'
-import { ICoreSystem, CoreSystem, SYSTEM_ID, stripVersion } from '../../lib/collections/CoreSystem'
+import { ICoreSystem, CoreSystem, SYSTEM_ID, stripVersion, parseCoreIntegrationCompatabilityRange } from '../../lib/collections/CoreSystem'
 import { internalUploadBlueprint } from '../../server/api/blueprints/api'
 import { literal, getCurrentTime, protectString, unprotectString, getRandomId, getRandomString } from '../../lib/lib'
 import { DBRundown, Rundowns, RundownId } from '../../lib/collections/Rundowns'
@@ -79,17 +79,11 @@ export enum LAYER_IDS {
 }
 
 function getBlueprintDependencyVersions(): { TSR_VERSION: string; INTEGRATION_VERSION: string } {
-	const INTEGRATION_VERSION =
-		require('../../node_modules/@sofie-automation/blueprints-integration/package.json').version
+	const integrationVersionRange = parseCoreIntegrationCompatabilityRange(PackageInfo.version)
+	const version = integrationVersionRange.substring(1)
 
-	let TSR_VERSION = ''
-	try {
-		// eslint-disable-next-line node/no-missing-require
-		TSR_VERSION = require('../../node_modules/timeline-state-resolver-types/package.json').version
-	} catch (e) {
-		TSR_VERSION =
-			require('../../node_modules/@sofie-automation/blueprints-integration/node_modules/timeline-state-resolver-types/package.json').version
-	}
+	const INTEGRATION_VERSION = version
+	const TSR_VERSION = version	
 
 	return {
 		INTEGRATION_VERSION,

--- a/meteor/server/systemStatus/__tests__/systemStatus.test.ts
+++ b/meteor/server/systemStatus/__tests__/systemStatus.test.ts
@@ -125,7 +125,7 @@ describe('systemStatus', () => {
 
 			// Change integration lib versions, simulate a major version mismatch
 			// Expected status is BAD, because the device expects a different major version
-			await updateAndCheckSystemStatus(
+			await updateAndAssertSystemStatus(
 				{
 					versions: {
 						'@sofie-automation/server-core-integration': coreVersion.format(),
@@ -143,7 +143,7 @@ describe('systemStatus', () => {
 
 			// Change integration lib versions, simulate a minor version mismatch
 			// Expected status is BAD, because the device expects a different minor version
-			await updateAndCheckSystemStatus(
+			await updateAndAssertSystemStatus(
 				{
 					versions: {
 						'@sofie-automation/server-core-integration': coreVersion.format(),
@@ -161,7 +161,7 @@ describe('systemStatus', () => {
 
 			// Change integration lib versions, simulate a patch version mismatch
 			// Expected status is GOOD, because this should have no effect
-			await updateAndCheckSystemStatus(
+			await updateAndAssertSystemStatus(
 				{
 					versions: {
 						'@sofie-automation/server-core-integration': coreVersion.format(),
@@ -174,7 +174,7 @@ describe('systemStatus', () => {
 
 		// Try some silly version
 		// Expected status is BAD, because the device expects a different version
-		await updateAndCheckSystemStatus(
+		await updateAndAssertSystemStatus(
 			{
 				versions: {
 					test: '0.1.2',
@@ -186,7 +186,7 @@ describe('systemStatus', () => {
 
 		// disableVersion check
 		// Expected status is GOOD, as the check has been skipped
-		await updateAndCheckSystemStatus(
+		await updateAndAssertSystemStatus(
 			{
 				disableVersionChecks: true,
 			},
@@ -196,10 +196,10 @@ describe('systemStatus', () => {
 	})
 })
 
-async function updateAndCheckSystemStatus(
+async function updateAndAssertSystemStatus(
 	setObj: object,
 	env: DefaultEnvironment,
-	expected: StatusCode
+	expectedStatusCode: StatusCode
 ): Promise<void> {
 	PeripheralDevices.update(env.ingestDevice._id, {
 		$set: setObj,
@@ -207,7 +207,7 @@ async function updateAndCheckSystemStatus(
 	const result: StatusResponse = await MeteorCall.systemStatus.getSystemStatus()
 
 	expect(result).toMatchObject({
-		status: status2ExternalStatus(expected),
-		_status: expected,
+		status: status2ExternalStatus(expectedStatusCode),
+		_status: expectedStatusCode,
 	})
 }

--- a/meteor/server/systemStatus/__tests__/systemStatus.test.ts
+++ b/meteor/server/systemStatus/__tests__/systemStatus.test.ts
@@ -124,21 +124,16 @@ describe('systemStatus', () => {
 			coreVersion.major = 99
 
 			// Change integration lib versions, simulate a major version mismatch
-			PeripheralDevices.update(env.ingestDevice._id, {
-				$set: {
+			// Expected status is BAD, because the device expects a different major version
+			await updateAndCheckSystemStatus(
+				{
 					versions: {
 						'@sofie-automation/server-core-integration': coreVersion.format(),
 					},
 				},
-			})
-			const result1: StatusResponse = await MeteorCall.systemStatus.getSystemStatus()
-
-			// Expected status is BAD, because the device expects a different major version
-			const expectedStatus1 = StatusCode.BAD
-			expect(result1).toMatchObject({
-				status: status2ExternalStatus(expectedStatus1),
-				_status: expectedStatus1,
-			})
+				env,
+				StatusCode.BAD
+			)
 		}
 
 		{
@@ -147,21 +142,16 @@ describe('systemStatus', () => {
 			coreVersion.minor = 999
 
 			// Change integration lib versions, simulate a minor version mismatch
-			PeripheralDevices.update(env.ingestDevice._id, {
-				$set: {
+			// Expected status is BAD, because the device expects a different minor version
+			await updateAndCheckSystemStatus(
+				{
 					versions: {
 						'@sofie-automation/server-core-integration': coreVersion.format(),
 					},
 				},
-			})
-			const result2: StatusResponse = await MeteorCall.systemStatus.getSystemStatus()
-
-			// Expected status is BAD, because the device expects a different minor version
-			const expectedStatus2 = StatusCode.BAD
-			expect(result2).toMatchObject({
-				status: status2ExternalStatus(expectedStatus2),
-				_status: expectedStatus2,
-			})
+				env,
+				StatusCode.BAD
+			)
 		}
 
 		{
@@ -170,53 +160,54 @@ describe('systemStatus', () => {
 			coreVersion.patch = 999
 
 			// Change integration lib versions, simulate a patch version mismatch
-			PeripheralDevices.update(env.ingestDevice._id, {
-				$set: {
+			// Expected status is GOOD, because this should have no effect
+			await updateAndCheckSystemStatus(
+				{
 					versions: {
 						'@sofie-automation/server-core-integration': coreVersion.format(),
 					},
 				},
-			})
-			const result3: StatusResponse = await MeteorCall.systemStatus.getSystemStatus()
-
-			// Expected status is GOOD, because this should have no effect
-			const expectedStatus3 = StatusCode.GOOD
-			expect(result3).toMatchObject({
-				status: status2ExternalStatus(expectedStatus3),
-				_status: expectedStatus3,
-			})
+				env,
+				StatusCode.GOOD
+			)
 		}
 
 		// Try some silly version
-		PeripheralDevices.update(env.ingestDevice._id, {
-			$set: {
+		// Expected status is BAD, because the device expects a different version
+		await updateAndCheckSystemStatus(
+			{
 				versions: {
 					test: '0.1.2',
 				},
 			},
-		})
-		const result4: StatusResponse = await MeteorCall.systemStatus.getSystemStatus()
-
-		// Expected status is BAD, because the device expects a different version
-		const expectedStatus4 = StatusCode.BAD
-		expect(result4).toMatchObject({
-			status: status2ExternalStatus(expectedStatus4),
-			_status: expectedStatus4,
-		})
+			env,
+			StatusCode.BAD
+		)
 
 		// disableVersion check
-		PeripheralDevices.update(env.ingestDevice._id, {
-			$set: {
+		// Expected status is GOOD, as the check has been skipped
+		await updateAndCheckSystemStatus(
+			{
 				disableVersionChecks: true,
 			},
-		})
-		const result5: StatusResponse = await MeteorCall.systemStatus.getSystemStatus()
-
-		// Expected status is GOOD, as the check has been skipped
-		const expectedStatus5 = StatusCode.GOOD
-		expect(result5).toMatchObject({
-			status: status2ExternalStatus(expectedStatus5),
-			_status: expectedStatus5,
-		})
+			env,
+			StatusCode.GOOD
+		)
 	})
 })
+
+async function updateAndCheckSystemStatus(
+	setObj: Object,
+	env: DefaultEnvironment,
+	expected: StatusCode
+): Promise<void> {
+	PeripheralDevices.update(env.ingestDevice._id, {
+		$set: setObj,
+	})
+	const result: StatusResponse = await MeteorCall.systemStatus.getSystemStatus()
+
+	expect(result).toMatchObject({
+		status: status2ExternalStatus(expected),
+		_status: expected,
+	})
+}

--- a/meteor/server/systemStatus/__tests__/systemStatus.test.ts
+++ b/meteor/server/systemStatus/__tests__/systemStatus.test.ts
@@ -197,7 +197,7 @@ describe('systemStatus', () => {
 })
 
 async function updateAndCheckSystemStatus(
-	setObj: Object,
+	setObj: object,
 	env: DefaultEnvironment,
 	expected: StatusCode
 ): Promise<void> {


### PR DESCRIPTION
Fixes 4 tests failing if the blueprints integration version doesn't fit with core's version.
Also boyscouts/refactors away some duplicate code, with use of a helper method.