### PR TITLE
fix: SOF-1135 fix half removed device

### DIFF
--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -9832,10 +9832,10 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.0.3.tgz#cb22a1dee460403c2a306e666003a1d57af7f8d2"
-  integrity sha512-PqqV2EFCfhQyphngRFh0K7UcO+pptB5e6vk73uT+gz0S+j/aV2uAtOKA3PPeEc7W37ov4KCsP10T4KVTntNkAw==
+"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.1.0.tgz#1f5c2de4943c2d422ab6eb049da6f064a510e080"
+  integrity sha512-sjVvIdLAgR2ciX8oJZkLBaPwUt4WtU7TYlzaS3OdrfZMXQWhWnxwUmjYHfSB69VXIoiP1ZP4rknKh6Q73+N3Cg==
   dependencies:
     tslib "^2.3.1"
 

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -39,7 +39,7 @@
 	],
 	"dependencies": {
 		"@sofie-automation/shared-lib": "link:../shared-lib",
-		"timeline-state-resolver-types": "npm:@tv2media/timeline-state-resolver-types@3.0.3",
+		"timeline-state-resolver-types": "npm:@tv2media/timeline-state-resolver-types@3.1.0",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0"
 	},

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -62,6 +62,7 @@
 		"debug": "^4.3.3",
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
+		"object-hash": "^3.0.0",
 		"timeline-state-resolver": "npm:@tv2media/timeline-state-resolver@3.0.3",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.4",
@@ -74,5 +75,8 @@
 		"*.{ts,tsx,js,jsx}": [
 			"yarn lint:raw"
 		]
+	},
+	"devDependencies": {
+		"@types/object-hash": "^3.0.1"
 	}
 }

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -63,7 +63,7 @@
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
 		"object-hash": "^3.0.0",
-		"timeline-state-resolver": "npm:@tv2media/timeline-state-resolver@3.0.3",
+		"timeline-state-resolver": "npm:@tv2media/timeline-state-resolver@3.1.0",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.4",
 		"winston": "^3.8.2"

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -608,7 +608,7 @@ export class TSRHandler {
 				}
 			}
 
