### PR TITLE
Sof 1337/playout gateway produces many useless logs

### DIFF
--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -9832,10 +9832,10 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.1.0.tgz#1f5c2de4943c2d422ab6eb049da6f064a510e080"
-  integrity sha512-sjVvIdLAgR2ciX8oJZkLBaPwUt4WtU7TYlzaS3OdrfZMXQWhWnxwUmjYHfSB69VXIoiP1ZP4rknKh6Q73+N3Cg==
+"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.3.0.tgz#08e5b700d59a92855f27e80e98830307f0e50ead"
+  integrity sha512-2fnXgtg3H1mZwQNz1ax7kHPXhcMmp3ak7qVf8WIPysodtBXExP4LoRypv6fgOzX15og+gmgR3YYQGLrqiw14QA==
   dependencies:
     tslib "^2.3.1"
 

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -59,14 +59,14 @@
 		"@sofie-automation/blueprints-integration": "link:../blueprints-integration",
 		"@sofie-automation/server-core-integration": "link:../server-core-integration",
 		"@sofie-automation/shared-lib": "link:../shared-lib",
+		"@tv2media/logger": "^2.0.0",
 		"debug": "^4.3.3",
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
 		"object-hash": "^3.0.0",
 		"timeline-state-resolver": "npm:@tv2media/timeline-state-resolver@3.3.0",
 		"tslib": "^2.4.0",
