### PR TITLE
feat: SOF-1272 expose TriCaster subdevice and mappings

### DIFF
--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -39,7 +39,7 @@
 	],
 	"dependencies": {
 		"@sofie-automation/shared-lib": "link:../shared-lib",
-		"timeline-state-resolver-types": "npm:@tv2media/timeline-state-resolver-types@3.2.0",
+		"timeline-state-resolver-types": "npm:@tv2media/timeline-state-resolver-types@3.3.0",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0"
 	},

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -39,7 +39,7 @@
 	],
 	"dependencies": {
 		"@sofie-automation/shared-lib": "link:../shared-lib",
-		"timeline-state-resolver-types": "npm:@tv2media/timeline-state-resolver-types@3.1.0",
+		"timeline-state-resolver-types": "npm:@tv2media/timeline-state-resolver-types@3.2.0",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0"
 	},

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -63,7 +63,7 @@
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
 		"object-hash": "^3.0.0",
-		"timeline-state-resolver": "npm:@tv2media/timeline-state-resolver@3.2.0",
+		"timeline-state-resolver": "npm:@tv2media/timeline-state-resolver@3.3.0",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.4",
 		"winston": "^3.8.2"

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -63,7 +63,7 @@
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
 		"object-hash": "^3.0.0",
-		"timeline-state-resolver": "npm:@tv2media/timeline-state-resolver@3.1.0",
+		"timeline-state-resolver": "npm:@tv2media/timeline-state-resolver@3.2.0",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.4",
 		"winston": "^3.8.2"

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -19,6 +19,7 @@ import {
 	QuantelControlMode,
 	MappingVMixType,
 	MappingOBSType,
+	MappingTriCasterType,
 } from 'timeline-state-resolver'
 
 const PLAYOUT_SUBDEVICE_COMMON: ConfigManifestEntry[] = [
@@ -445,6 +446,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 		},
 	],
 	[TSRDeviceType.TELEMETRICS]: [...PLAYOUT_SUBDEVICE_HOST],
+	[TSRDeviceType.TRICASTER]: [...PLAYOUT_SUBDEVICE_COMMON, ...PLAYOUT_SUBDEVICE_HOST_PORT],
 }
 
 // TODO: should come from types
@@ -659,6 +661,22 @@ const MAPPING_MANIFEST: ImplementedMappingsManifest = {
 		},
 	],
 	[TSRDeviceType.TELEMETRICS]: [],