-			for (const oldDevice of this.tsr.getDevices()) {
+			for (const oldDevice of this.tsr.getDevices(true)) {
 				const deviceId = oldDevice.deviceId
 				if (!deviceOptions.has(deviceId)) {
 					this.logger.info('Un-initializing device: ' + deviceId)

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -643,11 +643,10 @@ export class TSRHandler {
 				jobId
 			)
 			.end(
-				(queue) => {
-					if (!queue.length) {
-						this.updateDeviceStatus(deviceId)
-						this._triggerUpdateDevices()
-					}
+				() => {
+					if (jobQueue.length) return
+					this.updateDeviceStatus(deviceId)
+					this._triggerUpdateDevices()
 				},
 				() => {
 					this.updateDeviceStatus(deviceId, JobFailure.REMOVE_ERROR)
@@ -677,7 +676,7 @@ export class TSRHandler {
 				jobId
 			)
 			.end(
-				(_queue, result) => {
+				(result) => {
 					this.updateDeviceStatus(deviceId)
 					this._coreTsrHandlers[deviceId] = result.coreTsrHandler
 					const { groupedExpectedItems, rundowns } = this.getExpectedPlayoutItems()

--- a/packages/playout-gateway/src/tsrHandlerJobs/createDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/createDeviceJob.ts
@@ -1,0 +1,48 @@
+import { CoreTSRDeviceHandler } from '../coreHandler'
+import { Job } from './job'
+import { AbortError, DeviceContainer, DeviceOptionsAny, StatusCode } from 'timeline-state-resolver'
+import { TSRHandler } from '../tsrHandler'
+
+export interface CreateDeviceJobsResult {
+	deviceContainer: DeviceContainer<DeviceOptionsAny>
+	coreTsrHandler: CoreTSRDeviceHandler
+}
+
+export class CreateDeviceJob extends Job<CreateDeviceJobsResult, any, Partial<CreateDeviceJobsResult>> {
+	protected artifacts: Partial<CreateDeviceJobsResult> = {}
+
+	constructor(private deviceId: string, private deviceOptions: DeviceOptionsAny, private tsrHandler: TSRHandler) {
+		super()
+	}
+	async run(_previousResult?: undefined, abortSignal?: AbortSignal): Promise<CreateDeviceJobsResult> {
+		if (abortSignal?.aborted) {
+			throw new AbortError()
+		}
+
+		const device = await this.tsrHandler.tsr.createDevice(this.deviceId, this.deviceOptions, {
+			signal: abortSignal,
+		})
+		this.artifacts.deviceContainer = device
+
+		if (abortSignal?.aborted) {
+			throw new AbortError()
+		}
+
+		const coreTsrHandler = new CoreTSRDeviceHandler(this.artifacts.deviceContainer, this.deviceId, this.tsrHandler)
+		this.artifacts.coreTsrHandler = coreTsrHandler
+		// set the status to uninitialized for now:
+		coreTsrHandler.statusChanged({
+			statusCode: StatusCode.BAD,
+			messages: ['Device initialising...'],
+		})
+
+		return { deviceContainer: device, coreTsrHandler }
+	}
+	async cleanup(): Promise<void> {
+		if (this.artifacts.coreTsrHandler) {
+			await this.artifacts.coreTsrHandler.dispose(false)
+		} else if (this.artifacts.deviceContainer) {
+			await this.tsrHandler.tsr.removeDevice(this.deviceId)
+		}
+	}
+}

--- a/packages/playout-gateway/src/tsrHandlerJobs/createDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/createDeviceJob.ts
@@ -8,13 +8,14 @@ export interface CreateDeviceJobsResult {
 	coreTsrHandler: CoreTSRDeviceHandler
 }
 
-export class CreateDeviceJob extends Job<CreateDeviceJobsResult, any, Partial<CreateDeviceJobsResult>> {
+export class CreateDeviceJob extends Job<CreateDeviceJobsResult, Partial<CreateDeviceJobsResult>> {
 	protected artifacts: Partial<CreateDeviceJobsResult> = {}
 
 	constructor(private deviceId: string, private deviceOptions: DeviceOptionsAny, private tsrHandler: TSRHandler) {
 		super()
 	}
-	async run(_previousResult?: undefined, abortSignal?: AbortSignal): Promise<CreateDeviceJobsResult> {
+
+	async run(_previousResult: unknown, abortSignal?: AbortSignal): Promise<CreateDeviceJobsResult> {
 		if (abortSignal?.aborted) {
 			throw new AbortError()
 		}
@@ -28,19 +29,20 @@ export class CreateDeviceJob extends Job<CreateDeviceJobsResult, any, Partial<Cr
 			throw new AbortError()
 		}
 
-		const coreTsrHandler = new CoreTSRDeviceHandler(this.artifacts.deviceContainer, this.deviceId, this.tsrHandler)
+		const coreTsrHandler = new CoreTSRDeviceHandler(this.artifacts.deviceContainer, this.tsrHandler)
 		this.artifacts.coreTsrHandler = coreTsrHandler
 		// set the status to uninitialized for now:
 		coreTsrHandler.statusChanged({
-			statusCode: StatusCode.BAD,
+			statusCode: StatusCode.UNKNOWN,
 			messages: ['Device initialising...'],
 		})
 
 		return { deviceContainer: device, coreTsrHandler }
 	}
+
 	async cleanup(): Promise<void> {
 		if (this.artifacts.coreTsrHandler) {
-			await this.artifacts.coreTsrHandler.dispose(false)
+			await this.artifacts.coreTsrHandler.disposeUnexpectedly()
 		} else if (this.artifacts.deviceContainer) {
 			await this.tsrHandler.tsr.removeDevice(this.deviceId)
 		}

--- a/packages/playout-gateway/src/tsrHandlerJobs/initCoreTsrHandlerJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/initCoreTsrHandlerJob.ts
@@ -4,7 +4,7 @@ import { AbortError } from 'timeline-state-resolver'
 
 type InitCoreTsrHandlerJobResult = CreateDeviceJobsResult
 
-export class InitCoreTsrHandlerJob extends Job<InitCoreTsrHandlerJobResult, CreateDeviceJobsResult, undefined> {
+export class InitCoreTsrHandlerJob extends Job<InitCoreTsrHandlerJobResult, undefined, CreateDeviceJobsResult> {
 	protected artifacts: undefined
 
 	async run(previousResult: CreateDeviceJobsResult, abortSignal?: AbortSignal): Promise<InitCoreTsrHandlerJobResult> {

--- a/packages/playout-gateway/src/tsrHandlerJobs/initCoreTsrHandlerJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/initCoreTsrHandlerJob.ts
@@ -1,0 +1,17 @@
+import { Job } from './job'
+import { CreateDeviceJobsResult } from './createDeviceJob'
+import { AbortError } from 'timeline-state-resolver'
+
+type InitCoreTsrHandlerJobResult = CreateDeviceJobsResult
+
+export class InitCoreTsrHandlerJob extends Job<InitCoreTsrHandlerJobResult, CreateDeviceJobsResult, undefined> {
+	protected artifacts: undefined
+
+	async run(previousResult: CreateDeviceJobsResult, abortSignal?: AbortSignal): Promise<InitCoreTsrHandlerJobResult> {
+		if (abortSignal?.aborted) {
+			throw new AbortError()
+		}
+		await previousResult.coreTsrHandler.init()
+		return previousResult
+	}
+}

--- a/packages/playout-gateway/src/tsrHandlerJobs/initDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/initDeviceJob.ts
@@ -20,7 +20,7 @@ import { disableAtemUpload } from '../config'
 import { FinishedTrace, sendTrace } from '../influxdb'
 import debug = require('debug')
 
-export class InitDeviceJob extends Job<CreateDeviceJobsResult, CreateDeviceJobsResult, undefined> {
+export class InitDeviceJob extends Job<CreateDeviceJobsResult, undefined, CreateDeviceJobsResult> {
 	protected artifacts: undefined
 
 	constructor(
@@ -31,6 +31,7 @@ export class InitDeviceJob extends Job<CreateDeviceJobsResult, CreateDeviceJobsR
 	) {
 		super()
 	}
+
 	async run(previousResult: CreateDeviceJobsResult, abortSignal?: AbortSignal): Promise<CreateDeviceJobsResult> {
 		if (abortSignal?.aborted) {
 			throw new AbortError()
@@ -157,7 +158,6 @@ export class InitDeviceJob extends Job<CreateDeviceJobsResult, CreateDeviceJobsR
 		// otherwise there might be problems with threadedclass!
 
 		await deviceContainer.device.on('connectionChanged', onDeviceStatusChanged as () => void)
-		// await device.device.on('slowCommand', onSlowCommand)
 		await deviceContainer.device.on('slowSentCommand', onSlowSentCommand as () => void)
 		await deviceContainer.device.on('slowFulfilledCommand', onSlowFulfilledCommand as () => void)
 		await deviceContainer.device.on('commandError', onCommandError as () => void)

--- a/packages/playout-gateway/src/tsrHandlerJobs/initDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/initDeviceJob.ts
@@ -1,0 +1,201 @@
+import { Logger } from 'winston'
+import { Job } from './job'
+import {
+	AbortError,
+	CommandReport,
+	DeviceOptionsAny,
+	DeviceOptionsAtem,
+	DeviceStatus,
+	DeviceType,
+	MediaObject,
+	SlowFulfilledCommandInfo,
+	SlowSentCommandInfo,
+	StatusCode,
+} from 'timeline-state-resolver'
+import { TSRHandler } from '../tsrHandler'
+import { StatusObject } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
+import _ = require('underscore')
+import { CreateDeviceJobsResult } from './createDeviceJob'
+import { disableAtemUpload } from '../config'
+import { FinishedTrace, sendTrace } from '../influxdb'
+import debug = require('debug')
+
+export class InitDeviceJob extends Job<CreateDeviceJobsResult, CreateDeviceJobsResult, undefined> {
+	protected artifacts: undefined
+
+	constructor(
+		private deviceId: string,
+		private deviceOptions: DeviceOptionsAny,
+		private tsrHandler: TSRHandler,
+		private logger: Logger
+	) {
+		super()
+	}
+	async run(previousResult: CreateDeviceJobsResult, abortSignal?: AbortSignal): Promise<CreateDeviceJobsResult> {
+		if (abortSignal?.aborted) {
+			throw new AbortError()
+		}
+
+		const { deviceContainer, coreTsrHandler } = previousResult
+		// Set up device status
+		const deviceType = deviceContainer.deviceType
+
+		const onDeviceStatusChanged = (connectedOrStatus: Partial<DeviceStatus>) => {
+			let deviceStatus: Partial<StatusObject>
+			if (_.isBoolean(connectedOrStatus)) {
+				// for backwards compability, to be removed later
+				if (connectedOrStatus) {
+					deviceStatus = {
+						statusCode: StatusCode.GOOD,
+					}
+				} else {
+					deviceStatus = {
+						statusCode: StatusCode.BAD,
+						messages: ['Disconnected'],
+					}
+				}
+			} else {
+				deviceStatus = connectedOrStatus
+			}
+			coreTsrHandler.statusChanged(deviceStatus)
+
+			// When the status has changed, the deviceName might have changed:
+			deviceContainer.reloadProps().catch((err) => {
+				this.logger.error(`Error in reloadProps: ${err}`)
+			})
+			// hack to make sure atem has media after restart
+			if (
+				(deviceStatus.statusCode === StatusCode.GOOD ||
+					deviceStatus.statusCode === StatusCode.WARNING_MINOR ||
+					deviceStatus.statusCode === StatusCode.WARNING_MAJOR) &&
+				deviceType === DeviceType.ATEM &&
+				!disableAtemUpload
+			) {
+				const assets = (this.deviceOptions as DeviceOptionsAtem).options?.mediaPoolAssets
+				if (assets && assets.length > 0) {
+					try {
+						this.tsrHandler.uploadFilesToAtem(
+							deviceContainer,
+							assets.filter((asset) => _.isNumber(asset.position) && asset.path)
+						)
+					} catch (e) {
+						// don't worry about it.
+					}
+				}
+			}
+		}
+		const onSlowSentCommand = (info: SlowSentCommandInfo) => {
+			// If the internalDelay is too large, it should be logged as an error,
+			// since something took too long internally.
+
+			if (info.internalDelay > 100) {
+				this.logger.error('slowSentCommand', {
+					deviceName: deviceContainer.deviceName,
+					...info,
+				})
+			} else {
+				this.logger.warn('slowSentCommand', {
+					deviceName: deviceContainer.deviceName,
+					...info,
+				})
+			}
+		}
+		const onSlowFulfilledCommand = (info: SlowFulfilledCommandInfo) => {
+			// Note: we don't emit slow fulfilled commands as error, since
+			// the fulfillment of them lies on the device being controlled, not on us.
+
+			this.logger.warn('slowFulfilledCommand', {
+				deviceName: deviceContainer.deviceName,
+				...info,
+			})
+		}
+		const onCommandReport = (commandReport: CommandReport) => {
+			if (this.tsrHandler.reportAllCommands) {
+				// Todo: send these to Core
+				this.logger.info('commandReport', {
+					commandReport: commandReport,
+				})
+			}
+		}
+		const onCommandError = (error: any, context: any) => {
+			// todo: handle this better
+			this.logger.error(error)
+			this.logger.debug(context)
+		}
+		const onUpdateMediaObject = (collectionId: string, docId: string, doc: MediaObject | null) => {
+			coreTsrHandler.onUpdateMediaObject(collectionId, docId, doc)
+		}
+		const onClearMediaObjectCollection = (collectionId: string) => {
+			coreTsrHandler.onClearMediaObjectCollection(collectionId)
+		}
+		const fixError = (e: any): string => {
+			const name = `Device "${deviceContainer.deviceName || this.deviceId}" (${deviceContainer.instanceId})`
+			if (e.reason) e.reason = name + ': ' + e.reason
+			if (e.message) e.message = name + ': ' + e.message
+			if (e.stack) {
+				e.stack += '\nAt device' + name
+			}
+			if (_.isString(e)) e = name + ': ' + e
+
+			return e
+		}
+
+		deviceContainer.onChildClose = () => {
+			// Called if a child is closed / crashed
+			this.logger.warn(`Child of device ${this.deviceId} closed/crashed`)
+			debug(`Trigger update devices because "${this.deviceId}" process closed`)
+
+			onDeviceStatusChanged({
+				statusCode: StatusCode.BAD,
+				messages: ['Child process closed'],
+			})
+
+			this.tsrHandler.onDeviceChildClosed(this.deviceId)
+		}
+		// Note for the future:
+		// It is important that the callbacks returns void,
+		// otherwise there might be problems with threadedclass!
+
+		await deviceContainer.device.on('connectionChanged', onDeviceStatusChanged as () => void)
+		// await device.device.on('slowCommand', onSlowCommand)
+		await deviceContainer.device.on('slowSentCommand', onSlowSentCommand as () => void)
+		await deviceContainer.device.on('slowFulfilledCommand', onSlowFulfilledCommand as () => void)
+		await deviceContainer.device.on('commandError', onCommandError as () => void)
+		await deviceContainer.device.on('commandReport', onCommandReport as () => void)
+		await deviceContainer.device.on('updateMediaObject', onUpdateMediaObject as () => void)
+		await deviceContainer.device.on('clearMediaObjects', onClearMediaObjectCollection as () => void)
+
+		await deviceContainer.device.on('info', ((e: any, ...args: any[]) => {
+			this.logger.info(fixError(e), ...args)
+		}) as () => void)
+		await deviceContainer.device.on('warning', ((e: any, ...args: any[]) => {
+			this.logger.warn(fixError(e), ...args)
+		}) as () => void)
+		await deviceContainer.device.on('error', ((e: any, ...args: any[]) => {
+			this.logger.error(fixError(e), ...args)
+		}) as () => void)
+
+		await deviceContainer.device.on('debug', (...args: any[]) => {
+			if (!deviceContainer.debugLogging && !this.tsrHandler.coreHandler.logDebug) {
+				return
+			}
+			if (args.length === 0) {
+				this.logger.debug('>empty message<')
+				return
+			}
+			const data = args.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg) : arg))
+			this.logger.debug(
+				`Device "${deviceContainer.deviceName || this.deviceId}" (${deviceContainer.instanceId})`,
+				{ data }
+			)
+		})
+
+		await deviceContainer.device.on('timeTrace', ((trace: FinishedTrace) => sendTrace(trace)) as () => void)
+
+		// now initialize it
+		await this.tsrHandler.tsr.initDevice(this.deviceId, this.deviceOptions, undefined, { signal: abortSignal })
+
+		onDeviceStatusChanged(await deviceContainer.device.getStatus())
+		return previousResult
+	}
+}

--- a/packages/playout-gateway/src/tsrHandlerJobs/job.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/job.ts
@@ -1,0 +1,18 @@
+interface IJob<OwnResultType, PrevResultType> {
+	/**
+	 * Main logic of the Job
+	 */
+	run(previousResult?: PrevResultType, abortSignal?: AbortSignal): Promise<OwnResultType>
+	cleanup(): Promise<void>
+}
+
+export abstract class Job<OwnResultType, PrevResultType, ArtifactsType> implements IJob<OwnResultType, PrevResultType> {
+	protected abstract readonly artifacts: ArtifactsType
+	/**
+	 * Main logic of the Job
+	 */
+	abstract run(previousResult: PrevResultType, abortSignal?: AbortSignal): Promise<OwnResultType>
+	async cleanup(): Promise<void> {
+		return Promise.resolve()
+	}
+}

--- a/packages/playout-gateway/src/tsrHandlerJobs/job.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/job.ts
@@ -1,17 +1,11 @@
-interface IJob<OwnResultType, PrevResultType> {
-	/**
-	 * Main logic of the Job
-	 */
-	run(previousResult?: PrevResultType, abortSignal?: AbortSignal): Promise<OwnResultType>
-	cleanup(): Promise<void>
-}
-
-export abstract class Job<OwnResultType, PrevResultType, ArtifactsType> implements IJob<OwnResultType, PrevResultType> {
+export abstract class Job<ResultType, ArtifactsType = undefined, PreviousResultType = unknown> {
 	protected abstract readonly artifacts: ArtifactsType
+
 	/**
 	 * Main logic of the Job
 	 */
-	abstract run(previousResult: PrevResultType, abortSignal?: AbortSignal): Promise<OwnResultType>
+	abstract run(previousResult: PreviousResultType, abortSignal?: AbortSignal): Promise<ResultType>
+
 	async cleanup(): Promise<void> {
 		return Promise.resolve()
 	}

--- a/packages/playout-gateway/src/tsrHandlerJobs/jobQueue.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/jobQueue.ts
@@ -3,16 +3,16 @@ import { AbortError } from 'timeline-state-resolver'
 import { Logger } from 'winston'
 import { Job } from './job'
 
-interface JobDescription<X> {
+interface JobDescription<ResultType> {
 	id?: string
-	job: Job<X, any, any>
-	chained: boolean
+	job: Job<ResultType, unknown, unknown>
+	isChained: boolean
 	abortController: AbortController
 	timeout?: number
 	didTimeOut?: boolean
-	result?: any
+	result?: ResultType
 	importance?: JobImportance
-	onFulfilled?: FulfilledCallback<X>
+	onFulfilled?: FulfilledCallback<ResultType>
 	onRejected?: RejectedCallback
 	onTimeout?: TimeoutCallback
 }
@@ -22,33 +22,41 @@ export enum JobImportance {
 	LOW = 'low',
 }
 
-type FulfilledCallback<T> = (queue: IJobQueue, result: T) => void
+type FulfilledCallback<ResultType> = (queue: IJobQueue, result: ResultType) => void
 type RejectedCallback = (reason: any) => void
 type TimeoutCallback = (queue: IJobQueue) => void
 
-interface IChainableJobQueue<X> extends IJobQueue {
-	chain: <T, V>(job: Job<T, X, V>, timeout?: number, importance?: JobImportance, id?: string) => IChainableJobQueue<T>
-	end: (onFulfilled?: FulfilledCallback<X>, onRejected?: RejectedCallback, onTimeout?: TimeoutCallback) => void
+interface ChainableJobQueue<PreviousResultType> extends IJobQueue {
+	chain: <ResultType, ArtifactType>(
+		job: Job<ResultType, ArtifactType, PreviousResultType>,
+		timeout?: number,
+		importance?: JobImportance,
+		id?: string
+	) => ChainableJobQueue<ResultType>
+	end: (
+		onFulfilled?: FulfilledCallback<PreviousResultType>,
+		onRejected?: RejectedCallback,
+		onTimeout?: TimeoutCallback
+	) => void
 }
 
 export interface IJobQueue {
 	get length(): number
 	clear(): void
-	endsWith(jobId: string): boolean
 	getLastJobIdByImportance(importance: JobImportance): string | undefined
-	enqueue<T, V>(
-		job: Job<T, void, V>,
+	enqueue<ResultType, ArtifactsType, PreviousResultType>(
+		job: Job<ResultType, ArtifactsType, PreviousResultType>,
 		timeout?: number,
 		importance?: JobImportance,
 		id?: string
-	): IChainableJobQueue<T>
+	): ChainableJobQueue<ResultType>
 	removeJob(jobId: string): void
 }
 
 export class JobQueue extends EventEmitter implements IJobQueue {
-	private queue: JobDescription<any>[] = []
-	private currentJob: JobDescription<any> | null = null
-	private currentJobChain: JobDescription<any>[] = []
+	private queue: JobDescription<unknown>[] = []
+	private currentJob: JobDescription<unknown> | null = null
+	private currentJobChain: JobDescription<unknown>[] = []
 	private currentJobTimeout: NodeJS.Timeout | null = null
 
 	constructor(private name: string, private logger: Logger) {
@@ -62,40 +70,40 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 	clear(): void {
 		if (this.currentJob) {
 			this.abortJob(this.currentJob)
-		} else {
-			if (this.currentJobChain.length) {
-				this.currentJob = this.currentJobChain[this.currentJobChain.length - 1]
-
-				Promise.allSettled(this.currentJobChain.map(async (job) => job.job.cleanup()))
-					.then(this.handleCleanupResults)
-					.finally(this.advanceJob)
-				this.removeChainedJobsFromTheFront()
-			}
+			return
 		}
+		if (!this.currentJobChain.length) return
+
+		this.currentJob = this.currentJobChain[this.currentJobChain.length - 1]
+
+		Promise.allSettled(this.currentJobChain.map(async (jobDescription) => jobDescription.job.cleanup()))
+			.then(this.handleCleanupResults)
+			.finally(this.advanceJob)
+		this.removeChainedJobsFromTheFront()
 	}
 
-	enqueue<T, U>(
-		job: Job<T, void, U>,
+	enqueue<ResultType, ArtifactsType, PreviousResultType>(
+		job: Job<ResultType, ArtifactsType, PreviousResultType>,
 		timeout?: number,
 		importance?: JobImportance,
 		id?: string
-	): IChainableJobQueue<T> {
-		this.queue.push({ id, job, chained: false, timeout, importance, abortController: new AbortController() })
+	): ChainableJobQueue<ResultType> {
+		this.queue.push({ id, job, isChained: false, timeout, importance, abortController: new AbortController() })
 		this.run()
-		return this as IChainableJobQueue<T>
+		return this as ChainableJobQueue<ResultType>
 	}
 
-	chain<T, U, V>(
-		job: Job<T, U, V>,
+	chain<ResultType, ArtifactsType, PreviousResultType>(
+		job: Job<ResultType, ArtifactsType, PreviousResultType>,
 		timeout?: number,
 		importance?: JobImportance,
 		id?: string
-	): IChainableJobQueue<T> {
-		this.queue.push({ id, job, chained: true, timeout, importance, abortController: new AbortController() })
-		return this as IChainableJobQueue<T>
+	): ChainableJobQueue<ResultType> {
+		this.queue.push({ id, job, isChained: true, timeout, importance, abortController: new AbortController() })
+		return this as ChainableJobQueue<ResultType>
 	}
 
-	end<X>(onFulfilled?: FulfilledCallback<X>, onRejected?: RejectedCallback, onTimeout?: TimeoutCallback): void {
+	end(onFulfilled?: FulfilledCallback<unknown>, onRejected?: RejectedCallback, onTimeout?: TimeoutCallback): void {
 		const lastJob = this.queue[this.queue.length - 1]
 		if (!lastJob) return
 		lastJob.onFulfilled = onFulfilled
@@ -116,12 +124,7 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 	}
 
 	removeJob(jobId: string): void {
-		this.queue = this.queue.filter((job) => job.id !== jobId && !job.chained)
-	}
-
-	endsWith(jobId: string): boolean {
-		const lastJob = this.queue[this.queue.length - 1] ?? this.currentJob
-		return lastJob?.id === jobId
+		this.queue = this.queue.filter((job) => job.id !== jobId && !job.isChained)
 	}
 
 	private run(): void {
@@ -152,14 +155,14 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 		})
 	}
 
-	private handleJobFulfilled = (result: any): void => {
+	private handleJobFulfilled = (result: unknown): void => {
 		if (!this.currentJob) return
 		if (this.currentJob.abortController.signal.aborted) {
 			throw new AbortError()
 		}
 		this.currentJob.result = result
 		const nextJob = this.queue[0]
-		if (nextJob?.chained) {
+		if (nextJob?.isChained) {
 			this.currentJobChain.push(this.currentJob)
 		}
 		if (this.currentJob.onFulfilled) {
@@ -167,20 +170,20 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 		}
 	}
 
-	private handleJobRejected = async (reason: any): Promise<PromiseSettledResult<void>[] | void> => {
+	private handleJobRejected = async (reason: unknown): Promise<PromiseSettledResult<void>[] | void> => {
 		if (!this.currentJob) return
 		this.logger.error(
 			`Error in queue "${this.name}" at Job.run "${this.currentJob.job.constructor.name}": ${reason}`
 		)
-		const ps = []
+		const cleanupPromises = []
 		if (this.currentJobChain.length) {
-			ps.push(...this.currentJobChain.map(async (job) => job.job.cleanup()))
+			cleanupPromises.push(...this.currentJobChain.map(async (job) => job.job.cleanup()))
 			this.currentJobChain = []
 		}
-		ps.push(this.currentJob.job.cleanup())
+		cleanupPromises.push(this.currentJob.job.cleanup())
 		const lastChainedJob = this.removeChainedJobsFromTheFront() ?? this.currentJob
 
-		const result = await Promise.allSettled(ps)
+		const result = await Promise.allSettled(cleanupPromises)
 		if (this.currentJob.didTimeOut && lastChainedJob?.onTimeout) {
 			lastChainedJob.onTimeout(this)
 		} else if (lastChainedJob?.onRejected) {
@@ -199,10 +202,10 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 		}
 	}
 
-	private removeChainedJobsFromTheFront(): JobDescription<any> | undefined {
-		let lastChainedJob: JobDescription<any> | undefined
+	private removeChainedJobsFromTheFront(): JobDescription<unknown> | undefined {
+		let lastChainedJob: JobDescription<unknown> | undefined
 		for (const job of this.queue) {
-			if (job.chained) {
+			if (job.isChained) {
 				lastChainedJob = this.queue.shift()
 			} else {
 				break
@@ -211,7 +214,7 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 		return lastChainedJob
 	}
 
-	private abortJob = (job: JobDescription<any>) => {
+	private abortJob = (job: JobDescription<unknown>) => {
 		job.abortController.abort()
 	}
 
@@ -223,7 +226,7 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 		}
 
 		const nextJob = this.queue[0]
-		if (!nextJob?.chained && this.currentJobChain.length) {
+		if (!nextJob?.isChained && this.currentJobChain.length) {
 			this.currentJobChain = []
 		}
 		this.run()

--- a/packages/playout-gateway/src/tsrHandlerJobs/jobQueue.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/jobQueue.ts
@@ -22,9 +22,9 @@ export enum JobImportance {
 	LOW = 'low',
 }
 
-type FulfilledCallback<ResultType> = (queue: IJobQueue, result: ResultType) => void
+type FulfilledCallback<ResultType> = (result: ResultType) => void
 type RejectedCallback = (reason: any) => void
-type TimeoutCallback = (queue: IJobQueue) => void
+type TimeoutCallback = () => void
 
 interface ChainableJobQueue<PreviousResultType> extends IJobQueue {
 	chain: <ResultType, ArtifactType>(
@@ -166,7 +166,7 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 			this.currentJobChain.push(this.currentJob)
 		}
 		if (this.currentJob.onFulfilled) {
-			this.currentJob.onFulfilled(this, result)
+			this.currentJob.onFulfilled(result)
 		}
 	}
 
@@ -185,7 +185,7 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 
 		const result = await Promise.allSettled(cleanupPromises)
 		if (this.currentJob.didTimeOut && lastChainedJob?.onTimeout) {
-			lastChainedJob.onTimeout(this)
+			lastChainedJob.onTimeout()
 		} else if (lastChainedJob?.onRejected) {
 			lastChainedJob.onRejected(reason)
 		}

--- a/packages/playout-gateway/src/tsrHandlerJobs/jobQueue.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/jobQueue.ts
@@ -1,0 +1,231 @@
+import { EventEmitter } from 'stream'
+import { AbortError } from 'timeline-state-resolver'
+import { Logger } from 'winston'
+import { Job } from './job'
+
+interface JobDescription<X> {
+	id?: string
+	job: Job<X, any, any>
+	chained: boolean
+	abortController: AbortController
+	timeout?: number
+	didTimeOut?: boolean
+	result?: any
+	importance?: JobImportance
+	onFulfilled?: FulfilledCallback<X>
+	onRejected?: RejectedCallback
+	onTimeout?: TimeoutCallback
+}
+
+export enum JobImportance {
+	HIGH = 'high',
+	LOW = 'low',
+}
+
+type FulfilledCallback<T> = (queue: IJobQueue, result: T) => void
+type RejectedCallback = (reason: any) => void
+type TimeoutCallback = (queue: IJobQueue) => void
+
+interface IChainableJobQueue<X> extends IJobQueue {
+	chain: <T, V>(job: Job<T, X, V>, timeout?: number, importance?: JobImportance, id?: string) => IChainableJobQueue<T>
+	end: (onFulfilled?: FulfilledCallback<X>, onRejected?: RejectedCallback, onTimeout?: TimeoutCallback) => void
+}
+
+export interface IJobQueue {
+	get length(): number
+	clear(): void
+	endsWith(jobId: string): boolean
+	getLastJobIdByImportance(importance: JobImportance): string | undefined
+	enqueue<T, V>(
+		job: Job<T, void, V>,
+		timeout?: number,
+		importance?: JobImportance,
+		id?: string
+	): IChainableJobQueue<T>
+	removeJob(jobId: string): void
+}
+
+export class JobQueue extends EventEmitter implements IJobQueue {
+	private queue: JobDescription<any>[] = []
+	private currentJob: JobDescription<any> | null = null
+	private currentJobChain: JobDescription<any>[] = []
+	private currentJobTimeout: NodeJS.Timeout | null = null
+
+	constructor(private name: string, private logger: Logger) {
+		super()
+	}
+
+	get length(): number {
+		return this.queue.length
+	}
+
+	clear(): void {
+		if (this.currentJob) {
+			this.abortJob(this.currentJob)
+		} else {
+			if (this.currentJobChain.length) {
+				this.currentJob = this.currentJobChain[this.currentJobChain.length - 1]
+
+				Promise.allSettled(this.currentJobChain.map(async (job) => job.job.cleanup()))
+					.then(this.handleCleanupResults)
+					.finally(this.advanceJob)
+				this.removeChainedJobsFromTheFront()
+			}
+		}
+	}
+
+	enqueue<T, U>(
+		job: Job<T, void, U>,
+		timeout?: number,
+		importance?: JobImportance,
+		id?: string
+	): IChainableJobQueue<T> {
+		this.queue.push({ id, job, chained: false, timeout, importance, abortController: new AbortController() })
+		this.run()
+		return this as IChainableJobQueue<T>
+	}
+
+	chain<T, U, V>(
+		job: Job<T, U, V>,
+		timeout?: number,
+		importance?: JobImportance,
+		id?: string
+	): IChainableJobQueue<T> {
+		this.queue.push({ id, job, chained: true, timeout, importance, abortController: new AbortController() })
+		return this as IChainableJobQueue<T>
+	}
+
+	end<X>(onFulfilled?: FulfilledCallback<X>, onRejected?: RejectedCallback, onTimeout?: TimeoutCallback): void {
+		const lastJob = this.queue[this.queue.length - 1]
+		if (!lastJob) return
+		lastJob.onFulfilled = onFulfilled
+		lastJob.onRejected = onRejected
+		lastJob.onTimeout = onTimeout
+	}
+
+	getLastJobIdByImportance(importance: JobImportance): string | undefined {
+		for (let i = this.queue.length - 1; i >= 0; --i) {
+			if (this.queue[i].importance === importance) {
+				return this.queue[i].id
+			}
+		}
+		if (this.currentJob?.importance === importance) {
+			return this.currentJob.id
+		}
+		return undefined
+	}
+
+	removeJob(jobId: string): void {
+		this.queue = this.queue.filter((job) => job.id !== jobId && !job.chained)
+	}
+
+	endsWith(jobId: string): boolean {
+		const lastJob = this.queue[this.queue.length - 1] ?? this.currentJob
+		return lastJob?.id === jobId
+	}
+
+	private run(): void {
+		setImmediate(() => {
+			if (this.currentJob) {
+				return
+			}
+			if (this.queue.length === 0 && this.currentJobChain.length === 0) {
+				this.emit('done')
+			}
+			this.currentJob = this.queue.shift() ?? null
+			if (!this.currentJob) return
+			const jobChainTop = this.currentJobChain[this.currentJobChain.length - 1]
+			const prevResult = jobChainTop?.result
+			const currentJob = this.currentJob
+			if (this.currentJob.timeout) {
+				this.currentJobTimeout = setTimeout(() => {
+					this.abortJob(currentJob)
+					currentJob.didTimeOut = true
+				}, this.currentJob.timeout)
+			}
+			this.currentJob.job
+				.run(prevResult, this.currentJob.abortController.signal)
+				.then(this.handleJobFulfilled)
+				.catch(this.handleJobRejected)
+				.then(this.handleCleanupResults)
+				.finally(this.advanceJob)
+		})
+	}
+
+	private handleJobFulfilled = (result: any): void => {
+		if (!this.currentJob) return
+		if (this.currentJob.abortController.signal.aborted) {
+			throw new AbortError()
+		}
+		this.currentJob.result = result
+		const nextJob = this.queue[0]
+		if (nextJob?.chained) {
+			this.currentJobChain.push(this.currentJob)
+		}
+		if (this.currentJob.onFulfilled) {
+			this.currentJob.onFulfilled(this, result)
+		}
+	}
+
+	private handleJobRejected = async (reason: any): Promise<PromiseSettledResult<void>[] | void> => {
+		if (!this.currentJob) return
+		this.logger.error(
+			`Error in queue "${this.name}" at Job.run "${this.currentJob.job.constructor.name}": ${reason}`
+		)
+		const ps = []
+		if (this.currentJobChain.length) {
+			ps.push(...this.currentJobChain.map(async (job) => job.job.cleanup()))
+			this.currentJobChain = []
+		}
+		ps.push(this.currentJob.job.cleanup())
+		const lastChainedJob = this.removeChainedJobsFromTheFront() ?? this.currentJob
+
+		const result = await Promise.allSettled(ps)
+		if (this.currentJob.didTimeOut && lastChainedJob?.onTimeout) {
+			lastChainedJob.onTimeout(this)
+		} else if (lastChainedJob?.onRejected) {
+			lastChainedJob.onRejected(reason)
+		}
+		return result
+	}
+
+	private handleCleanupResults = (results: PromiseSettledResult<void>[] | void) => {
+		if (!results) {
+			return
+		}
+		const failedCleanups = results.filter((result) => result.status === 'rejected') as PromiseRejectedResult[]
+		for (const result of failedCleanups) {
+			this.logger.error(`Error in queue "${this.name}" at Job.cleanup: ${result.reason}`)
+		}
+	}
+
+	private removeChainedJobsFromTheFront(): JobDescription<any> | undefined {
+		let lastChainedJob: JobDescription<any> | undefined
+		for (const job of this.queue) {
+			if (job.chained) {
+				lastChainedJob = this.queue.shift()
+			} else {
+				break
+			}
+		}
+		return lastChainedJob
+	}
+
+	private abortJob = (job: JobDescription<any>) => {
+		job.abortController.abort()
+	}
+
+	private advanceJob = () => {
+		this.currentJob = null
+		if (this.currentJobTimeout) {
+			clearTimeout(this.currentJobTimeout)
+			this.currentJobTimeout = null
+		}
+
+		const nextJob = this.queue[0]
+		if (!nextJob?.chained && this.currentJobChain.length) {
+			this.currentJobChain = []
+		}
+		this.run()
+	}
+}

--- a/packages/playout-gateway/src/tsrHandlerJobs/jobQueueManager.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/jobQueueManager.ts
@@ -1,0 +1,18 @@
+import { Logger } from 'winston'
+import { IJobQueue, JobQueue } from './jobQueue'
+
+export class JobQueueManager {
+	private jobQueues = new Map<string, JobQueue>()
+
+	constructor(private logger: Logger) {}
+
+	get(queueName: string): IJobQueue {
+		let queue = this.jobQueues.get(queueName)
+		if (!queue) {
+			queue = new JobQueue(queueName, this.logger)
+			queue.once('done', () => this.jobQueues.delete(queueName))
+			this.jobQueues.set(queueName, queue)
+		}
+		return queue
+	}
+}

--- a/packages/playout-gateway/src/tsrHandlerJobs/removeDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/removeDeviceJob.ts
@@ -1,0 +1,28 @@
+import { CoreTSRDeviceHandler } from '../coreHandler'
+import { Logger } from 'winston'
+import { Job } from './job'
+
+export class RemoveDeviceJob extends Job<void, any, undefined> {
+	protected artifacts: undefined
+
+	constructor(
+		private deviceId: string,
+		private coreTsrHandlers: { [deviceId: string]: CoreTSRDeviceHandler },
+		private expected: boolean,
+		private logger: Logger
+	) {
+		super()
+	}
+	async run(): Promise<void> {
+		if (this.coreTsrHandlers[this.deviceId]) {
+			try {
+				await this.coreTsrHandlers[this.deviceId].dispose(this.expected)
+				this.logger.debug('Disposed device ' + this.deviceId)
+			} catch (error) {
+				this.logger.error(`Error when removing device "${this.deviceId}"`, { data: error })
+			} finally {
+				delete this.coreTsrHandlers[this.deviceId]
+			}
+		}
+	}
+}

--- a/packages/playout-gateway/src/tsrHandlerJobs/removeDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/removeDeviceJob.ts
@@ -2,7 +2,7 @@ import { CoreTSRDeviceHandler } from '../coreHandler'
 import { Logger } from 'winston'
 import { Job } from './job'
 
-export class RemoveDeviceJob extends Job<void, any, undefined> {
+export class RemoveDeviceJob extends Job<void> {
 	protected artifacts: undefined
 
 	constructor(
@@ -13,10 +13,15 @@ export class RemoveDeviceJob extends Job<void, any, undefined> {
 	) {
 		super()
 	}
+
 	async run(): Promise<void> {
 		if (this.coreTsrHandlers[this.deviceId]) {
 			try {
-				await this.coreTsrHandlers[this.deviceId].dispose(this.expected)
+				if (this.expected) {
+					await this.coreTsrHandlers[this.deviceId].disposeExpectedly()
+				} else {
+					await this.coreTsrHandlers[this.deviceId].disposeUnexpectedly()
+				}
 				this.logger.debug('Disposed device ' + this.deviceId)
 			} catch (error) {
 				this.logger.error(`Error when removing device "${this.deviceId}"`, { data: error })

--- a/packages/playout-gateway/src/tsrHandlerJobs/setDebugLogging.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/setDebugLogging.ts
@@ -1,0 +1,17 @@
+import { Job } from './job'
+import { Conductor } from 'timeline-state-resolver'
+
+export class SetDebugLoggingJob extends Job<void, void, undefined> {
+	protected artifacts: undefined
+
+	constructor(private deviceId: string, private conductor: Conductor, private debugLogging: boolean) {
+		super()
+	}
+	async run(): Promise<void> {
+		const deviceContainer = this.conductor.getDevice(this.deviceId)
+		if (!deviceContainer) {
+			throw new Error(`Device "${this.deviceId}" does not exist or is not initialized`)
+		}
+		await deviceContainer.setDebugLogging(this.debugLogging)
+	}
+}

--- a/packages/playout-gateway/src/tsrHandlerJobs/setDebugLoggingJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/setDebugLoggingJob.ts
@@ -1,12 +1,13 @@
 import { Job } from './job'
 import { Conductor } from 'timeline-state-resolver'
 
-export class SetDebugLoggingJob extends Job<void, void, undefined> {
+export class SetDebugLoggingJob extends Job<void> {
 	protected artifacts: undefined
 
 	constructor(private deviceId: string, private conductor: Conductor, private debugLogging: boolean) {
 		super()
 	}
+
 	async run(): Promise<void> {
 		const deviceContainer = this.conductor.getDevice(this.deviceId)
 		if (!deviceContainer) {

--- a/packages/playout-gateway/src/tsrHandlerJobs/updateExpectedPlayoutItemsJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/updateExpectedPlayoutItemsJob.ts
@@ -3,7 +3,7 @@ import { Conductor, ExpectedPlayoutItem, ExpectedPlayoutItemContent } from 'time
 import _ = require('underscore')
 import { CollectionObj } from '@sofie-automation/server-core-integration'
 
-export class UpdateExpectedPlayoutItemsJob extends Job<void, void, undefined> {
+export class UpdateExpectedPlayoutItemsJob extends Job<void, void> {
 	protected artifacts: undefined
 
 	constructor(
@@ -14,6 +14,7 @@ export class UpdateExpectedPlayoutItemsJob extends Job<void, void, undefined> {
 	) {
 		super()
 	}
+
 	async run(): Promise<void> {
 		const deviceContainer = this.conductor.getDevice(this.deviceId)
 		if (!deviceContainer) {

--- a/packages/playout-gateway/src/tsrHandlerJobs/updateExpectedPlayoutItemsJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/updateExpectedPlayoutItemsJob.ts
@@ -1,0 +1,41 @@
+import { Job } from './job'
+import { Conductor, ExpectedPlayoutItem, ExpectedPlayoutItemContent } from 'timeline-state-resolver'
+import _ = require('underscore')
+import { CollectionObj } from '@sofie-automation/server-core-integration'
+
+export class UpdateExpectedPlayoutItemsJob extends Job<void, void, undefined> {
+	protected artifacts: undefined
+
+	constructor(
+		private deviceId: string,
+		private conductor: Conductor,
+		private expectedPlayoutItems: Record<string, CollectionObj[]>,
+		private rundowns: Record<string, CollectionObj>
+	) {
+		super()
+	}
+	async run(): Promise<void> {
+		const deviceContainer = this.conductor.getDevice(this.deviceId)
+		if (!deviceContainer) {
+			throw new Error(`Device "${this.deviceId}" does not exist or is not initialized`)
+		}
+		if (!(await deviceContainer.device.supportsExpectedPlayoutItems)) {
+			return
+		}
+		const expectedPlayoutItemsForDeviceType = this.expectedPlayoutItems[deviceContainer.deviceType]
+		if (!expectedPlayoutItemsForDeviceType) {
+			return
+		}
+		await deviceContainer.device.handleExpectedPlayoutItems(
+			_.map(expectedPlayoutItemsForDeviceType, (item): ExpectedPlayoutItem => {
+				const itemContent: ExpectedPlayoutItemContent = item.content
+				return {
+					...itemContent,
+					rundownId: item.rundownId,
+					playlistId: item.rundownId && this.rundowns[item.rundownId]?.playlistId,
+					baseline: item.baseline,
+				}
+			})
+		)
+	}
+}

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3095,7 +3095,7 @@
   version "46.0.4"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.0.3"
+    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.1.0"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 
@@ -13993,17 +13993,17 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.0.3.tgz#cb22a1dee460403c2a306e666003a1d57af7f8d2"
-  integrity sha512-PqqV2EFCfhQyphngRFh0K7UcO+pptB5e6vk73uT+gz0S+j/aV2uAtOKA3PPeEc7W37ov4KCsP10T4KVTntNkAw==
+"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.1.0.tgz#1f5c2de4943c2d422ab6eb049da6f064a510e080"
+  integrity sha512-sjVvIdLAgR2ciX8oJZkLBaPwUt4WtU7TYlzaS3OdrfZMXQWhWnxwUmjYHfSB69VXIoiP1ZP4rknKh6Q73+N3Cg==
   dependencies:
     tslib "^2.3.1"
 
-"timeline-state-resolver@npm:@tv2media/timeline-state-resolver@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver/-/timeline-state-resolver-3.0.3.tgz#126597abd24f049d80688eecb824bbe3e5a270c2"
-  integrity sha512-+8cbkuFVi8OAMn8McAghn/l5vmPYjFRxFNKqj2QQuFQA62W0UOmHxJlNsYXe3AJKooPjDZUC/PKs5g+FvW+nlw==
+"timeline-state-resolver@npm:@tv2media/timeline-state-resolver@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver/-/timeline-state-resolver-3.1.0.tgz#c85df55187682d953fb2fc965ad79a43a21c0fb7"
+  integrity sha512-IAQC70TVulL6nfYLYfucd8wb4SBPkPnyM4USxoA0YhazwJH9qyV8r/lmTLZbA67LgOOcIFvUbiJj340p8Lo/mg==
   dependencies:
     "@tv2media/v-connection" "^7.2.1"
     atem-connection "2.4.0"
@@ -14025,7 +14025,7 @@ timecode@0.0.4:
     sprintf-js "^1.1.2"
     superfly-timeline "^8.2.8"
     threadedclass "^1.1.1"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.0.3"
+    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.1.0"
     tslib "^2.3.1"
     tv-automation-quantel-gateway-client "^2.0.5"
     underscore "^1.13.4"

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3092,7 +3092,7 @@
     webpack-sources "^3.2.2"
 
 "@sofie-automation/blueprints-integration@link:blueprints-integration":
-  version "46.0.3"
+  version "46.0.4"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
     timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.0.3"
@@ -3687,6 +3687,11 @@
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
+
+"@types/object-hash@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-3.0.1.tgz#6e9adda54582dac92fff9f2ea3e2d7651c17d15e"
+  integrity sha512-AeyooJR4pesRnPLXONFEpxrdvwYVkBiq26j4Uo4QYcJO2FQhAFmHHWBfRpEzwMtItz7q9JiD50s7HDbHS7PleQ==
 
 "@types/object-path@^0.11.1":
   version "0.11.1"
@@ -10842,6 +10847,11 @@ object-filter-sequence@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/object-filter-sequence/-/object-filter-sequence-1.0.0.tgz#10bb05402fff100082b80d7e83991b10db411692"
   integrity sha512-CsubGNxhIEChNY4cXYuA6KXafztzHqzLLZ/y3Kasf3A+sa3lL9thq3z+7o0pZqzEinjXT6lXDPAfVWI59dUyzQ==
+
+object-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
+  integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
 object-identity-map@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Fixes a bug that caused a device to be half-removed if its creation timed out, leaving it in an unwanted state that required user intervention. Refactors the device update logic, uses a queue to manage the actions. Some actions are broken down into multiple chained jobs to facilitate cleanup if one of the jobs fails or if the queue is cleared entirely (when settings of a device change before it's fully created and initialized, or a device pending creation is no longer needed)
Depends on https://github.com/tv2/tv-automation-state-timeline-resolver/pull/44