-		"underscore": "^1.13.4",
-		"winston": "^3.8.2"
+		"underscore": "^1.13.4"
 	},
 	"lint-staged": {
 		"*.{css,json,md,scss}": [

--- a/packages/playout-gateway/src/atemUploader.ts
+++ b/packages/playout-gateway/src/atemUploader.ts
@@ -14,10 +14,10 @@ import * as path from 'path'
 const ATEM_MAX_FILENAME_LENGTH = 63
 const ATEM_MAX_CLIPNAME_LENGTH = 43
 
-function consoleLog(...args: any[]) {
+function consoleLog(...args: unknown[]) {
 	console.log('AtemUpload:', ...args)
 }
-function consoleError(...args: any[]) {
+function consoleError(...args: unknown[]) {
 	console.error('AtemUpload:', ...args)
 }
 export class AtemUploadScript {

--- a/packages/playout-gateway/src/atemUploader.ts
+++ b/packages/playout-gateway/src/atemUploader.ts
@@ -5,9 +5,9 @@ import * as fs from 'fs'
 import { AtemMediaPoolAsset, AtemMediaPoolType } from 'timeline-state-resolver'
 import * as _ from 'underscore'
 import * as path from 'path'
-import { logger } from './logger'
+import { logger as untaggedLogger } from './logger'
 
-const atemUploaderLogger = logger.tag('atemUploader')
+const logger = untaggedLogger.tag('atemUploader')
 
 /**
  * This script is a temporary implementation to upload media to the atem.
@@ -23,7 +23,7 @@ export class AtemUploadScript {
 	constructor() {
 		this.connection = new Atem()
 
-		this.connection.on('error', (error) => atemUploaderLogger.data(error).error('A connection error occurred:'))
+		this.connection.on('error', (error) => logger.data(error).error('A connection error occurred:'))
 	}
 
 	public async connect(ip: string): Promise<void> {
@@ -40,23 +40,23 @@ export class AtemUploadScript {
 	public async loadFile(fileUrl: string): Promise<Buffer> {
 		return new Promise<Buffer>((resolve, reject) => {
 			fs.readFile(fileUrl, (error, data) => {
-				atemUploaderLogger.debug('got file')
+				logger.debug('got file')
 				error ? reject(error) : resolve(data)
 			})
 		})
 	}
 	public async loadFiles(folder: string): Promise<Buffer[]> {
 		const files = await fs.promises.readdir(folder)
-		atemUploaderLogger.data(files).debug('Listed files')
+		logger.data(files).debug('Listed files')
 		const loadBuffers = files.map(async (file) => fs.promises.readFile(path.join(folder, file)))
 		const buffers = Promise.all(loadBuffers)
 
-		atemUploaderLogger.data(buffers).debug('got files')
+		logger.data(buffers).debug('got files')
 		return buffers
 	}
 
 	public checkIfFileOrClipExistsOnAtem(fileName: string, stillOrClipIndex: number, type: AtemMediaPoolType): boolean {
-		atemUploaderLogger.data({ fileName, stillOrClipIndex, type }).debug('Checking if file or clip exists on atem')
+		logger.data({ fileName, stillOrClipIndex, type }).debug('Checking if file or clip exists on atem')
 
 		const still = this.connection.state?.media.stillPool[stillOrClipIndex]
 		const clip = this.connection.state?.media.clipPool[stillOrClipIndex]
@@ -72,7 +72,7 @@ export class AtemUploadScript {
 			return false
 		}
 
-		atemUploaderLogger.debug(`'${type}' is used.`)
+		logger.debug(`'${type}' is used.`)
 		const comparisonName = fileName.substring(
 			type === AtemMediaPoolType.Still ? -ATEM_MAX_FILENAME_LENGTH : -ATEM_MAX_CLIPNAME_LENGTH
 		)
@@ -84,38 +84,38 @@ export class AtemUploadScript {
 	public async uploadStillToAtem(fileName: string, fileData: Buffer, stillIndex: number): Promise<void> {
 		fileName = fileName.substring(-ATEM_MAX_FILENAME_LENGTH) // cannot be longer than 63 chars
 		if (this.checkIfFileOrClipExistsOnAtem(fileName, stillIndex, AtemMediaPoolType.Still)) {
-			atemUploaderLogger.debug(`Still '${fileName} already exists on ATEM.`)
+			logger.debug(`Still '${fileName} already exists on ATEM.`)
 			return
 		}
 
-		atemUploaderLogger.debug(`'${fileName}' does not exist on ATEM.`)
+		logger.debug(`'${fileName}' does not exist on ATEM.`)
 		await this.connection.clearMediaPoolStill(stillIndex)
 		await this.connection.uploadStill(stillIndex, fileData, fileName, '')
 	}
 	public async uploadClipToAtem(name: string, fileData: Buffer[], clipIndex: number): Promise<void> {
 		name = name.substring(-ATEM_MAX_CLIPNAME_LENGTH) // cannot be longer than 43 chars
 		if (this.checkIfFileOrClipExistsOnAtem(name, clipIndex, AtemMediaPoolType.Clip)) {
-			atemUploaderLogger.debug(`'${name} already exists on ATEM.`)
+			logger.debug(`'${name} already exists on ATEM.`)
 			return
 		}
-		atemUploaderLogger.debug(`Clip '${name}' does not exist on ATEM.`)
+		logger.debug(`Clip '${name}' does not exist on ATEM.`)
 		await this.connection.clearMediaPoolClip(clipIndex)
 		await this.connection.uploadClip(clipIndex, fileData, name)
 	}
 }
 
-atemUploaderLogger.debug('Setup AtemUploader...')
+logger.debug('Setup AtemUploader...')
 const singleton = new AtemUploadScript()
 const assets: AtemMediaPoolAsset[] = JSON.parse(process.argv[3])
 singleton.connect(process.argv[2]).then(
 	async () => {
-		atemUploaderLogger.debug('ATEM upload connected')
+		logger.debug('ATEM upload connected')
 
 		for (const asset of assets) {
 			// upload 1 by 1
 
 			if (asset.position === undefined || isNaN(asset.position) || !_.isNumber(asset.position)) {
-				atemUploaderLogger.error(`Skipping due to invalid media pool '${asset.path}'.`)
+				logger.error(`Skipping due to invalid media pool '${asset.path}'.`)
 				continue
 			}
 
@@ -124,19 +124,19 @@ singleton.connect(process.argv[2]).then(
 					const fileData = await singleton.loadFile(asset.path)
 
 					await singleton.uploadStillToAtem(asset.path, fileData, asset.position)
-					atemUploaderLogger.debug(`Uploaded ATEM media to stillpool ${asset.position}.`)
+					logger.debug(`Uploaded ATEM media to stillpool ${asset.position}.`)
 				} else if (asset.type === AtemMediaPoolType.Clip) {
 					const fileData = await singleton.loadFiles(asset.path)
 
 					await singleton.uploadClipToAtem(asset.path, fileData, asset.position)
-					atemUploaderLogger.debug(`Uploaded ATEM media to clippool ${asset.position}.`)
+					logger.debug(`Uploaded ATEM media to clippool ${asset.position}.`)
 				}
 			} catch (error) {
-				atemUploaderLogger.data(error).error(`Failed to upload '${asset.path}'.`)
+				logger.data(error).error(`Failed to upload '${asset.path}'.`)
 			}
 		}
 
-		atemUploaderLogger.debug('All media checked/uploaded, exiting...')
+		logger.debug('All media checked/uploaded, exiting...')
 		process.exit(0)
 	},
 	() => process.exit(-1)

--- a/packages/playout-gateway/src/atemUploader.ts
+++ b/packages/playout-gateway/src/atemUploader.ts
@@ -65,7 +65,7 @@ export class AtemUploadScript {
 		else if (type === AtemMediaPoolType.Clip) pool = clip
 
 		if (!pool) {
-			throw Error(`Atem appears to be missing the type '${type}'`)
+			throw new Error(`Atem appears to be missing the type '${type}'`)
 		}
 
 		if (!pool.isUsed) {

--- a/packages/playout-gateway/src/atemUploader.ts
+++ b/packages/playout-gateway/src/atemUploader.ts
@@ -115,7 +115,7 @@ singleton.connect(process.argv[2]).then(
 			// upload 1 by 1
 
 			if (asset.position === undefined || isNaN(asset.position) || !_.isNumber(asset.position)) {
-				console.error('Skipping due to invalid media pool ' + asset.path)
+				atemUploaderLogger.error(`Skipping due to invalid media pool '${asset.path}'.`)
 				continue
 			}
 

--- a/packages/playout-gateway/src/connector.ts
+++ b/packages/playout-gateway/src/connector.ts
@@ -1,6 +1,6 @@
 import { TSRHandler, TSRConfig } from './tsrHandler'
 import { CoreHandler, CoreConfig } from './coreHandler'
-import { Logger } from 'winston'
+import { Logger } from './logger'
 import { Process } from './process'
 import { InfluxConfig } from './influxdb'
 import { PeripheralDeviceId } from '@sofie-automation/shared-lib/dist/core/model/Ids'
@@ -13,7 +13,7 @@ export interface Config {
 	influx: InfluxConfig
 }
 export interface ProcessConfig {
-	/** Will cause the Node applocation to blindly accept all certificates. Not recommenced unless in local, controlled networks. */
+	/** Will cause the Node application to blindly accept all certificates. Not recommenced unless in local, controlled networks. */
 	unsafeSSL: boolean
 	/** Paths to certificates to load, for SSL-connections */
 	certificates: string[]
@@ -25,50 +25,52 @@ export interface DeviceConfig {
 export class Connector {
 	private tsrHandler: TSRHandler | undefined
 	private coreHandler: CoreHandler | undefined
-	private _logger: Logger
+	private readonly logger: Logger
 	private _process: Process | undefined
 
 	constructor(logger: Logger) {
-		this._logger = logger
+		this.logger = logger.tag(this.constructor.name)
 	}
 
 	public async init(config: Config): Promise<void> {
 		try {
-			this._logger.info('Initializing Process...')
-			this._process = new Process(this._logger)
+			this.logger.info('Initializing Process...')
+			this._process = new Process(this.logger)
 			this._process.init(config.process)
-			this._logger.info('Process initialized')
+			this.logger.info('Process initialized')
 
-			this._logger.info('Initializing Core...')
-			this.coreHandler = new CoreHandler(this._logger, config.device)
+			this.logger.info('Initializing Core...')
+			this.coreHandler = new CoreHandler(this.logger, config.device)
 			await this.coreHandler.init(config.core, this._process)
-			this._logger.info('Core initialized')
+			this.logger.info('Core initialized')
 
-			this._logger.info('Initializing TSR...')
-			this.tsrHandler = new TSRHandler(this._logger)
+			this.logger.info('Initializing TSR...')
+			this.tsrHandler = new TSRHandler(this.logger)
 			await this.tsrHandler.init(config.tsr, this.coreHandler)
-			this._logger.info('TSR initialized')
+			this.logger.info('TSR initialized')
 
-			this._logger.info('Initialization done')
+			this.logger.info('Initialization done')
 			return
-		} catch (e: any) {
-			this._logger.error('Error during initialization:')
-			this._logger.error(e)
-			this._logger.error(e.stack)
+		} catch (error: any) {
+			this.logger.error('Error during initialization:', { data: error?.stack ?? error })
 
 			try {
 				if (this.coreHandler) {
-					this.coreHandler.destroy().catch(this._logger.error)
+					this.coreHandler
+						.destroy()
+						.catch((error) => this.logger.data(error).error('Failed destroying coreHandler:'))
 				}
 				if (this.tsrHandler) {
-					this.tsrHandler.destroy().catch(this._logger.error)
+					this.tsrHandler
+						.destroy()
+						.catch((error) => this.logger.data(error).error('Failed destroying tsrHandler:'))
 				}
 			} catch (e) {
 				// Handle the edge case where destroy() throws synchronously:
-				this._logger.error(e)
+				this.logger.error(e)
 			}
 
-			this._logger.info('Shutting down in 10 seconds!')
+			this.logger.info('Shutting down in 10 seconds!')
 			setTimeout(() => {
 				// eslint-disable-next-line no-process-exit
 				process.exit(0)

--- a/packages/playout-gateway/src/connector.ts
+++ b/packages/playout-gateway/src/connector.ts
@@ -51,31 +51,34 @@ export class Connector {
 
 			this.logger.info('Initialization done')
 			return
-		} catch (error: any) {
-			this.logger.error('Error during initialization:', { data: error?.stack ?? error })
+		} catch (error: unknown) {
+			this.logger.data(error).error('Error during initialization:')
 
-			try {
-				if (this.coreHandler) {
-					this.coreHandler
-						.destroy()
-						.catch((error) => this.logger.data(error).error('Failed destroying coreHandler:'))
-				}
-				if (this.tsrHandler) {
-					this.tsrHandler
-						.destroy()
-						.catch((error) => this.logger.data(error).error('Failed destroying tsrHandler:'))
-				}
-			} catch (e) {
-				// Handle the edge case where destroy() throws synchronously:
-				this.logger.error(e)
-			}
-
-			this.logger.info('Shutting down in 10 seconds!')
-			setTimeout(() => {
-				// eslint-disable-next-line no-process-exit
-				process.exit(0)
-			}, 10 * 1000)
-			return
+			this.teardown()
 		}
+	}
+
+	private teardown(): void {
+		try {
+			if (this.coreHandler) {
+				this.coreHandler
+					.destroy()
+					.catch((error) => this.logger.data(error).error('Failed destroying coreHandler:'))
+			}
+			if (this.tsrHandler) {
+				this.tsrHandler
+					.destroy()
+					.catch((error) => this.logger.data(error).error('Failed destroying tsrHandler:'))
+			}
+		} catch (error) {
+			// Handle the edge case where destroy() throws synchronously:
+			this.logger.data(error).error('An error occurred during teardown.')
+		}
+
+		this.logger.info('Shutting down in 10 seconds!')
+		setTimeout(() => {
+			// eslint-disable-next-line no-process-exit
+			process.exit(0)
+		}, 10 * 1000)
 	}
 }

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -286,7 +286,7 @@ export class CoreHandler {
 	executeFunction(cmd: PeripheralDeviceCommand, fcnObject: CoreHandler | CoreTSRDeviceHandler): void {
 		if (cmd) {
 			if (this._executedFunctions[cmd._id]) return // prevent it from running multiple times
-			this.logger.debug(`Executing function "${cmd.functionName}", args: ${JSON.stringify(cmd.args)}`)
+			this.logger.debug(`Executing function '${cmd.functionName}', args: ${JSON.stringify(cmd.args)}`)
 			this._executedFunctions[cmd._id] = true
 			const cb = (error: any, res?: any) => {
 				if (error) {
@@ -300,7 +300,7 @@ export class CoreHandler {
 			// eslint-disable-next-line @typescript-eslint/ban-types
 			const fcn: Function = fcnObject[cmd.functionName]
 			try {
-				if (!fcn) throw Error(`Function "${cmd.functionName}" not found on device "${cmd.deviceId}"!`)
+				if (!fcn) throw Error(`Function '${cmd.functionName}' not found on device '${cmd.deviceId}'!`)
 
 				Promise.resolve(fcn.apply(fcnObject, cmd.args))
 					.then((result) => cb(null, result))
@@ -436,7 +436,7 @@ export class CoreHandler {
 		if (!this._tsrHandler) throw new Error('TSRHandler is not initialized')
 
 		const device = this._tsrHandler.tsr.getDevice(deviceId)?.device as ThreadedClass<CasparCGDevice>
-		if (!device) throw new Error(`TSR Device "${deviceId}" not found!`)
+		if (!device) throw new Error(`TSR Device '${deviceId}' not found!`)
 
 		return device.restartCasparCG()
 	}
@@ -444,7 +444,7 @@ export class CoreHandler {
 		if (!this._tsrHandler) throw new Error('TSRHandler is not initialized')
 
 		const device = this._tsrHandler.tsr.getDevice(deviceId)?.device as ThreadedClass<QuantelDevice>
-		if (!device) throw new Error(`TSR Device "${deviceId}" not found!`)
+		if (!device) throw new Error(`TSR Device '${deviceId}' not found!`)
 
 		return device.restartGateway()
 	}
@@ -452,7 +452,7 @@ export class CoreHandler {
 		if (!this._tsrHandler) throw new Error('TSRHandler is not initialized')
 
 		const device = this._tsrHandler.tsr.getDevice(deviceId)?.device as ThreadedClass<HyperdeckDevice>
-		if (!device) throw new Error(`TSR Device "${deviceId}" not found!`)
+		if (!device) throw new Error(`TSR Device '${deviceId}' not found!`)
 
 		await device.formatDisks()
 	}

--- a/packages/playout-gateway/src/index.ts
+++ b/packages/playout-gateway/src/index.ts
@@ -2,8 +2,9 @@ import { Connector } from './connector'
 import { config, disableWatchdog } from './config'
 import { logger } from './logger'
 
-console.log('process started') // This is a message all Sofie processes log upon startup
 const indexLogger = logger.tag('index')
+
+indexLogger.info('process started') // This is a message all Sofie processes log upon startup
 
 // Because the default NodeJS-handler sucks and won't display error properly
 process.on('warning', (error: unknown) => indexLogger.data(error).error('Unhandled warning:'))

--- a/packages/playout-gateway/src/index.ts
+++ b/packages/playout-gateway/src/index.ts
@@ -3,9 +3,10 @@ import { config, disableWatchdog } from './config'
 import { logger } from './logger'
 
 console.log('process started') // This is a message all Sofie processes log upon startup
+const indexLogger = logger.tag('index')
 
 // Because the default NodeJS-handler sucks and won't display error properly
-process.on('warning', (error: unknown) => logger.data(error).error('Unhandled warning:'))
+process.on('warning', (error: unknown) => indexLogger.data(error).error('Unhandled warning:'))
 
 logger.info(
 	'\n------------------------------------------------------------------\n' +
@@ -15,4 +16,4 @@ logger.info(
 		'------------------------------------------------------------------'
 )
 const connector = new Connector(logger)
-connector.init(config).catch((error) => logger.data(error).error('Failed initializing the Connector:'))
+connector.init(config).catch((error) => indexLogger.data(error).error('Failed initializing the Connector:'))

--- a/packages/playout-gateway/src/index.ts
+++ b/packages/playout-gateway/src/index.ts
@@ -1,95 +1,18 @@
 import { Connector } from './connector'
-import { config, logPath, disableWatchdog, logLevel } from './config'
-
-import * as Winston from 'winston'
+import { config, disableWatchdog } from './config'
+import { logger } from './logger'
 
 console.log('process started') // This is a message all Sofie processes log upon startup
 
-// Setup logging --------------------------------------
-let logger: Winston.Logger
-if (logPath) {
-	const transportConsole = new Winston.transports.Console({
-		level: logLevel || 'silly',
-		handleExceptions: true,
-		handleRejections: true,
-	})
-	const transportFile = new Winston.transports.File({
-		level: logLevel || 'silly',
-		handleExceptions: true,
-		handleRejections: true,
-		filename: logPath,
-		format: Winston.format.json(),
-	})
+// Because the default NodeJS-handler sucks and won't display error properly
+process.on('warning', (error: unknown) => logger.data(error).error('Unhandled warning:'))
 
-	logger = Winston.createLogger({
-		transports: [transportConsole, transportFile],
-	})
-	logger.info('Logging to', logPath)
-
-	// Hijack console.log:
-	const orgConsoleLog = console.log
-	console.log = function (...args: any[]) {
-		// orgConsoleLog('a')
-		if (args.length >= 1) {
-			// @ts-expect-error one or more arguments
-			logger.debug(...args)
-			orgConsoleLog(...args)
-		}
-	}
-} else {
-	// custom json stringifier
-	const { splat, combine, printf } = Winston.format
-	const myFormat = printf((obj) => {
-		obj.localTimestamp = getCurrentTime()
-		obj.randomId = Math.round(Math.random() * 10000)
-		return JSON.stringify(obj) // make single line
-	})
-
-	// Log json to console
-	const transportConsole = new Winston.transports.Console({
-		level: logLevel || 'silly',
-		handleExceptions: true,
-		handleRejections: true,
-		format: combine(splat(), myFormat),
-	})
-
-	logger = Winston.createLogger({
-		transports: [transportConsole],
-	})
-	logger.info('Logging to Console')
-
-	// Hijack console.log:
-	console.log = function (...args: any[]) {
-		// orgConsoleLog('a')
-		if (args.length >= 1) {
-			// @ts-expect-error one or more arguments
-			logger.debug(...args)
-		}
-	}
-}
-function getCurrentTime() {
-	const v = Date.now()
-	// if (c && c.coreHandler && c.coreHandler.core) {
-	// 	v = c.coreHandler.core.getCurrentTime()
-	// }
-	return new Date(v).toISOString()
-}
-
-// Because the default NodeJS-handler sucks and wont display error properly
-process.on('warning', (e: any) => {
-	logger.warn('Unhandled warning, see below')
-	logger.error('error', e)
-	logger.error('error.reason', e.reason || e.message)
-	logger.error('error.stack', e.stack)
-})
-
-logger.info('------------------------------------------------------------------')
-logger.info('Starting Playout Gateway')
-if (disableWatchdog) logger.info('Watchdog is disabled!')
+logger.info(
+	'\n------------------------------------------------------------------\n' +
+		'Starting Playout Gateway.\n' +
+		`Core:          ${config.core.host}:${config.core.port}\n` +
+		`Watchdog:      ${disableWatchdog ? 'disabled' : 'enabled'}\n` +
+		'------------------------------------------------------------------'
+)
 const connector = new Connector(logger)
-
-logger.info('Core:          ' + config.core.host + ':' + config.core.port)
-logger.info('------------------------------------------------------------------')
-connector.init(config).catch((e) => {
-	logger.error(e)
-})
+connector.init(config).catch((error) => logger.data(error).error('Failed initializing the Connector:'))

--- a/packages/playout-gateway/src/index.ts
+++ b/packages/playout-gateway/src/index.ts
@@ -1,13 +1,13 @@
 import { Connector } from './connector'
 import { config, disableWatchdog } from './config'
-import { logger } from './logger'
+import { logger as untaggedLogger } from './logger'
 
-const indexLogger = logger.tag('index')
+const logger = untaggedLogger.tag('index')
 
-indexLogger.info('process started') // This is a message all Sofie processes log upon startup
+logger.info('process started') // This is a message all Sofie processes log upon startup
 
 // Because the default NodeJS-handler sucks and won't display error properly
-process.on('warning', (error: unknown) => indexLogger.data(error).error('Unhandled warning:'))
+process.on('warning', (error: unknown) => logger.data(error).error('Unhandled warning:'))
 
 logger.info(
 	'\n------------------------------------------------------------------\n' +
@@ -17,4 +17,4 @@ logger.info(
 		'------------------------------------------------------------------'
 )
 const connector = new Connector(logger)
-connector.init(config).catch((error) => indexLogger.data(error).error('Failed initializing the Connector:'))
+connector.init(config).catch((error) => logger.data(error).error('Failed initializing the Connector:'))

--- a/packages/playout-gateway/src/influxdb.ts
+++ b/packages/playout-gateway/src/influxdb.ts
@@ -105,7 +105,7 @@ function getVersions(): Record<string, string> {
 		const pkgInfo = require(`timeline-state-resolver/package.json`)
 		versions['tsrVersion'] = pkgInfo.version || 'N/A'
 	} catch (e) {
-		// this.logger.error(`Failed to load package.json for lib "${pkgName}": ${e}`)
+		// this.logger.error(`Failed to load package.json for lib '${pkgName}': ${e}`)
 	}
 
 	return versions

--- a/packages/playout-gateway/src/logger/custom-json-format.ts
+++ b/packages/playout-gateway/src/logger/custom-json-format.ts
@@ -1,0 +1,22 @@
+import { JsonFormat, Log } from '@tv2media/logger'
+
+export class CustomJsonFormat extends JsonFormat {
+	constructor() {
+		super({ isPretty: false })
+	}
+
+	apply(log: Log): string {
+		log.message = this.ensureStringMessage(log.message)
+		return super.apply(log)
+	}
+
+	private ensureStringMessage(message: unknown): string {
+		if (typeof message === 'string') {
+			return message
+		}
+		if (message instanceof Error) {
+			return message.stack ?? message.message
+		}
+		return JSON.stringify(message)
+	}
+}

--- a/packages/playout-gateway/src/logger/index.ts
+++ b/packages/playout-gateway/src/logger/index.ts
@@ -64,12 +64,14 @@ function hijackConsole(logger: Logger): void {
 	console.error = getConsoleErrorFunction(logger)
 }
 
+const HIJACKED_CONSOLE_TAG = 'hijacked-console'
+
 function getConsoleLogFunction(logger: Logger): (...args: unknown[]) => void {
 	return (...args: unknown[]): void => {
 		if (args.length < 1) {
 			return
 		}
-		logger.data(args).debug('Logged via console.log:')
+		logger.tag(HIJACKED_CONSOLE_TAG).data(args).debug('Logged via console.log:')
 	}
 }
 
@@ -78,7 +80,7 @@ function getConsoleWarnFunction(logger: Logger): (...args: unknown[]) => void {
 		if (args.length < 1) {
 			return
 		}
-		logger.data(args).warn('Logged via console.warn:')
+		logger.tag(HIJACKED_CONSOLE_TAG).data(args).warn('Logged via console.warn:')
 	}
 }
 
@@ -87,6 +89,6 @@ function getConsoleErrorFunction(logger: Logger): (...args: unknown[]) => void {
 		if (args.length < 1) {
 			return
 		}
-		logger.data(args).error('Logged via console.error:')
+		logger.tag(HIJACKED_CONSOLE_TAG).data(args).error('Logged via console.error:')
 	}
 }

--- a/packages/playout-gateway/src/logger/index.ts
+++ b/packages/playout-gateway/src/logger/index.ts
@@ -1,0 +1,70 @@
+import { basename, dirname } from 'path'
+// eslint-disable-next-line node/no-missing-import
+import { ConsoleVault, FileVault } from '@tv2media/logger/node'
+import { Vault, Level, PlainTextFormat } from '@tv2media/logger'
+
+import { logPath } from '../config'
+import { CustomJsonFormat } from './custom-json-format'
+import { Logger } from './logger'
+export { Logger, Level } from '@tv2media/logger'
+
+const DEFAULT_LOG_LEVEL = Level.TRACE
+
+export const logger = getLogger(logPath)
+
+function getLogger(logPath: string | undefined): Logger {
+	const vaults = getVaults(logPath)
+	const logger = new Logger(vaults)
+	hijackConsole(logger)
+	return logger
+}
+
+function getVaults(logPath: string | undefined): Vault[] {
+	return logPath ? getVaultsWithLogPath(logPath) : getVaultsWithoutLogPath()
+}
+
+function getVaultsWithLogPath(logPath: string): Vault[] {
+	const consoleVault = new ConsoleVault({
+		level: DEFAULT_LOG_LEVEL,
+		format: new PlainTextFormat(),
+		isFormatLocked: false,
+	})
+
+	const fileName = basename(logPath)
+	const directory = dirname(logPath)
+	const fileVault = new FileVault({
+		level: DEFAULT_LOG_LEVEL,
+		format: new CustomJsonFormat(),
+		directory,
+		fileName,
+		useRotation: false,
+		isFormatLocked: true,
+	})
+
+	return [consoleVault, fileVault]
+}
+
+function getVaultsWithoutLogPath(): Vault[] {
+	const consoleVault = new ConsoleVault({
+		level: DEFAULT_LOG_LEVEL,
+		format: new PlainTextFormat(),
+		isFormatLocked: false,
+	})
+
+	return [consoleVault]
+}
+
+function hijackConsole(logger: Logger): void {
+	console.log = getConsoleLogFunction(logger)
+	console.warn = getConsoleLogFunction(logger)
+	console.error = getConsoleLogFunction(logger)
+}
+
+function getConsoleLogFunction(logger: Logger): (...args: unknown[]) => void {
+	return (...args: unknown[]): void => {
+		if (args.length < 1) {
+			return
+		}
+		logger.debug(args)
+	}
+}

--- a/packages/playout-gateway/src/logger/index.ts
+++ b/packages/playout-gateway/src/logger/index.ts
@@ -60,8 +60,8 @@ function getVaultsWithoutLogPath(): Vault[] {
 
 function hijackConsole(logger: Logger): void {
 	console.log = getConsoleLogFunction(logger)
-	console.warn = getConsoleLogFunction(logger)
-	console.error = getConsoleLogFunction(logger)
+	console.warn = getConsoleWarnFunction(logger)
+	console.error = getConsoleErrorFunction(logger)
 }
 
 function getConsoleLogFunction(logger: Logger): (...args: unknown[]) => void {
@@ -69,6 +69,24 @@ function getConsoleLogFunction(logger: Logger): (...args: unknown[]) => void {
 		if (args.length < 1) {
 			return
 		}
-		logger.debug(args)
+		logger.data(args).debug('Logged via console.log:')
+	}
+}
+
+function getConsoleWarnFunction(logger: Logger): (...args: unknown[]) => void {
+	return (...args: unknown[]): void => {
+		if (args.length < 1) {
+			return
+		}
+		logger.data(args).warn('Logged via console.warn:')
+	}
+}
+
+function getConsoleErrorFunction(logger: Logger): (...args: unknown[]) => void {
+	return (...args: unknown[]): void => {
+		if (args.length < 1) {
+			return
+		}
+		logger.data(args).error('Logged via console.error:')
 	}
 }

--- a/packages/playout-gateway/src/logger/index.ts
+++ b/packages/playout-gateway/src/logger/index.ts
@@ -30,7 +30,7 @@ function getVaultsWithLogPath(logPath: string): Vault[] {
 		isFormatLocked: false,
 	})
 
-	const fileName = basename(logPath)
+	const fileName = getFileName(logPath)
 	const directory = dirname(logPath)
 	const fileVault = new FileVault({
 		level: DEFAULT_LOG_LEVEL,
@@ -42,6 +42,10 @@ function getVaultsWithLogPath(logPath: string): Vault[] {
 	})
 
 	return [consoleVault, fileVault]
+}
+
+function getFileName(logPath: string): string {
+	return basename(logPath).replace(/\.log$/, '')
 }
 
 function getVaultsWithoutLogPath(): Vault[] {

--- a/packages/playout-gateway/src/logger/logger.ts
+++ b/packages/playout-gateway/src/logger/logger.ts
@@ -4,7 +4,7 @@ import { Environment, Format, PlainTextFormat } from '@tv2media/logger'
 import { CustomJsonFormat } from './custom-json-format'
 
 export class Logger extends DefaultLogger {
-	getEnvironmentFormat(environment: Environment): Format {
+	protected getEnvironmentFormat(environment: Environment): Format {
 		switch (environment) {
 			case Environment.PRODUCTION:
 			case Environment.STAGING:

--- a/packages/playout-gateway/src/logger/logger.ts
+++ b/packages/playout-gateway/src/logger/logger.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line node/no-missing-import
+import { DefaultLogger } from '@tv2media/logger/node'
+import { Environment, Format, PlainTextFormat } from '@tv2media/logger'
+import { CustomJsonFormat } from './custom-json-format'
+
+export class Logger extends DefaultLogger {
+	getEnvironmentFormat(environment: Environment): Format {
+		switch (environment) {
+			case Environment.PRODUCTION:
+			case Environment.STAGING:
+				return new CustomJsonFormat()
+			case Environment.DEVELOPMENT:
+			case Environment.LOCAL:
+				return new PlainTextFormat()
+		}
+	}
+}

--- a/packages/playout-gateway/src/process.ts
+++ b/packages/playout-gateway/src/process.ts
@@ -23,9 +23,9 @@ export class Process {
 			_.each(processConfig.certificates, (certificate) => {
 				try {
 					this.certificates.push(fs.readFileSync(certificate))
-					this.logger.info(`Using certificate "${certificate}"`)
+					this.logger.info(`Using certificate '${certificate}'`)
 				} catch (error) {
-					this.logger.data(error).error(`Error loading certificate "${certificate}"`)
+					this.logger.data(error).error(`Error loading certificate '${certificate}'`)
 				}
 			})
 		}

--- a/packages/playout-gateway/src/process.ts
+++ b/packages/playout-gateway/src/process.ts
@@ -1,15 +1,15 @@
-import { Logger } from 'winston'
+import { Logger } from './logger'
 import _ = require('underscore')
 import * as fs from 'fs'
 import { ProcessConfig } from './connector'
 
 export class Process {
-	logger: Logger
+	private readonly logger: Logger
 
 	public certificates: Buffer[] = []
 
 	constructor(logger: Logger) {
-		this.logger = logger
+		this.logger = logger.tag(this.constructor.name)
 	}
 	init(processConfig: ProcessConfig): void {
 		if (processConfig.unsafeSSL) {
@@ -25,7 +25,7 @@ export class Process {
 					this.certificates.push(fs.readFileSync(certificate))
 					this.logger.info(`Using certificate "${certificate}"`)
 				} catch (error) {
-					this.logger.error(`Error loading certificate "${certificate}"`, error)
+					this.logger.data(error).error(`Error loading certificate "${certificate}"`)
 				}
 			})
 		}

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -449,7 +449,7 @@ export class TSRHandler {
 		// Compare mappingsHash to ensure that the timeline we've received is in sync with the mappings:
 		if (timeline.mappingsHash !== mappingsObject.mappingsHash) {
 			this.logger.info(
-				`Cancel resolving: mappingsHash differ: "${timeline.mappingsHash}" vs "${mappingsObject.mappingsHash}"`
+				`Cancel resolving: mappingsHash differ: '${timeline.mappingsHash}' vs '${mappingsObject.mappingsHash}'`
 			)
 			return
 		}
@@ -884,7 +884,7 @@ export class TSRHandler {
 			const groupObj = objects[obj.inGroup]
 			if (!groupObj) {
 				// referenced group not found
-				this.logger.error(`Referenced group "${obj.inGroup}" not found! Referenced by "${obj.id}"`)
+				this.logger.error(`Referenced group '${obj.inGroup}' not found! Referenced by '${obj.id}'`)
 				return
 			}
 			// Add object into group:

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -825,7 +825,7 @@ export class TSRHandler {
 		const options = device.deviceOptions.options as { host: string }
 		if (!options || !options.host) {
 			this.logger.data(options).debug('ATEM host options is missing from:')
-			throw Error('ATEM host option not set')
+			throw new Error('ATEM host option is not set.')
 		}
 		this.logger.info(`Trying to upload files to ${options.host}`)
 		const process = cp.spawn(`node`, [`./dist/atemUploader.js`, options.host, JSON.stringify(files)])

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -136,7 +136,7 @@ enum JobFailure {
  * Represents a connection between Gateway and TSR
  */
 export class TSRHandler {
-	logger: Logger
+	private readonly logger: Logger
 	private _tsr!: Conductor
 	private _coreHandler!: CoreHandler
 	private _triggerUpdateExpectedPlayoutItemsTimeout: any = null
@@ -664,7 +664,7 @@ export class TSRHandler {
 		}
 		this.enqueueDeviceRemoveIfNotLast(deviceId, true)
 		jobQueue
-			.enqueue(new CreateDeviceJob(deviceId, deviceOptions, this), JOB_TIMEOUT, JobImportance.HIGH)
+			.enqueue(new CreateDeviceJob(deviceId, deviceOptions, this, this.logger), JOB_TIMEOUT, JobImportance.HIGH)
 			.chain(new InitCoreTsrHandlerJob(), JOB_TIMEOUT, JobImportance.HIGH)
 			.chain(
 				new InitDeviceJob(deviceId, deviceOptions, this, this.logger),

--- a/packages/playout-gateway/src/tsrHandlerJobs/createDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/createDeviceJob.ts
@@ -2,6 +2,7 @@ import { CoreTSRDeviceHandler } from '../coreHandler'
 import { Job } from './job'
 import { AbortError, DeviceContainer, DeviceOptionsAny, StatusCode } from 'timeline-state-resolver'
 import { TSRHandler } from '../tsrHandler'
+import { Logger } from '../logger'
 
 export interface CreateDeviceJobsResult {
 	deviceContainer: DeviceContainer<DeviceOptionsAny>
@@ -10,9 +11,16 @@ export interface CreateDeviceJobsResult {
 
 export class CreateDeviceJob extends Job<CreateDeviceJobsResult, Partial<CreateDeviceJobsResult>> {
 	protected artifacts: Partial<CreateDeviceJobsResult> = {}
+	private readonly logger: Logger
 
-	constructor(private deviceId: string, private deviceOptions: DeviceOptionsAny, private tsrHandler: TSRHandler) {
+	constructor(
+		private deviceId: string,
+		private deviceOptions: DeviceOptionsAny,
+		private tsrHandler: TSRHandler,
+		logger: Logger
+	) {
 		super()
+		this.logger = logger.tag(this.constructor.name)
 	}
 
 	async run(_previousResult: unknown, abortSignal?: AbortSignal): Promise<CreateDeviceJobsResult> {
@@ -29,7 +37,7 @@ export class CreateDeviceJob extends Job<CreateDeviceJobsResult, Partial<CreateD
 			throw new AbortError()
 		}
 
-		const coreTsrHandler = new CoreTSRDeviceHandler(this.artifacts.deviceContainer, this.tsrHandler)
+		const coreTsrHandler = new CoreTSRDeviceHandler(this.artifacts.deviceContainer, this.tsrHandler, this.logger)
 		this.artifacts.coreTsrHandler = coreTsrHandler
 		// set the status to uninitialized for now:
 		coreTsrHandler.statusChanged({

--- a/packages/playout-gateway/src/tsrHandlerJobs/initDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/initDeviceJob.ts
@@ -159,17 +159,17 @@ export class InitDeviceJob extends Job<CreateDeviceJobsResult, undefined, Create
 
 		await deviceContainer.device.on('info', ((message: any, ...args: any[]) => {
 			const deviceName = deviceContainer.deviceName || this.deviceId
-			this.logger.data({ args }).info(`Received info from device '${deviceName}': ${fixError(message)}`)
+			this.logger.data(args).info(`Received info from device '${deviceName}': ${fixError(message)}`)
 		}) as () => void)
 
 		await deviceContainer.device.on('warning', ((warn: any, ...args: any[]) => {
 			const deviceName = deviceContainer.deviceName || this.deviceId
-			this.logger.data({ args }).warn(`Received warning from device '${deviceName}': ${fixError(warn)}`)
+			this.logger.data(args).warn(`Received warning from device '${deviceName}': ${fixError(warn)}`)
 		}) as () => void)
 
 		await deviceContainer.device.on('error', ((e: any, ...args: any[]) => {
 			const deviceName = deviceContainer.deviceName || this.deviceId
-			this.logger.data({ args }).error(`Received error from device '${deviceName}': ${fixError(e)}`)
+			this.logger.data(args).error(`Received error from device '${deviceName}': ${fixError(e)}`)
 		}) as () => void)
 
 		await deviceContainer.device.on('debug', (...args: any[]) => {

--- a/packages/playout-gateway/src/tsrHandlerJobs/initDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/initDeviceJob.ts
@@ -1,4 +1,4 @@
-import { Logger } from 'winston'
+import { Logger } from '../logger'
 import { Job } from './job'
 import {
 	AbortError,
@@ -22,14 +22,16 @@ import debug = require('debug')
 
 export class InitDeviceJob extends Job<CreateDeviceJobsResult, undefined, CreateDeviceJobsResult> {
 	protected artifacts: undefined
+	private readonly logger: Logger
 
 	constructor(
 		private deviceId: string,
 		private deviceOptions: DeviceOptionsAny,
 		private tsrHandler: TSRHandler,
-		private logger: Logger
+		logger: Logger
 	) {
 		super()
+		this.logger = logger.tag(this.constructor.name)
 	}
 
 	async run(previousResult: CreateDeviceJobsResult, abortSignal?: AbortSignal): Promise<CreateDeviceJobsResult> {

--- a/packages/playout-gateway/src/tsrHandlerJobs/initDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/initDeviceJob.ts
@@ -63,8 +63,8 @@ export class InitDeviceJob extends Job<CreateDeviceJobsResult, undefined, Create
 			coreTsrHandler.statusChanged(deviceStatus)
 
 			// When the status has changed, the deviceName might have changed:
-			deviceContainer.reloadProps().catch((err) => {
-				this.logger.error(`Error in reloadProps: ${err}`)
+			deviceContainer.reloadProps().catch((error) => {
+				this.logger.data(error).error(`Error in reloadProps:`)
 			})
 			// hack to make sure atem has media after restart
 			if (
@@ -92,38 +92,27 @@ export class InitDeviceJob extends Job<CreateDeviceJobsResult, undefined, Create
 			// since something took too long internally.
 
 			if (info.internalDelay > 100) {
-				this.logger.error('slowSentCommand', {
-					deviceName: deviceContainer.deviceName,
-					...info,
-				})
+				this.logger.data(info).error(`slowSentCommand for ${deviceContainer.deviceName}.`)
 			} else {
-				this.logger.warn('slowSentCommand', {
-					deviceName: deviceContainer.deviceName,
-					...info,
-				})
+				this.logger.data(info).warn(`slowSentCommand for ${deviceContainer.deviceName}.`)
 			}
 		}
 		const onSlowFulfilledCommand = (info: SlowFulfilledCommandInfo) => {
 			// Note: we don't emit slow fulfilled commands as error, since
 			// the fulfillment of them lies on the device being controlled, not on us.
 
-			this.logger.warn('slowFulfilledCommand', {
-				deviceName: deviceContainer.deviceName,
-				...info,
-			})
+			this.logger.data(info).warn(`slowFulfilledCommand for ${deviceContainer.deviceName}.`)
 		}
 		const onCommandReport = (commandReport: CommandReport) => {
 			if (this.tsrHandler.reportAllCommands) {
 				// Todo: send these to Core
-				this.logger.info('commandReport', {
-					commandReport: commandReport,
-				})
+				this.logger.data(commandReport).debug('commandReport')
 			}
 		}
 		const onCommandError = (error: any, context: any) => {
 			// todo: handle this better
-			this.logger.error(error)
-			this.logger.debug(context)
+			this.logger.data(error).error('Received command error from device.')
+			this.logger.data(context).debug('Context for reported command error:')
 		}
 		const onUpdateMediaObject = (collectionId: string, docId: string, doc: MediaObject | null) => {
 			coreTsrHandler.onUpdateMediaObject(collectionId, docId, doc)
@@ -132,7 +121,8 @@ export class InitDeviceJob extends Job<CreateDeviceJobsResult, undefined, Create
 			coreTsrHandler.onClearMediaObjectCollection(collectionId)
 		}
 		const fixError = (e: any): string => {
-			const name = `Device "${deviceContainer.deviceName || this.deviceId}" (${deviceContainer.instanceId})`
+			const deviceName = deviceContainer.deviceName || this.deviceId
+			const name = `Device '${deviceName}' (${deviceContainer.instanceId})`
 			if (e.reason) e.reason = name + ': ' + e.reason
 			if (e.message) e.message = name + ': ' + e.message
 			if (e.stack) {
@@ -146,7 +136,7 @@ export class InitDeviceJob extends Job<CreateDeviceJobsResult, undefined, Create
 		deviceContainer.onChildClose = () => {
 			// Called if a child is closed / crashed
 			this.logger.warn(`Child of device ${this.deviceId} closed/crashed`)
-			debug(`Trigger update devices because "${this.deviceId}" process closed`)
+			debug(`Trigger update devices because '${this.deviceId}' process closed`)
 
 			onDeviceStatusChanged({
 				statusCode: StatusCode.BAD,
@@ -167,29 +157,31 @@ export class InitDeviceJob extends Job<CreateDeviceJobsResult, undefined, Create
 		await deviceContainer.device.on('updateMediaObject', onUpdateMediaObject as () => void)
 		await deviceContainer.device.on('clearMediaObjects', onClearMediaObjectCollection as () => void)
 
-		await deviceContainer.device.on('info', ((e: any, ...args: any[]) => {
-			this.logger.info(fixError(e), ...args)
+		await deviceContainer.device.on('info', ((message: any, ...args: any[]) => {
+			const deviceName = deviceContainer.deviceName || this.deviceId
+			this.logger.data({ args }).info(`Received info from device '${deviceName}': ${fixError(message)}`)
 		}) as () => void)
-		await deviceContainer.device.on('warning', ((e: any, ...args: any[]) => {
-			this.logger.warn(fixError(e), ...args)
+
+		await deviceContainer.device.on('warning', ((warn: any, ...args: any[]) => {
+			const deviceName = deviceContainer.deviceName || this.deviceId
+			this.logger.data({ args }).warn(`Received warning from device '${deviceName}': ${fixError(warn)}`)
 		}) as () => void)
+
 		await deviceContainer.device.on('error', ((e: any, ...args: any[]) => {
-			this.logger.error(fixError(e), ...args)
+			const deviceName = deviceContainer.deviceName || this.deviceId
+			this.logger.data({ args }).error(`Received error from device '${deviceName}': ${fixError(e)}`)
 		}) as () => void)
 
 		await deviceContainer.device.on('debug', (...args: any[]) => {
+			const deviceName = deviceContainer.deviceName || this.deviceId
 			if (!deviceContainer.debugLogging && !this.tsrHandler.coreHandler.logDebug) {
 				return
 			}
 			if (args.length === 0) {
-				this.logger.debug('>empty message<')
+				this.logger.debug(`Received empty debug message from device '${deviceName}'.`)
 				return
 			}
-			const data = args.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg) : arg))
-			this.logger.debug(
-				`Device "${deviceContainer.deviceName || this.deviceId}" (${deviceContainer.instanceId})`,
-				{ data }
-			)
+			this.logger.data(args).debug(`Received debug from device '${deviceName}' (${deviceContainer.instanceId}):`)
 		})
 
 		await deviceContainer.device.on('timeTrace', ((trace: FinishedTrace) => sendTrace(trace)) as () => void)

--- a/packages/playout-gateway/src/tsrHandlerJobs/jobQueue.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/jobQueue.ts
@@ -175,7 +175,7 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 	private handleJobRejected = async (reason: unknown): Promise<PromiseSettledResult<void>[] | void> => {
 		if (!this.currentJob) return
 		this.logger.error(
-			`Error in queue "${this.name}" at Job.run "${this.currentJob.job.constructor.name}": ${reason}`
+			`Error in queue '${this.name}' at Job.run '${this.currentJob.job.constructor.name}': ${reason}`
 		)
 		const cleanupPromises = []
 		if (this.currentJobChain.length) {
@@ -200,7 +200,7 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 		}
 		const failedCleanups = results.filter((result) => result.status === 'rejected') as PromiseRejectedResult[]
 		for (const result of failedCleanups) {
-			this.logger.error(`Error in queue "${this.name}" at Job.cleanup: ${result.reason}`)
+			this.logger.error(`Error in queue '${this.name}' at Job.cleanup: ${result.reason}`)
 		}
 	}
 

--- a/packages/playout-gateway/src/tsrHandlerJobs/jobQueue.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/jobQueue.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'stream'
 import { AbortError } from 'timeline-state-resolver'
-import { Logger } from 'winston'
+import { Logger } from '../logger'
 import { Job } from './job'
 
 interface JobDescription<ResultType> {
@@ -58,9 +58,11 @@ export class JobQueue extends EventEmitter implements IJobQueue {
 	private currentJob: JobDescription<unknown> | null = null
 	private currentJobChain: JobDescription<unknown>[] = []
 	private currentJobTimeout: NodeJS.Timeout | null = null
+	private readonly logger: Logger
 
-	constructor(private name: string, private logger: Logger) {
+	constructor(private name: string, logger: Logger) {
 		super()
+		this.logger = logger.tag(this.constructor.name)
 	}
 
 	get length(): number {

--- a/packages/playout-gateway/src/tsrHandlerJobs/jobQueueManager.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/jobQueueManager.ts
@@ -1,10 +1,13 @@
-import { Logger } from 'winston'
+import { Logger } from '../logger'
 import { IJobQueue, JobQueue } from './jobQueue'
 
 export class JobQueueManager {
 	private jobQueues = new Map<string, JobQueue>()
+	private readonly logger: Logger
 
-	constructor(private logger: Logger) {}
+	constructor(logger: Logger) {
+		this.logger = logger.tag(this.constructor.name)
+	}
 
 	get(queueName: string): IJobQueue {
 		let queue = this.jobQueues.get(queueName)

--- a/packages/playout-gateway/src/tsrHandlerJobs/removeDeviceJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/removeDeviceJob.ts
@@ -1,33 +1,36 @@
 import { CoreTSRDeviceHandler } from '../coreHandler'
-import { Logger } from 'winston'
+import { Logger } from '../logger'
 import { Job } from './job'
 
 export class RemoveDeviceJob extends Job<void> {
 	protected artifacts: undefined
+	private readonly logger: Logger
 
 	constructor(
 		private deviceId: string,
 		private coreTsrHandlers: { [deviceId: string]: CoreTSRDeviceHandler },
 		private expected: boolean,
-		private logger: Logger
+		logger: Logger
 	) {
 		super()
+		this.logger = logger.tag(this.constructor.name)
 	}
 
 	async run(): Promise<void> {
-		if (this.coreTsrHandlers[this.deviceId]) {
-			try {
-				if (this.expected) {
-					await this.coreTsrHandlers[this.deviceId].disposeExpectedly()
-				} else {
-					await this.coreTsrHandlers[this.deviceId].disposeUnexpectedly()
-				}
-				this.logger.debug('Disposed device ' + this.deviceId)
-			} catch (error) {
-				this.logger.error(`Error when removing device "${this.deviceId}"`, { data: error })
-			} finally {
-				delete this.coreTsrHandlers[this.deviceId]
+		if (!this.coreTsrHandlers[this.deviceId]) {
+			return
+		}
+		try {
+			if (this.expected) {
+				await this.coreTsrHandlers[this.deviceId].disposeExpectedly()
+			} else {
+				await this.coreTsrHandlers[this.deviceId].disposeUnexpectedly()
 			}
+			this.logger.debug(`Disposed device '${this.deviceId}'`)
+		} catch (error) {
+			this.logger.data(error).error(`Error when removing device '${this.deviceId}'`)
+		} finally {
+			delete this.coreTsrHandlers[this.deviceId]
 		}
 	}
 }

--- a/packages/playout-gateway/src/tsrHandlerJobs/setDebugLoggingJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/setDebugLoggingJob.ts
@@ -11,7 +11,7 @@ export class SetDebugLoggingJob extends Job<void> {
 	async run(): Promise<void> {
 		const deviceContainer = this.conductor.getDevice(this.deviceId)
 		if (!deviceContainer) {
-			throw new Error(`Device "${this.deviceId}" does not exist or is not initialized`)
+			throw new Error(`Device '${this.deviceId}' does not exist or is not initialized`)
 		}
 		await deviceContainer.setDebugLogging(this.debugLogging)
 	}

--- a/packages/playout-gateway/src/tsrHandlerJobs/updateExpectedPlayoutItemsJob.ts
+++ b/packages/playout-gateway/src/tsrHandlerJobs/updateExpectedPlayoutItemsJob.ts
@@ -18,7 +18,7 @@ export class UpdateExpectedPlayoutItemsJob extends Job<void, void> {
 	async run(): Promise<void> {
 		const deviceContainer = this.conductor.getDevice(this.deviceId)
 		if (!deviceContainer) {
-			throw new Error(`Device "${this.deviceId}" does not exist or is not initialized`)
+			throw new Error(`Device '${this.deviceId}' does not exist or is not initialized`)
 		}
 		if (!(await deviceContainer.device.supportsExpectedPlayoutItems)) {
 			return

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3092,7 +3092,7 @@
     webpack-sources "^3.2.2"
 
 "@sofie-automation/blueprints-integration@link:blueprints-integration":
-  version "46.2.1"
+  version "46.2.0"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
     timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.3.0"
@@ -3392,6 +3392,11 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+
+"@tv2media/logger@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/logger/-/logger-2.0.0.tgz#bca8d260d966d844d0810fc1c26e8de7bb787239"
+  integrity sha512-H1btFAJqLvWvyH3lWeU/ECZ6khJOb6WeNgwtJf6g1f4ZLiMUK28a2mFPkvjUNtcOImaZWoEfAslJXI/KZ0y37A==
 
 "@tv2media/v-connection@^7.2.1":
   version "7.2.1"


### PR DESCRIPTION
The PR is a refactor of how we log:

- Ensure that the arguments that are given to the logger is given correctly (e.g. not a string as metadata object).
- Winston have been removed in favor of @tv2media/logger.
- Log statements are tagged with with the class/component that produced them.
- Errors and data is stored in the log attribute `data`, when applicable.
- `console.(warn|error|log)` is hijacked, and will state in the log message, that it was logged from a console method.
