### PR TITLE
fix: SOF-1159 prevent queued piece from starting prematurely with in-transition

### DIFF
--- a/packages/job-worker/src/__mocks__/presetCollections.ts
+++ b/packages/job-worker/src/__mocks__/presetCollections.ts
@@ -25,7 +25,7 @@ import { ShowStyleCompound } from '@sofie-automation/corelib/dist/dataModel/Show
 import { DBShowStyleVariant } from '@sofie-automation/corelib/dist/dataModel/ShowStyleVariant'
 import { getRandomId, literal } from '@sofie-automation/corelib/dist/lib'
 import _ = require('underscore')
-import { defaultRundownPlaylist } from './defaultCollectionObjects'
+import { defaultAdLibPiece, defaultRundownPlaylist } from './defaultCollectionObjects'
 import {
 	PeripheralDeviceCategory,
 	PeripheralDeviceType,
@@ -275,8 +275,19 @@ export async function setupDefaultRundown(
 		content: {},
 		timelineObjectsString: EmptyPieceTimelineObjectsBlob,
 	}
-
 	await context.directCollections.AdLibPieces.insertOne(adLibPiece000)
+
+	const adLibPiece001: AdLibPiece = {
+		...defaultAdLibPiece(protectString(rundownId + '_adLib001'), rundownId, part00._id),
+		expectedDuration: 1000,
+		externalId: 'MOCK_ADLIB_001',
+		status: PieceStatusCode.UNKNOWN,
+		name: 'AdLib 1',
+		sourceLayerId: showStyleCompound.sourceLayers[1]._id,
+		outputLayerId: showStyleCompound.outputLayers[0]._id,
+		toBeQueued: true,
+	}
+	await context.directCollections.AdLibPieces.insertOne(adLibPiece001)
 
 	const part01: DBPart = {
 		_id: protectString(rundownId + '_part0_1'),

--- a/packages/job-worker/src/playout/adlib.ts
+++ b/packages/job-worker/src/playout/adlib.ts
@@ -299,7 +299,8 @@ export async function innerStartOrQueueAdLibPiece(
 
 	const span = context.startSpan('innerStartOrQueueAdLibPiece')
 	let queuedPartInstanceId: PartInstanceId | undefined
-	if (queue || adLibPiece.toBeQueued) {
+	const shouldPieceBeQueued = queue || !!adLibPiece.toBeQueued
+	if (shouldPieceBeQueued) {
 		const newPartInstance: DBPartInstance = {
 			_id: getRandomId(),
 			rundownId: rundown._id,
@@ -325,7 +326,7 @@ export async function innerStartOrQueueAdLibPiece(
 			playlist.activationId,
 			adLibPiece,
 			newPartInstance,
-			queue
+			shouldPieceBeQueued
 		)
 
 		newPartInstance.part.expectedDurationWithPreroll = calculatePartExpectedDurationWithPreroll(
@@ -343,7 +344,7 @@ export async function innerStartOrQueueAdLibPiece(
 			playlist.activationId,
 			adLibPiece,
 			currentPartInstance,
-			queue
+			shouldPieceBeQueued
 		)
 		innerStartAdLibPiece(context, cache, rundown, currentPartInstance, newPieceInstance)
 


### PR DESCRIPTION
Fixes a bug that caused queued adLib pieces (with `toBeQueued: true`) to start 'now' instead of being delayed when a transition was added to next partInstance