+	[TSRDeviceType.TRICASTER]: [
+		{
+			id: 'mappingType',
+			type: ConfigManifestEntryType.ENUM,
+			values: MappingTriCasterType,
+			name: 'Mapping Type',
+			includeInSummary: true,
+		},
+		{
+			id: 'name',
+			type: ConfigManifestEntryType.STRING,
+			name: 'Target Name',
+			includeInSummary: true,
+			optional: false,
+		},
+	],
 }
 
 export const PLAYOUT_DEVICE_CONFIG: DeviceConfigManifest = {

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -665,7 +665,7 @@ const MAPPING_MANIFEST: ImplementedMappingsManifest = {
 		{
 			id: 'mappingType',
 			type: ConfigManifestEntryType.ENUM,
-			values: MappingTriCasterType,
+			values: Object.values(MappingTriCasterType),
 			name: 'Mapping Type',
 			includeInSummary: true,
 		},

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3092,10 +3092,10 @@
     webpack-sources "^3.2.2"
 
 "@sofie-automation/blueprints-integration@link:blueprints-integration":
-  version "46.0.4"
+  version "46.1.1"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.1.0"
+    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.2.0"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 
@@ -3120,7 +3120,7 @@
     shelljs "^0.8.5"
 
 "@sofie-automation/corelib@link:corelib":
-  version "46.0.0"
+  version "46.1.0"
   dependencies:
     "@sofie-automation/blueprints-integration" "link:blueprints-integration"
     "@sofie-automation/shared-lib" "link:shared-lib"
@@ -3136,7 +3136,7 @@
     underscore "^1.13.4"
 
 "@sofie-automation/server-core-integration@link:server-core-integration":
-  version "46.0.1"
+  version "46.1.0"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
     ejson "^2.2.3"
@@ -3147,7 +3147,7 @@
     underscore "^1.13.4"
 
 "@sofie-automation/shared-lib@link:shared-lib":
-  version "46.0.0"
+  version "46.1.0"
   dependencies:
     tslib "^2.4.0"
     type-fest "^2.19.0"
@@ -13993,17 +13993,17 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.1.0.tgz#1f5c2de4943c2d422ab6eb049da6f064a510e080"
-  integrity sha512-sjVvIdLAgR2ciX8oJZkLBaPwUt4WtU7TYlzaS3OdrfZMXQWhWnxwUmjYHfSB69VXIoiP1ZP4rknKh6Q73+N3Cg==
+"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.2.0.tgz#8a0b77ece176e0c837122e94ecf7ae4d96e25b64"
+  integrity sha512-SMDeu+dfJU479ijWeC7oaDZOiMTBGXP1mCqQUiuZxsVaM0MVJh0qHBojqC+BlJ9kFsIfM5jaSEPs21Kl3FyjKw==
   dependencies:
     tslib "^2.3.1"
 
-"timeline-state-resolver@npm:@tv2media/timeline-state-resolver@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver/-/timeline-state-resolver-3.1.0.tgz#c85df55187682d953fb2fc965ad79a43a21c0fb7"
-  integrity sha512-IAQC70TVulL6nfYLYfucd8wb4SBPkPnyM4USxoA0YhazwJH9qyV8r/lmTLZbA67LgOOcIFvUbiJj340p8Lo/mg==
+"timeline-state-resolver@npm:@tv2media/timeline-state-resolver@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver/-/timeline-state-resolver-3.2.0.tgz#5ea88902c784c339676d285ddff12c47485ee328"
+  integrity sha512-6qX3/t7lTtU0trDlSFJb3CCce9T4VzB/dHCRsCtXyfzFdYoghxNXrKGV/zzWHU0j4KbYTt+KR+RGiHbUwgP/og==
   dependencies:
     "@tv2media/v-connection" "^7.2.1"
     atem-connection "2.4.0"
@@ -14025,7 +14025,7 @@ timecode@0.0.4:
     sprintf-js "^1.1.2"
     superfly-timeline "^8.2.8"
     threadedclass "^1.1.1"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.1.0"
+    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.2.0"
     tslib "^2.3.1"
     tv-automation-quantel-gateway-client "^2.0.5"
     underscore "^1.13.4"

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3095,7 +3095,7 @@
   version "46.1.1"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.2.0"
+    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.3.0"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 
@@ -13993,17 +13993,17 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.2.0.tgz#8a0b77ece176e0c837122e94ecf7ae4d96e25b64"
-  integrity sha512-SMDeu+dfJU479ijWeC7oaDZOiMTBGXP1mCqQUiuZxsVaM0MVJh0qHBojqC+BlJ9kFsIfM5jaSEPs21Kl3FyjKw==
+"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.3.0.tgz#08e5b700d59a92855f27e80e98830307f0e50ead"
+  integrity sha512-2fnXgtg3H1mZwQNz1ax7kHPXhcMmp3ak7qVf8WIPysodtBXExP4LoRypv6fgOzX15og+gmgR3YYQGLrqiw14QA==
   dependencies:
     tslib "^2.3.1"
 
-"timeline-state-resolver@npm:@tv2media/timeline-state-resolver@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver/-/timeline-state-resolver-3.2.0.tgz#5ea88902c784c339676d285ddff12c47485ee328"
-  integrity sha512-6qX3/t7lTtU0trDlSFJb3CCce9T4VzB/dHCRsCtXyfzFdYoghxNXrKGV/zzWHU0j4KbYTt+KR+RGiHbUwgP/og==
+"timeline-state-resolver@npm:@tv2media/timeline-state-resolver@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver/-/timeline-state-resolver-3.3.0.tgz#1188af9a0857f89184826ee9f15a13d941300e0c"
+  integrity sha512-5m4zXb2llUvLtn3RAFPq4qpkkGqIviopZBCEehWvZEkKRhaz08WOlnV2Et02E+EEnF4U/mdhU2YUwUMs4ZeWtw==
   dependencies:
     "@tv2media/v-connection" "^7.2.1"
     atem-connection "2.4.0"
@@ -14025,7 +14025,7 @@ timecode@0.0.4:
     sprintf-js "^1.1.2"
     superfly-timeline "^8.2.8"
     threadedclass "^1.1.1"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.2.0"
+    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.3.0"
     tslib "^2.3.1"
     tv-automation-quantel-gateway-client "^2.0.5"
     underscore "^1.13.4"


### PR DESCRIPTION
Exposes the bare minimum. Would be nice to have some dropdowns or other ways to prepopulate/validate the mapping target name, but the mappings are generated by the blueprints anyway, and there's type checking in there.

Depends on https://github.com/tv2/tv-automation-state-timeline-resolver/pull/46 (before merging this PR it needs bumping the TSR and TSR types after they're released)