### PR TITLE
fix: SOF-1203 worker autoRestart fixes

### DIFF
--- a/meteor/package.json
+++ b/meteor/package.json
@@ -100,7 +100,7 @@
 		"react-timer-hoc": "^2.3.0",
 		"semver": "^7.3.7",
 		"superfly-timeline": "^8.2.8",
-		"threadedclass": "^1.1.0",
+		"threadedclass": "^1.2.0",
 		"timecode": "0.0.4",
 		"type-fest": "^2.19.0",
 		"underscore": "^1.13.4",

--- a/meteor/server/worker/worker.ts
+++ b/meteor/server/worker/worker.ts
@@ -41,7 +41,7 @@ interface JobEntry {
 interface JobQueue {
 	jobs: Array<JobEntry | null>
 	/** Notify that there is a job waiting (aka worker is long-polling) */
-	notifyWorker: ManualPromise<JobSpec | null> | null
+	notifyWorker: ManualPromise<void> | null
 }
 
 type JobCompletionHandler = (startedTime: number, finishedTime: number, err: any, result: any) => void
@@ -76,15 +76,11 @@ async function jobFinished(
 	}
 }
 /** This is called by each Worker Thread, when it is idle and wants another job */
-async function getNextJob(queueName: string): Promise<JobSpec | null> {
+async function waitForNextJob(queueName: string): Promise<void> {
 	// Check if there is a job waiting:
 	const queue = getOrCreateQueue(queueName)
-	const job = queue.jobs.shift()
-	if (job) {
-		// If there is a completion handler, register it for execution
-		if (job.completionHandler) runningJobs.set(job.spec.id, job.completionHandler)
-		// Pass the job to the worker
-		return job.spec
+	if (queue.jobs.length > 0) {
+		return
 	}
 	// No job ready, do a long-poll
 
@@ -106,6 +102,21 @@ async function getNextJob(queueName: string): Promise<JobSpec | null> {
 	queue.notifyWorker = createManualPromise()
 	return queue.notifyWorker
 }
+/** This is called by each Worker Thread, when it thinks there is a job to execute */
+async function getNextJob(queueName: string): Promise<JobSpec | null> {
+	// Check if there is a job waiting:
+	const queue = getOrCreateQueue(queueName)
+	const job = queue.jobs.shift()
+	if (job) {
+		// If there is a completion handler, register it for execution
+		if (job.completionHandler) runningJobs.set(job.spec.id, job.completionHandler)
+		// Pass the job to the worker
+		return job.spec
+	}
+
+	// No job ready
+	return null
+}
 /** This is called by each Worker Thread, when it is idle and wants another job */
 async function interruptJobStream(queueName: string): Promise<void> {
 	// Check if there is a job waiting:
@@ -117,7 +128,7 @@ async function interruptJobStream(queueName: string): Promise<void> {
 		Meteor.defer(() => {
 			try {
 				// Notify the worker in the background
-				oldNotify.manualResolve(null)
+				oldNotify.manualResolve()
 			} catch (e) {
 				// Ignore
 			}
@@ -145,23 +156,18 @@ function queueJobInner(queueName: string, jobToQueue: JobEntry): void {
 	// If there is a worker waiting to pick up a job
 	if (queue.notifyWorker) {
 		const notify = queue.notifyWorker
-		const job = queue.jobs.shift()
-		if (job) {
-			// If there is a completion handler, register it for execution
-			if (job.completionHandler) runningJobs.set(job.spec.id, job.completionHandler)
 
-			// Worker is about to be notified, so clear the handle:
-			queue.notifyWorker = null
-			Meteor.defer(() => {
-				try {
-					// Notify the worker in the background
-					notify.manualResolve(job.spec)
-				} catch (e) {
-					// Queue failed, inform caller
-					if (job.completionHandler) job.completionHandler(0, 0, e, null)
-				}
-			})
-		}
+		// Worker is about to be notified, so clear the handle:
+		queue.notifyWorker = null
+		Meteor.defer(() => {
+			try {
+				// Notify the worker in the background
+				notify.manualResolve()
+			} catch (e) {
+				// Queue failed
+				logger.error(`Error in notifyWorker: ${stringifyError(e)}`)
+			}
+		})
 	}
 }
 
@@ -251,7 +257,16 @@ Meteor.startup(() => {
 		threadedClass<IpcJobWorker, typeof IpcJobWorker>(
 			workerEntrypoint,
 			'IpcJobWorker',
-			[workerId, jobFinished, interruptJobStream, getNextJob, queueJobWithoutResult, logLine, fastTrackTimeline],
+			[
+				workerId,
+				jobFinished,
+				interruptJobStream,
+				waitForNextJob,
+				getNextJob,
+				queueJobWithoutResult,
+				logLine,
+				fastTrackTimeline,
+			],
 			{
 				autoRestart: true,
 				autoRestartRetryCount: AUTO_RESTART_RETRY_COUNT,

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -9784,10 +9784,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-threadedclass@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/threadedclass/-/threadedclass-1.1.1.tgz#6813b3c401b3d55264f6225c9d2c15516d7efa97"
-  integrity sha512-HffBjerRZGOlhUBt9Ue8nYCuV6khK9er86w4svTvf1Xn6ibAyJok290o2MJ/qJ1vy0A4UphEo3DSsxFN5g+TBQ==
+threadedclass@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/threadedclass/-/threadedclass-1.2.0.tgz#da76b83caee58f170d191f507251b53f0bc4db9b"
+  integrity sha512-o1noXHysn9YhiktrUkuCGz/FT6Ikh6NOqd8ptAVt4JZR5o//O7EmLDxSpal4wAUrjFUvKEtDw03ihdoKMRLkSg==
   dependencies:
     callsites "^3.1.0"
     eventemitter3 "^4.0.4"

--- a/packages/job-worker/package.json
+++ b/packages/job-worker/package.json
@@ -53,7 +53,7 @@
 		"p-lazy": "^3.1.0",
 		"p-timeout": "^4.1.0",
 		"superfly-timeline": "^8.2.8",
-		"threadedclass": "^1.1.0",
+		"threadedclass": "^1.2.0",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0",
 		"underscore": "^1.13.4",

--- a/packages/job-worker/src/ipc.ts
+++ b/packages/job-worker/src/ipc.ts
@@ -17,12 +17,14 @@ class IpcJobManager implements JobManager {
 		) => Promise<void>,
 		public readonly queueJob: (queueName: string, jobName: string, jobData: unknown) => Promise<void>,
 		private readonly interruptJobStream: (queueName: string) => Promise<void>,
+		private readonly waitForNextJob: (queueName: string) => Promise<void>,
 		private readonly getNextJob: (queueName: string) => Promise<JobSpec | null>
 	) {}
 
 	public subscribeToQueue(queueName: string, _workerId: WorkerId): JobStream {
 		return {
-			next: async () => this.getNextJob(queueName),
+			wait: async () => this.waitForNextJob(queueName),
+			pop: async () => this.getNextJob(queueName),
 			interrupt: () => {
 				this.interruptJobStream(queueName).catch((error) =>
 					logger.error(`Failed to interrupt job queue ${queueName}.`, { data: error })
@@ -41,6 +43,7 @@ export class IpcJobWorker extends JobWorkerBase {
 		workerId: WorkerId,
 		jobFinished: (id: string, startedTime: number, finishedTime: number, error: any, result: any) => Promise<void>,
 		interruptJobStream: (queueName: string) => Promise<void>,
+		waitForNextJob: (queueName: string) => Promise<void>,
 		getNextJob: (queueName: string) => Promise<JobSpec | null>,
 		queueJob: (queueName: string, jobName: string, jobData: unknown) => Promise<void>,
 		logLine: (msg: LogEntry) => Promise<void>,
@@ -49,7 +52,7 @@ export class IpcJobWorker extends JobWorkerBase {
 		// Intercept logging to pipe back over ipc
 		interceptLogging('worker-parent', async (msg) => logLine(msg))
 
-		const jobManager = new IpcJobManager(jobFinished, queueJob, interruptJobStream, getNextJob)
+		const jobManager = new IpcJobManager(jobFinished, queueJob, interruptJobStream, waitForNextJob, getNextJob)
 		super(workerId, jobManager, logLine, fastTrackTimeline)
 	}
 }

--- a/packages/job-worker/src/manager.ts
+++ b/packages/job-worker/src/manager.ts
@@ -16,8 +16,10 @@ export interface JobManager {
 }
 
 export interface JobStream {
+	/** Wait for the job queue to notify */
+	wait(): Promise<void>
 	/** Get the next queued job */
-	next(): Promise<JobSpec | null>
+	pop(): Promise<JobSpec | null>
 	/** Make the next job returned be `null` */
 	interrupt(): void
 	/** Close the JobStream */

--- a/packages/job-worker/src/workers/events/parent.ts
+++ b/packages/job-worker/src/workers/events/parent.ts
@@ -9,6 +9,8 @@ import { FastTrackTimelineFunc, LogLineWithSourceFunc } from '../../main'
 const FREEZE_LIMIT = 1000 // how long to wait for a response to a Ping
 const RESTART_TIMEOUT = 10000 // how long to wait for a restart to complete before throwing an error
 const KILL_TIMEOUT = 10000 // how long to wait for a thread to terminate before throwing an error
+const AUTO_RESTART_RETRY_COUNT = 0 // how many autorestart attemps are allowed (0 means it will never stop retrying)
+const AUTO_RESTART_RETRY_DELAY = 1000 // how long to wait before retrying after a failed restart
 
 export class EventsWorkerParent extends WorkerParentBase {
 	readonly #thread: Promisify<EventsWorkerChild>
@@ -36,6 +38,8 @@ export class EventsWorkerParent extends WorkerParentBase {
 			{
 				instanceName: `Events: ${baseOptions.studioId}`,
 				autoRestart: true,
+				autoRestartRetryCount: AUTO_RESTART_RETRY_COUNT,
+				autoRestartRetryDelay: AUTO_RESTART_RETRY_DELAY,
 				freezeLimit: FREEZE_LIMIT,
 				restartTimeout: RESTART_TIMEOUT,
 				killTimeout: KILL_TIMEOUT,

--- a/packages/job-worker/src/workers/ingest/parent.ts
+++ b/packages/job-worker/src/workers/ingest/parent.ts
@@ -9,6 +9,8 @@ import { FastTrackTimelineFunc, LogLineWithSourceFunc } from '../../main'
 const FREEZE_LIMIT = 10000 // how long to wait for a response to a Ping
 const RESTART_TIMEOUT = 10000 // how long to wait for a restart to complete before throwing an error
 const KILL_TIMEOUT = 10000 // how long to wait for a thread to terminate before throwing an error
+const AUTO_RESTART_RETRY_COUNT = 0 // how many autorestart attemps are allowed (0 means it will never stop retrying)
+const AUTO_RESTART_RETRY_DELAY = 1000 // how long to wait before retrying after a failed restart
 
 export class IngestWorkerParent extends WorkerParentBase {
 	readonly #thread: Promisify<IngestWorkerChild>
@@ -37,6 +39,8 @@ export class IngestWorkerParent extends WorkerParentBase {
 			{
 				instanceName: `Ingest: ${baseOptions.studioId}`,
 				autoRestart: true,
+				autoRestartRetryCount: AUTO_RESTART_RETRY_COUNT,
+				autoRestartRetryDelay: AUTO_RESTART_RETRY_DELAY,
 				freezeLimit: FREEZE_LIMIT,
 				restartTimeout: RESTART_TIMEOUT,
 				killTimeout: KILL_TIMEOUT,

--- a/packages/job-worker/src/workers/parent-base.ts
+++ b/packages/job-worker/src/workers/parent-base.ts
@@ -104,6 +104,9 @@ export abstract class WorkerParentBase {
 	}
 
 	protected registerStatusEvents(workerThread: Promisify<any>): void {
+		ThreadedClassManager.onEvent(workerThread, 'warning', (message: string) => {
+			logger.warn(`Warning in Worker ${this.#prettyName}: ${message}`)
+		})
 		ThreadedClassManager.onEvent(workerThread, 'error', (error: any) =>
 			logger.error(`Error in Worker ${this.#prettyName}.`, { data: error })
 		)

--- a/packages/job-worker/src/workers/parent-base.ts
+++ b/packages/job-worker/src/workers/parent-base.ts
@@ -25,6 +25,7 @@ export enum ThreadStatus {
 	Closed = 0,
 	PendingInit = 1,
 	Ready = 2,
+	ManualRestarting = 3,
 }
 
 /** How often to check the job for reaching the max duration */
@@ -117,6 +118,10 @@ export abstract class WorkerParentBase {
 			this.#jobStream.interrupt()
 		})
 		ThreadedClassManager.onEvent(workerThread, 'thread_closed', () => {
+			if (this.#threadStatus === ThreadStatus.ManualRestarting) {
+				// ignore closed events when manually restarting
+				return
+			}
 			logger.info(`Worker ${this.#prettyName} closed`)
 			this.#threadStatus = ThreadStatus.Closed
 			this.#jobStream.interrupt()
@@ -142,6 +147,26 @@ export abstract class WorkerParentBase {
 	/** Inform the worker thread about a lock change */
 	public abstract workerLockChange(lockId: string, locked: boolean): Promise<void>
 
+	private async tryRestartThread() {
+		// Ensure that the status is set to manual restart so that if this fails, we'll retry later:
+
+		this.#threadStatus = ThreadStatus.ManualRestarting
+		logger.info(`Worker ${this.#prettyName} manually restarting child`)
+
+		try {
+			await this.restartWorkerThread()
+			// Note: the 'restarted' event isn't fired when we are the ones restarting the worker.
+
+			// At this point we have successfully restarted.
+			logger.info(`Worker ${this.#prettyName} manually restarted`)
+			this.#threadInstanceId = getRandomString()
+
+			this.#threadStatus = ThreadStatus.PendingInit
+		} catch (error) {
+			logger.error(`Error when trying to restart worker thread ${this.#prettyName}: ${stringifyError(error)}`)
+		}
+	}
+
 	/** Start the loop feeding work to the worker */
 	protected startWorkerLoop(mongoUri: string): void {
 		if (!this.#watchdog) {
@@ -153,7 +178,9 @@ export abstract class WorkerParentBase {
 
 					logger.warn(`Force restarting worker thread: "${this.#queueName}"`)
 					this.#watchdogJobStarted = undefined
-					this.restartWorkerThread().catch((e) => {
+
+					// Force a restart now, to kill the running job
+					this.tryRestartThread().catch((e) => {
 						logger.warn(`Restarting worker thread "${this.#queueName}" error: ${stringifyError(e)}`)
 					})
 				}
@@ -186,23 +213,32 @@ export abstract class WorkerParentBase {
 									await sleep(100)
 									// Check again
 									continue
+								case ThreadStatus.ManualRestarting:
+									await this.tryRestartThread()
+
+									// Make sure the loop doesn't run as fast as possible:
+									await sleep(5000)
+
+									continue
 								case ThreadStatus.PendingInit:
 									logger.debug(`Re-initialising worker thread: "${this.#queueName}"`)
 									// Reinitialize the worker
 									try {
 										await this.initWorker(mongoUri, this.#mongoDbName)
+										logger.info(`Worker ${this.#prettyName} ready`)
+										this.#threadStatus = ThreadStatus.Ready
 									} catch (error) {
-										logger.error(`Worker ${this.#prettyName} could not be initialized:`, {
-											data: error,
-										})
-										this.#threadStatus = ThreadStatus.Closed
-										continue
+										// Initializing failed, restart the child:
+										logger.error(
+											`Worker ${this.#prettyName} failed to initialize: ${stringifyError(error)}`
+										)
+
+										this.#threadStatus = ThreadStatus.ManualRestarting
+										// Make sure the loop doesn't run as fast as possible:
+										await sleep(5000)
 									}
 
-									logger.info(`Worker ${this.#prettyName} ready`)
-									this.#threadStatus = ThreadStatus.Ready
-
-									break
+									continue
 								case ThreadStatus.Ready:
 									// Thread is happy to accept a job
 									break
@@ -210,7 +246,8 @@ export abstract class WorkerParentBase {
 									assertNever(this.#threadStatus)
 							}
 
-							const job = await this.#jobStream.next() // Note: this blocks
+							// Wait for a job to appear in the queue:
+							await this.#jobStream.wait() // Note: this blocks
 
 							// Handle any invalidations
 							if (this.#pendingInvalidations) {
@@ -223,7 +260,8 @@ export abstract class WorkerParentBase {
 								await this.invalidateWorkerCaches(invalidations)
 							}
 
-							// we may not get a job even when blocking, so try again
+							// fetch the job, if there was one
+							const job = await this.#jobStream.pop()
 							if (job) {
 								// Ensure the lock is still good
 								// await job.extendLock(this.#workerId, 10000) // Future - ensure the job is locked for enough to process
@@ -287,7 +325,10 @@ export abstract class WorkerParentBase {
 								transaction?.end()
 							}
 						} catch (e) {
-							logger.error(`Uncaught error in worker loop for ${this.#prettyName}: ${e}`)
+							logger.error(`Uncaught error in worker loop for ${this.#prettyName}: ${stringifyError(e)}`)
+
+							// To avoid flooding logs when re-running the loop, wait a little bit:
+							await sleep(5000)
 						}
 					}
 
@@ -326,6 +367,7 @@ export abstract class WorkerParentBase {
 				statusCode = StatusCode.BAD
 				reason = 'Closed'
 				break
+			case ThreadStatus.ManualRestarting:
 			case ThreadStatus.PendingInit:
 				statusCode = StatusCode.BAD
 				reason = 'Thread restarting'

--- a/packages/job-worker/src/workers/studio/parent.ts
+++ b/packages/job-worker/src/workers/studio/parent.ts
@@ -9,6 +9,8 @@ import { FastTrackTimelineFunc, LogLineWithSourceFunc } from '../../main'
 const FREEZE_LIMIT = 2500 // how long to wait for a response to a Ping
 const RESTART_TIMEOUT = 10000 // how long to wait for a restart to complete before throwing an error
 const KILL_TIMEOUT = 10000 // how long to wait for a thread to terminate before throwing an error
+const AUTO_RESTART_RETRY_COUNT = 0 // how many autorestart attemps are allowed (0 means it will never stop retrying)
+const AUTO_RESTART_RETRY_DELAY = 1000 // how long to wait before retrying after a failed restart
 
 export class StudioWorkerParent extends WorkerParentBase {
 	readonly #thread: Promisify<StudioWorkerChild>
@@ -36,6 +38,8 @@ export class StudioWorkerParent extends WorkerParentBase {
 			{
 				instanceName: `Studio: ${baseOptions.studioId}`,
 				autoRestart: true,
+				autoRestartRetryCount: AUTO_RESTART_RETRY_COUNT,
+				autoRestartRetryDelay: AUTO_RESTART_RETRY_DELAY,
 				freezeLimit: FREEZE_LIMIT,
 				restartTimeout: RESTART_TIMEOUT,
 				killTimeout: KILL_TIMEOUT,

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -13928,10 +13928,20 @@ threadedclass@^0.8.0:
     is-running "^2.1.0"
     tslib "^1.13.0"
 
-threadedclass@^1.1.0, threadedclass@^1.1.1:
+threadedclass@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/threadedclass/-/threadedclass-1.1.1.tgz#6813b3c401b3d55264f6225c9d2c15516d7efa97"
   integrity sha512-HffBjerRZGOlhUBt9Ue8nYCuV6khK9er86w4svTvf1Xn6ibAyJok290o2MJ/qJ1vy0A4UphEo3DSsxFN5g+TBQ==
+  dependencies:
+    callsites "^3.1.0"
+    eventemitter3 "^4.0.4"
+    is-running "^2.1.0"
+    tslib "^1.13.0"
+
+threadedclass@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/threadedclass/-/threadedclass-1.2.0.tgz#da76b83caee58f170d191f507251b53f0bc4db9b"
+  integrity sha512-o1noXHysn9YhiktrUkuCGz/FT6Ikh6NOqd8ptAVt4JZR5o//O7EmLDxSpal4wAUrjFUvKEtDw03ihdoKMRLkSg==
   dependencies:
     callsites "^3.1.0"
     eventemitter3 "^4.0.4"


### PR DESCRIPTION
Two bugfixes related to workers:

1. Upgrades threadedclass and uses its new properties to fix a bug where a timeout in child's constructor would cause the worker to be closed and never restarted again until the entire Core was restarted

3. Cherry-pick of a commit from NRK, fixing a bug where a force restart from within the worker loop would not trigger reintialization of the worker