### PR TITLE
Sof 1240/select from dropdown uses unique ids

### DIFF
--- a/meteor/client/lib/ModalDialog.tsx
+++ b/meteor/client/lib/ModalDialog.tsx
@@ -8,9 +8,10 @@ import * as _ from 'underscore'
 import type { Sorensen } from '@sofie-automation/sorensen'
 import { withTranslation } from 'react-i18next'
 import { Translated } from './ReactMeteorData/ReactMeteorData'
-import { EditAttribute, EditAttributeType, EditAttributeBase } from './EditAttribute'
+import { EditAttribute, EditAttributeType } from './EditAttribute'
 import { SorensenContext } from './SorensenContext'
 import { Settings } from '../../lib/Settings'
+import { EditAttributeBase } from './editAttribute/edit-attribute-base'
 
 interface IModalDialogAttributes {
 	show?: boolean

--- a/meteor/client/lib/editAttribute/edit-attribute-base.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-base.tsx
@@ -1,0 +1,155 @@
+import { MongoCollection } from '../../../lib/collections/lib'
+import * as React from 'react'
+import { withTracker } from '../ReactMeteorData/ReactMeteorData'
+
+export interface IEditAttributeBaseProps {
+	updateOnKey?: boolean
+	attribute?: string
+	collection?: MongoCollection<any>
+	myObject?: any
+	obj?: any
+	options?: any
+	optionsAreNumbers?: boolean
+	className?: string
+	modifiedClassName?: string
+	invalidClassName?: string
+	updateFunction?: (edit: EditAttributeBase, newValue: any) => void
+	overrideDisplayValue?: any
+	label?: string
+	mutateDisplayValue?: (v: any) => any
+	mutateUpdateValue?: (v: any) => any
+	disabled?: boolean
+	storeJsonAsObject?: boolean
+	/** Defaults to string */
+	arrayType?: 'boolean' | 'int' | 'float' | 'string'
+}
+
+interface IEditAttributeBaseState {
+	value: any
+	valueError: boolean
+	editing: boolean
+}
+
+export class EditAttributeBase extends React.Component<IEditAttributeBaseProps, IEditAttributeBaseState> {
+	constructor(props) {
+		super(props)
+
+		this.state = {
+			value: this.getAttribute(),
+			valueError: false,
+			editing: false,
+		}
+
+		this.handleEdit = this.handleEdit.bind(this)
+		this.handleUpdate = this.handleUpdate.bind(this)
+		this.handleDiscard = this.handleDiscard.bind(this)
+	}
+	handleEdit(inputValue: any, storeValue?: any) {
+		this.setState({
+			value: inputValue,
+			editing: true,
+		})
+		if (this.props.updateOnKey) {
+			this.updateValue(storeValue ?? inputValue)
+		}
+	}
+	handleUpdate(inputValue: any, storeValue?: any) {
+		this.handleUpdateButDontSave(inputValue)
+		this.updateValue(storeValue ?? inputValue)
+	}
+	handleUpdateEditing(newValue) {
+		this.handleUpdateButDontSave(newValue, true)
+		this.updateValue(newValue)
+	}
+	handleUpdateButDontSave(newValue, editing = false) {
+		this.setState({
+			value: newValue,
+			editing,
+		})
+	}
+	handleDiscard() {
+		this.setState({
+			value: this.getAttribute(),
+			editing: false,
+		})
+	}
+	deepAttribute(obj0: any, attr0: string | undefined): any {
+		// Returns a value deep inside an object
+		// Example: deepAttribute(company,"ceo.address.street");
+
+		const f = (obj: any, attr: string) => {
+			if (obj) {
+				const attributes = attr.split('.')
+
+				if (attributes.length > 1) {
+					const outerAttr = attributes.shift() as string
+					const innerAttrs = attributes.join('.')
+
+					return f(obj[outerAttr], innerAttrs)
+				} else {
+					return obj[attributes[0]]
+				}
+			} else {
+				return obj
+			}
+		}
+		return f(obj0, attr0 || '')
+	}
+	getAttribute() {
+		let v = null
+		if (this.props.overrideDisplayValue !== undefined) {
+			v = this.props.overrideDisplayValue
+		} else {
+			v = this.deepAttribute(this.props.myObject, this.props.attribute)
+		}
+		return this.props.mutateDisplayValue ? this.props.mutateDisplayValue(v) : v
+	}
+	getAttributeText() {
+		return this.getAttribute() + ''
+	}
+	getEditAttribute() {
+		return this.state.editing ? this.state.value : this.getAttribute()
+	}
+	updateValue(newValue) {
+		if (this.props.mutateUpdateValue) {
+			try {
+				newValue = this.props.mutateUpdateValue(newValue)
+				this.setState({
+					valueError: false,
+				})
+			} catch (e) {
+				this.setState({
+					valueError: true,
+					editing: true,
+				})
+				return
+			}
+		}
+
+		if (this.props.updateFunction && typeof this.props.updateFunction === 'function') {
+			this.props.updateFunction(this, newValue)
+		} else {
+			if (this.props.collection && this.props.attribute) {
+				if (newValue === undefined) {
+					const m = {}
+					m[this.props.attribute] = 1
+					this.props.collection.update(this.props.obj._id, { $unset: m })
+				} else {
+					const m = {}
+					m[this.props.attribute] = newValue
+					this.props.collection.update(this.props.obj._id, { $set: m })
+				}
+			}
+		}
+	}
+}
+
+export function wrapEditAttribute(newClass) {
+	return withTracker((props: IEditAttributeBaseProps) => {
+		// These properties will be exposed under this.props
+		// Note that these properties are reactively recalculated
+		return {
+			myObject: props.collection ? props.collection.findOne(props.obj._id) : props.obj || {},
+		}
+	})(newClass)
+}

--- a/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
@@ -1,0 +1,86 @@
+import { EditAttributeBase, IEditAttributeBaseProps, wrapEditAttribute } from './edit-attribute-base'
+import ClassNames from 'classnames'
+import * as React from 'react'
+
+export interface DropdownOption {
+	value: string
+	// Must be provided when 'useLabel' is true
+	label?: string
+}
+
+interface EditAttributeDropdownProps extends IEditAttributeBaseProps {
+	options: DropdownOption[]
+	useLabel?: boolean
+}
+
+export function EditAttributeDropdown(props: EditAttributeDropdownProps) {
+	return <WrappedEditAttributeDropdown {...props} />
+}
+
+const WrappedEditAttributeDropdown = wrapEditAttribute(
+	class EditAttributeDropdown extends EditAttributeBase {
+		constructor(props) {
+			super(props)
+
+			this.handleChange = this.handleChange.bind(this)
+		}
+
+		handleChange(event) {
+			const selectedOptionValue: string = event.target.value
+			const selectedOption: DropdownOption | undefined = this.getAvailableOptions().find(
+				(option) => option.value === selectedOptionValue
+			)
+			if (!selectedOption) {
+				return
+			}
+			const props = this.props as EditAttributeDropdownProps
+			this.handleUpdate(props.useLabel ? selectedOption : selectedOption.value)
+		}
+
+		getCurrentlySelectedOption(): DropdownOption {
+			let attribute = this.getAttribute()
+			if (!!attribute && !attribute.value) {
+				attribute = { value: attribute }
+			}
+			return attribute
+		}
+
+		getAvailableOptions(): DropdownOption[] {
+			return (this.props as EditAttributeDropdownProps).options
+		}
+
+		getMissingOptions(availableOptions: DropdownOption[]): DropdownOption[] {
+			const selectedOption: DropdownOption = this.getCurrentlySelectedOption()
+			if (!selectedOption) {
+				return []
+			}
+			const selectedIsAnAvailableOption = availableOptions.some((option) => option.value === selectedOption.value)
+			return !selectedIsAnAvailableOption ? [selectedOption] : []
+		}
+
+		render() {
+			const availableOptions = this.getAvailableOptions()
+			const missingOptions = this.getMissingOptions(availableOptions)
+			const currentlySelectedOption = this.getCurrentlySelectedOption()
+			return (
+				<select
+					className={ClassNames(
+						'form-control',
+						this.props.className,
+						this.state.editing && this.props.modifiedClassName,
+						missingOptions.length > 0 && 'option-missing'
+					)}
+					value={currentlySelectedOption?.value}
+					onChange={this.handleChange}
+					disabled={this.props.disabled}
+				>
+					{availableOptions.concat(missingOptions).map((option) => (
+						<option key={option.value} value={option.value}>
+							{option.label ?? option.value}
+						</option>
+					))}
+				</select>
+			)
+		}
+	}
+)

--- a/meteor/client/lib/editAttribute/edit-attribute-enum-dropdown.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-enum-dropdown.tsx
@@ -1,0 +1,17 @@
+import { DropdownOption, EditAttributeDropdown } from './edit-attribute-dropdown'
+import { IEditAttributeBaseProps } from './edit-attribute-base'
+import * as React from 'react'
+
+interface EditAttributeEnumDropdownProps extends IEditAttributeBaseProps {
+	options: object
+}
+
+export function EditAttributeEnumDropdown(props: EditAttributeEnumDropdownProps) {
+	return <EditAttributeDropdown {...props} options={mapToDropdownOptions(props.options)} useLabel={false} />
+}
+
+function mapToDropdownOptions(options: object): DropdownOption[] {
+	return Object.entries(options)
+		.filter(([enumName, _value]) => Number.isNaN(Number(enumName)))
+		.map(([enumName, _value]) => ({ value: enumName }))
+}

--- a/meteor/client/lib/editAttribute/edit-attribute-enum-multi-select.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-enum-multi-select.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { IEditAttributeBaseProps } from './edit-attribute-base'
+import { EditAttributeMultiSelect } from './edit-attribute-multi-select'
+import { MultiSelectOption } from '../multiSelect'
+
+interface EditAttributeEnumMultiSelectProps extends IEditAttributeBaseProps {
+	options: object
+}
+
+export function EditAttributeEnumMultiSelect(props: EditAttributeEnumMultiSelectProps) {
+	return <EditAttributeMultiSelect {...props} options={convertEnumToMultiSelectOptions(props.options)} />
+}
+
+function convertEnumToMultiSelectOptions(options: object): MultiSelectOption[] {
+	return Object.entries(options)
+		.filter(([enumName, _value]) => Number.isNaN(Number(enumName)))
+		.map(([enumName, value]) => ({ value: value, label: enumName }))
+}

--- a/meteor/client/lib/editAttribute/edit-attribute-multi-select.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-multi-select.tsx
@@ -1,0 +1,61 @@
+import { MultiSelect, MultiSelectOption } from '../multiSelect'
+import ClassNames from 'classnames'
+import * as React from 'react'
+import { EditAttributeBase, IEditAttributeBaseProps, wrapEditAttribute } from './edit-attribute-base'
+
+interface EditAttributeMultiSelectProps extends IEditAttributeBaseProps {
+	options: MultiSelectOption[]
+}
+
+export function EditAttributeMultiSelect(props: EditAttributeMultiSelectProps) {
+	return <WrappedEditAttributeMultiSelect {...props} />
+}
+
+const WrappedEditAttributeMultiSelect = wrapEditAttribute(
+	class EditAttributeMultiSelect extends EditAttributeBase {
+		constructor(props) {
+			super(props)
+
+			this.handleChange = this.handleChange.bind(this)
+		}
+
+		handleChange(changedOptions: MultiSelectOption[]): void {
+			this.handleUpdate(changedOptions)
+		}
+
+		getCurrentlySelectedOptions(): MultiSelectOption[] {
+			return this.getAttribute() ?? []
+		}
+
+		getAvailableOptions(): MultiSelectOption[] {
+			return (this.props as EditAttributeMultiSelectProps).options
+		}
+
+		getMissingOptions(availableOptions: MultiSelectOption[]): MultiSelectOption[] {
+			return this.getCurrentlySelectedOptions()
+				.filter((selectedOption) => availableOptions.every((option) => option.value !== selectedOption.value))
+				.map((option) => {
+					return {
+						value: option.value,
+						label: option.label,
+						className: 'option-missing',
+					}
+				})
+		}
+
+		render() {
+			const availableOptions = this.getAvailableOptions()
+			const missingOptions = this.getMissingOptions(availableOptions)
+			const currentlySelectedOptions = this.getCurrentlySelectedOptions()
+			return (
+				<MultiSelect
+					className={ClassNames(this.props.className, missingOptions.length > 0 && 'option-missing')}
+					options={availableOptions.concat(missingOptions)}
+					value={currentlySelectedOptions}
+					placeholder={this.props.label}
+					onChange={this.handleChange}
+				></MultiSelect>
+			)
+		}
+	}
+)

--- a/meteor/client/lib/editAttribute/edit-attribute-text-dropdown.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-text-dropdown.tsx
@@ -1,0 +1,28 @@
+import { IEditAttributeBaseProps } from './edit-attribute-base'
+import { DropdownOption, EditAttributeDropdown } from './edit-attribute-dropdown'
+import * as React from 'react'
+
+interface EditAttributeTextDropdownProps extends IEditAttributeBaseProps {
+	options: string[]
+	defaultNoneSelectedValue?: string
+}
+
+export function EditAttributeTextDropdown(props: EditAttributeTextDropdownProps) {
+	return (
+		<EditAttributeDropdown
+			{...props}
+			options={mapToDropdownOptions(props.options)}
+			mutateDisplayValue={mapDefaultNotSelectedValue(props.defaultNoneSelectedValue)}
+			useLabel={false}
+		/>
+	)
+}
+
+function mapToDropdownOptions(options: string[]): DropdownOption[] {
+	console.log(options)
+	return options.map((option) => ({ value: option }))
+}
+
+function mapDefaultNotSelectedValue(defaultValue?: string): (v: any) => any {
+	return (value) => (value === undefined ? { id: defaultValue, displayValue: defaultValue } : value)
+}

--- a/meteor/client/lib/multiSelect.tsx
+++ b/meteor/client/lib/multiSelect.tsx
@@ -1,31 +1,26 @@
 import * as React from 'react'
-import * as _ from 'underscore'
 import ClassNames from 'classnames'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCheckSquare, faSquare, faChevronUp } from '@fortawesome/free-solid-svg-icons'
-import { Manager, Reference, Popper } from 'react-popper'
+import { faCheckSquare, faChevronUp, faSquare } from '@fortawesome/free-solid-svg-icons'
+import { Manager, Popper, Reference } from 'react-popper'
 
-export interface MultiSelectEvent {
-	selectedValues: Array<string>
+export interface MultiSelectOption {
+	value: string
+	label: string
+	className?: string
 }
 
-export type MultiSelectOptions = _.Dictionary<{ value: string | string[]; className?: string }>
-
 interface IProps {
-	/**
-	 * A value of type string results in a checkbox with the key becoming the label.
-	 * A value of type string[] results in a group of checkboxes with the key becoming the header of the group.
-	 */
-	availableOptions: MultiSelectOptions
+	options: MultiSelectOption[]
 	placeholder?: string
 	className?: string
-	value?: Array<string>
-	onChange?: (event: MultiSelectEvent) => void
+	value: MultiSelectOption[]
+	onChange?: (selectedOptions: MultiSelectOption[]) => void
 }
 
 interface IState {
-	checkedValues: _.Dictionary<boolean>
+	checkedIds: string[]
 	expanded: boolean
 }
 
@@ -38,7 +33,7 @@ export class MultiSelect extends React.Component<IProps, IState> {
 		super(props)
 
 		this.state = {
-			checkedValues: {},
+			checkedIds: [],
 			expanded: false,
 		}
 	}
@@ -58,74 +53,53 @@ export class MultiSelect extends React.Component<IProps, IState> {
 	}
 
 	refreshChecked() {
-		if (this.props.value && _.isArray(this.props.value)) {
-			const checkedValues: _.Dictionary<boolean> = {}
-			_.forEach(this.props.value, (value) => {
-				checkedValues[value] = true
-			})
-
-			this.setState({
-				checkedValues,
-			})
-		} else {
-			this.setState({
-				checkedValues: {},
-			})
-		}
+		this.setState({
+			checkedIds: this.props.value.map((option) => option.value),
+		})
 	}
 
-	handleChange = (item) => {
-		const obj = {}
-		obj[item] = !this.state.checkedValues[item]
-		const valueUpdate = _.extend(this.state.checkedValues, obj)
+	handleChange = (clickedOption: MultiSelectOption) => {
+		const checkedIds = this.state.checkedIds
+
+		const index: number = checkedIds.findIndex((id) => id === clickedOption.value)
+		if (index === -1) {
+			checkedIds.push(clickedOption.value)
+		} else {
+			checkedIds.splice(index, 1)
+		}
 
 		this.setState({
-			checkedValues: valueUpdate,
+			checkedIds: checkedIds,
 		})
 
-		if (this.props.onChange && typeof this.props.onChange === 'function') {
-			this.props.onChange({
-				selectedValues: _.compact(
-					_.values(
-						_.mapObject(valueUpdate, (value, key) => {
-							return value ? key : null
-						})
-					)
-				),
-			})
+		if (!this.props.onChange || typeof this.props.onChange !== 'function') {
+			return
 		}
+		this.props.onChange(this.getOptionsFromCheckedIds())
 	}
 
-	isChecked = (key: string): boolean => {
-		return !!this.state.checkedValues[key]
+	getOptionsFromCheckedIds(): MultiSelectOption[] {
+		return this.state.checkedIds.map((id) => this.props.options.find((option) => option.value === id)!)
+	}
+
+	isChecked = (idToCheck: string): boolean => {
+		return this.state.checkedIds.some((id) => id === idToCheck)
 	}
 
 	generateSimpleSummary = () => {
-		return _.compact(
-			_.values(
-				_.mapObject(this.state.checkedValues, (value, key) => {
-					return value ? this.props.availableOptions[key].value || key : null
-				})
-			)
-		).join(', ')
+		return this.getOptionsFromCheckedIds()
+			.map((option) => option.label)
+			.join(', ')
 	}
 
 	generateRichSummary = () => {
-		return (
-			<>
-				{_.compact(
-					_.values(
-						_.mapObject(this.state.checkedValues, (value, key) => {
-							return value ? (
-								<span key={key} className={this.props.availableOptions[key].className}>
-									{this.props.availableOptions[key].value || key}
-								</span>
-							) : null
-						})
-					)
-				)}
-			</>
-		)
+		return this.getOptionsFromCheckedIds().map((option) => {
+			return (
+				<span key={option.value} className={option.className}>
+					{option.label}
+				</span>
+			)
+		})
 	}
 
 	onBlur = (event: React.FocusEvent<HTMLDivElement>) => {
@@ -169,16 +143,16 @@ export class MultiSelect extends React.Component<IProps, IState> {
 		this._popperUpdate = update
 	}
 
-	renderOption = (value: string, key: string, className: string | undefined) => {
+	renderOption = (option: MultiSelectOption) => {
 		return (
-			<p className="expco-item" key={key}>
-				<label className={ClassNames('action-btn', className)}>
+			<p className="expco-item" key={option.value}>
+				<label className={ClassNames('action-btn', option.className)}>
 					<span className="checkbox">
 						<input
 							type="checkbox"
 							className="form-control"
-							checked={this.isChecked(key)}
-							onChange={() => this.handleChange(key)}
+							checked={this.isChecked(option.value)}
+							onChange={() => this.handleChange(option)}
 						/>
 						<span className="checkbox-checked">
 							<FontAwesomeIcon icon={faCheckSquare} />
@@ -187,7 +161,7 @@ export class MultiSelect extends React.Component<IProps, IState> {
 							<FontAwesomeIcon icon={faSquare} />
 						</span>
 					</span>
-					{value}
+					{option.label}
 				</label>
 			</p>
 		)
@@ -259,24 +233,7 @@ export class MultiSelect extends React.Component<IProps, IState> {
 								onBlur={this.onBlur}
 							>
 								{this.state.expanded && (
-									<div className="expco-body bd">
-										{_.values(
-											_.mapObject(this.props.availableOptions, (value, key) => {
-												return Array.isArray(value.value) ? (
-													<React.Fragment key={key}>
-														<p className="expco-item" key={key}>
-															{key}
-														</p>
-														{_.map(value.value, (v) => {
-															return this.renderOption(v, v, value.className)
-														})}
-													</React.Fragment>
-												) : (
-													this.renderOption(value.value, key, value.className)
-												)
-											})
-										)}
-									</div>
+									<div className="expco-body bd">{this.props.options.map((option) => this.renderOption(option))}</div>
 								)}
 							</div>
 						)

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -9,70 +9,74 @@ import { ModalDialog } from '../../lib/ModalDialog'
 import { Translated } from '../../lib/ReactMeteorData/react-meteor-data'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-	ConfigManifestEntry,
-	ConfigManifestEntryType,
-	IBlueprintConfig,
 	BasicConfigManifestEntry,
 	ConfigItemValue,
-	ConfigManifestEntryTable,
-	TableConfigItemValue,
-	ConfigManifestEntrySourceLayers,
-	ConfigManifestEntryLayerMappings,
-	SourceLayerType,
-	ConfigManifestEntrySelectFromColumn,
+	ConfigManifestEntry,
 	ConfigManifestEntryBoolean,
 	ConfigManifestEntryEnum,
 	ConfigManifestEntryFloat,
 	ConfigManifestEntryInt,
-	ConfigManifestEntryMultilineString,
-	ConfigManifestEntrySelectFromOptions,
-	ConfigManifestEntryString,
 	ConfigManifestEntryJson,
+	ConfigManifestEntryLayerMappings,
+	ConfigManifestEntryMultilineString,
+	ConfigManifestEntrySelectFromColumn,
+	ConfigManifestEntrySelectFromOptions,
+	ConfigManifestEntrySourceLayers,
+	ConfigManifestEntryString,
+	ConfigManifestEntryTable,
+	ConfigManifestEntryType,
+	IBlueprintConfig,
+	SourceLayerType,
+	TableConfigItemValue,
 } from '@sofie-automation/blueprints-integration'
-import { DBObj, ProtectedString, objectPathGet, getRandomString } from '../../../lib/lib'
+import { DBObj, getRandomString, objectPathGet, ProtectedString } from '../../../lib/lib'
 import { MongoModifier } from '../../../lib/typings/meteor'
 import { Meteor } from 'meteor/meteor'
 import { getHelpMode } from '../../lib/localStorage'
 import {
-	faDownload,
-	faTrash,
-	faPencilAlt,
 	faCheck,
+	faDownload,
+	faPencilAlt,
 	faPlus,
-	faUpload,
-	faSortUp,
-	faSortDown,
 	faSort,
+	faSortDown,
+	faSortUp,
+	faTrash,
+	faUpload,
 } from '@fortawesome/free-solid-svg-icons'
 import { UploadButton } from '../../lib/uploadButton'
-import { NotificationCenter, NoticeLevel, Notification } from '../../lib/notifications/notifications'
+import { NoticeLevel, Notification, NotificationCenter } from '../../lib/notifications/notifications'
 import { MongoCollection } from '../../../lib/collections/lib'
+import { EditAttributeMultiSelect } from '../../lib/editAttribute/edit-attribute-multi-select'
+import { DropdownOption, EditAttributeDropdown } from '../../lib/editAttribute/edit-attribute-dropdown'
+import { MultiSelectOption } from '../../lib/multiSelect'
+import { EditAttributeTextDropdown } from '../../lib/editAttribute/edit-attribute-text-dropdown'
 
 function filterSourceLayers(
 	select: ConfigManifestEntrySourceLayers<true | false>,
 	layers: Array<{ name: string; value: string; type: SourceLayerType }>
-): Array<{ name: string; value: string; type: SourceLayerType }> {
+): SelectOption[] {
 	if (select.filters && select.filters.sourceLayerTypes) {
 		const sourceLayerTypes = select.filters.sourceLayerTypes
 		return _.filter(layers, (layer) => {
 			return sourceLayerTypes.includes(layer.type)
-		})
+		}).map((layer) => ({ label: layer.name, value: layer.value }))
 	} else {
-		return layers
+		return layers.map((layer) => ({ label: layer.name, value: layer.value }))
 	}
 }
 
 function filterLayerMappings(
 	select: ConfigManifestEntryLayerMappings<true | false>,
 	mappings: { [key: string]: MappingsExt }
-): Array<{ name: string; value: string }> {
+): SelectOption[] {
 	const deviceTypes = select.filters?.deviceTypes
-	const result: Array<{ name: string; value: string }> = []
+	const result: SelectOption[] = []
 
 	for (const studioMappings of Object.values(mappings)) {
 		for (const [layerId, mapping] of Object.entries(studioMappings)) {
 			if (!deviceTypes || deviceTypes.includes(mapping.device)) {
-				result.push({ name: mapping.layerName || layerId, value: layerId })
+				result.push({ label: mapping.layerName + '' || layerId + '', value: layerId + '' })
 			}
 		}
 	}
@@ -85,19 +89,20 @@ function getTableColumnValues<DBInterface extends { _id: ProtectedString<any> }>
 	configPath: string,
 	object: DBInterface,
 	alternateObject?: any
-): string[] {
+): SelectOption[] {
 	const attribute = `${configPath}.${item.tableId}`
 	const table = objectPathGet(object, attribute) ?? objectPathGet(alternateObject, attribute)
-	const result: string[] = []
 	if (!Array.isArray(table)) {
-		return result
+		return []
 	}
-	table.forEach((row) => {
-		if (typeof row === 'object' && row[item.columnId] !== undefined) {
-			result.push(row[item.columnId])
-		}
-	})
-	return result
+	return table
+		.filter((row) => typeof row === 'object' && row[item.columnId] !== undefined)
+		.map((row) => {
+			return {
+				value: row['_id'],
+				label: row[item.columnId],
+			}
+		})
 }
 
 function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
@@ -174,11 +179,10 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
 			)
 		case ConfigManifestEntryType.ENUM:
 			return (
-				<EditAttribute
+				<EditAttributeTextDropdown
 					modifiedClassName="bghl"
 					attribute={attribute}
 					obj={object}
-					type="dropdown"
 					options={item.options || []}
 					collection={collection}
 					className="input text-input input-l"
@@ -196,57 +200,75 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
 					className="input text-input input-l"
 				/>
 			)
-		case ConfigManifestEntryType.SELECT:
-			return (
-				<EditAttribute
-					modifiedClassName="bghl"
-					attribute={attribute}
-					obj={object}
-					type={item.multiple ? 'multiselect' : 'dropdown'}
-					options={item.options}
-					collection={collection}
-					className="input text-input dropdown input-l"
-				/>
-			)
-		case ConfigManifestEntryType.SOURCE_LAYERS:
-			return (
-				<EditAttribute
-					modifiedClassName="bghl"
-					attribute={attribute}
-					obj={object}
-					type={item.multiple ? 'multiselect' : 'dropdown'}
-					options={'options' in item ? item.options : filterSourceLayers(item, sourceLayers ?? [])}
-					collection={collection}
-					className="input text-input dropdown input-l"
-				/>
-			)
-		case ConfigManifestEntryType.LAYER_MAPPINGS:
-			return (
-				<EditAttribute
-					modifiedClassName="bghl"
-					attribute={attribute}
-					obj={object}
-					type={item.multiple ? 'multiselect' : 'dropdown'}
-					options={'options' in item ? item.options : filterLayerMappings(item, layerMappings ?? {})}
-					collection={collection}
-					className="input text-input dropdown input-l"
-				/>
-			)
-		case ConfigManifestEntryType.SELECT_FROM_COLUMN:
-			return (
-				<EditAttribute
-					modifiedClassName="bghl"
-					attribute={attribute}
-					obj={object}
-					type={item.multiple ? 'multiselect' : 'dropdown'}
-					options={'options' in item ? item.options : getTableColumnValues(item, configPath, object, alternateObject)}
-					collection={collection}
-					className="input text-input dropdown input-l"
-				/>
-			)
+		case ConfigManifestEntryType.SELECT: {
+			const selectOptions: SelectOption[] = item.options.map((option) => ({ value: option, label: option }))
+			if (item.multiple) {
+				return renderMultiSelect(attribute, object, selectOptions, collection)
+			}
+			return renderDropdown(attribute, object, selectOptions, collection)
+		}
+		case ConfigManifestEntryType.SOURCE_LAYERS: {
+			const filterSourceLayerOptions = 'options' in item ? item.options : filterSourceLayers(item, sourceLayers ?? [])
+			if (item.multiple) {
+				return renderMultiSelect(attribute, object, filterSourceLayerOptions, collection)
+			}
+			return renderDropdown(attribute, object, filterSourceLayerOptions, collection)
+		}
+		case ConfigManifestEntryType.LAYER_MAPPINGS: {
+			const layerMappingOptions = 'options' in item ? item.options : filterLayerMappings(item, layerMappings ?? {})
+			if (item.multiple) {
+				return renderMultiSelect(attribute, object, layerMappingOptions, collection)
+			}
+			return renderDropdown(attribute, object, layerMappingOptions, collection)
+		}
+		case ConfigManifestEntryType.SELECT_FROM_COLUMN: {
+			const selectFromOptions =
+				'options' in item ? item.options : getTableColumnValues(item, configPath, object, alternateObject)
+			if (item.multiple) {
+				return renderMultiSelect(attribute, object, selectFromOptions, collection)
+			}
+			return renderDropdown(attribute, object, selectFromOptions, collection)
+		}
 		default:
 			return null
 	}
+}
+
+function renderMultiSelect(
+	attribute: string,
+	obj: any,
+	options: MultiSelectOption[],
+	collection: MongoCollection<any>
+) {
+	return (
+		<EditAttributeMultiSelect
+			modifiedClassName="bghl"
+			attribute={attribute}
+			obj={obj}
+			options={options}
+			collection={collection}
+			className="input text-input dropdown input-l"
+		></EditAttributeMultiSelect>
+	)
+}
+
+function renderDropdown(attribute: string, obj: any, options: DropdownOption[], collection: MongoCollection<any>) {
+	return (
+		<EditAttributeDropdown
+			modifiedClassName="bghl"
+			attribute={attribute}
+			obj={obj}
+			options={options}
+			useLabel={true}
+			collection={collection}
+			className="input text-input dropdown input-l"
+		/>
+	)
+}
+
+interface SelectOption {
+	value: string
+	label: string
 }
 
 type ResolvedBasicConfigManifestEntry =
@@ -257,9 +279,9 @@ type ResolvedBasicConfigManifestEntry =
 	| ConfigManifestEntryBoolean
 	| ConfigManifestEntryEnum
 	| ConfigManifestEntrySelectFromOptions<boolean>
-	| (ConfigManifestEntrySelectFromColumn<boolean> & { options: string[] })
-	| (ConfigManifestEntrySourceLayers<boolean> & { options: Array<{ name: string; value: string }> })
-	| (ConfigManifestEntryLayerMappings<boolean> & { options: Array<{ name: string; value: string }> })
+	| (ConfigManifestEntrySelectFromColumn<boolean> & { options: SelectOption[] })
+	| (ConfigManifestEntrySourceLayers<boolean> & { options: SelectOption[] })
+	| (ConfigManifestEntryLayerMappings<boolean> & { options: SelectOption[] })
 	| ConfigManifestEntryJson
 
 interface IConfigManifestSettingsProps<
@@ -762,7 +784,7 @@ export class ConfigManifestSettings<
 			case ConfigManifestEntryType.INT:
 				return _.isNumber(value) && item.zeroBased ? (value + 1).toString() : value.toString()
 			default:
-				return value.toString()
+				return value['label'] ?? value.toString()
 		}
 	}
 
@@ -890,9 +912,9 @@ export class ConfigManifestSettings<
 	}
 
 	getAddOptions() {
-		let addOptions: { value: string; name: string }[] = []
+		let addOptions: { value: string; label: string }[] = []
 		const config = this.getObjectConfig()
-		addOptions = this.props.manifest.map((c) => ({ value: c.id, name: c.name }))
+		addOptions = this.props.manifest.map((c) => ({ value: c.id, label: c.name }))
 
 		return addOptions.filter((o) => objectPathGet(config, o.value) === undefined)
 	}
@@ -913,9 +935,8 @@ export class ConfigManifestSettings<
 						<label className="field">
 							{t('Item')}
 							<div className="select focusable">
-								<EditAttribute
+								<EditAttributeDropdown
 									modifiedClassName="bghl"
-									type="dropdown"
 									options={this.getAddOptions()}
 									updateFunction={(_e, v) => this.setState({ addItemId: v })}
 									overrideDisplayValue={this.state.addItemId}

--- a/meteor/client/ui/Settings/Migration.tsx
+++ b/meteor/client/ui/Settings/Migration.tsx
@@ -9,9 +9,10 @@ import { logger } from '../../../lib/logging'
 import { GetMigrationStatusResult, RunMigrationResult, MigrationChunk } from '../../../lib/api/migration'
 import { MigrationStepInput, MigrationStepInputResult } from '@sofie-automation/blueprints-integration'
 import * as _ from 'underscore'
-import { EditAttribute, EditAttributeBase } from '../../lib/EditAttribute'
+import { EditAttribute } from '../../lib/EditAttribute'
 import { MeteorCall } from '../../../lib/api/methods'
 import { checkForOldDataAndCleanUp } from './SystemManagement'
+import { EditAttributeBase } from '../../lib/editAttribute/edit-attribute-base'
 
 interface IProps {}
 interface IState {

--- a/meteor/client/ui/Settings/Studio/Generic.tsx
+++ b/meteor/client/ui/Settings/Studio/Generic.tsx
@@ -12,6 +12,7 @@ import { BlueprintManifestType } from '@sofie-automation/blueprints-integration'
 import { StudioBaselineStatus } from './Baseline'
 import { ShowStyleBaseId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { ShowStyleBase } from '../../../../lib/collections/ShowStyleBases'
+import { EditAttributeMultiSelect } from '../../../lib/editAttribute/edit-attribute-multi-select'
 
 interface IStudioGenericPropertiesProps {
 	studio: Studio
@@ -132,12 +133,14 @@ export const StudioGenericProperties = withTranslation()(
 							</div>
 						) : null}
 						<div className="mdi">
-							<EditAttribute
+							<EditAttributeMultiSelect
 								attribute="supportedShowStyleBase"
 								obj={this.props.studio}
-								options={this.props.availableShowStyleBases}
+								options={this.props.availableShowStyleBases.map((base) => ({
+									label: base.name,
+									value: base.value + '',
+								}))}
 								label={t('Click to show available Show Styles')}
-								type="multiselect"
 								collection={Studios}
 							/>
 							{this.renderShowStyleEditButtons()}

--- a/meteor/client/ui/Settings/Studio/Mappings.tsx
+++ b/meteor/client/ui/Settings/Studio/Mappings.tsx
@@ -4,7 +4,7 @@ import { Meteor } from 'meteor/meteor'
 import * as _ from 'underscore'
 import Tooltip from 'rc-tooltip'
 import { Studio, Studios, MappingExt, getActiveRoutes } from '../../../../lib/collections/Studios'
-import { EditAttribute, EditAttributeBase } from '../../../lib/EditAttribute'
+import { EditAttribute } from '../../../lib/EditAttribute'
 import { doModalDialog } from '../../../lib/ModalDialog'
 import { Translated } from '../../../lib/ReactMeteorData/react-meteor-data'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -19,6 +19,7 @@ import {
 import { LOOKAHEAD_DEFAULT_SEARCH_DISTANCE } from '@sofie-automation/shared-lib/dist/core/constants'
 import { MongoCollection } from '../../../../lib/collections/lib'
 import { renderEditAttribute } from '../components/ConfigManifestEntryComponent'
+import { EditAttributeBase } from '../../../lib/editAttribute/edit-attribute-base'
 
 interface IStudioMappingsProps {
 	studio: Studio

--- a/meteor/client/ui/Settings/Studio/PackageManager.tsx
+++ b/meteor/client/ui/Settings/Studio/PackageManager.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Meteor } from 'meteor/meteor'
 import * as _ from 'underscore'
 import { Studio, Studios, DBStudio, StudioPackageContainer } from '../../../../lib/collections/Studios'
-import { EditAttribute, EditAttributeBase } from '../../../lib/EditAttribute'
+import { EditAttribute } from '../../../lib/EditAttribute'
 import { doModalDialog } from '../../../lib/ModalDialog'
 import { Translated } from '../../../lib/ReactMeteorData/react-meteor-data'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -16,6 +16,8 @@ import {
 import { withTranslation } from 'react-i18next'
 import { Accessor } from '@sofie-automation/blueprints-integration'
 import { PlayoutDeviceSettings } from '@sofie-automation/corelib/dist/dataModel/PeripheralDeviceSettings/playoutDevice'
+import { EditAttributeBase } from '../../../lib/editAttribute/edit-attribute-base'
+import { EditAttributeMultiSelect } from '../../../lib/editAttribute/edit-attribute-multi-select'
 
 interface IStudioPackageManagerSettingsProps {
 	studio: Studio
@@ -136,7 +138,7 @@ export const StudioPackageManagerSettings = withTranslation()(
 		}
 		getPlayoutDeviceIds() {
 			const deviceIds: {
-				name: string
+				label: string
 				value: string
 			}[] = []
 
@@ -150,7 +152,7 @@ export const StudioPackageManagerSettings = withTranslation()(
 
 					for (const deviceId of Object.keys(settings.devices || {})) {
 						deviceIds.push({
-							name: deviceId,
+							label: deviceId,
 							value: deviceId,
 						})
 					}
@@ -227,14 +229,13 @@ export const StudioPackageManagerSettings = withTranslation()(
 											<div className="mod mvs mhs">
 												<div className="field">
 													<label>{t('Playout devices which uses this package container')}</label>
-													<EditAttribute
+													<EditAttributeMultiSelect
 														attribute={`packageContainers.${containerId}.deviceIds`}
 														obj={this.props.studio}
 														options={this.getPlayoutDeviceIds()}
 														label={t('Select playout devices')}
-														type="multiselect"
 														collection={Studios}
-													></EditAttribute>
+													></EditAttributeMultiSelect>
 													<span className="text-s dimmed">
 														{t('Select which playout devices are using this package container')}
 													</span>
@@ -783,7 +784,7 @@ export const StudioPackageManagerSettings = withTranslation()(
 		}
 		getAvailablePackageContainers() {
 			const arr: {
-				name: string
+				label: string
 				value: string
 			}[] = []
 
@@ -797,7 +798,7 @@ export const StudioPackageManagerSettings = withTranslation()(
 				}
 				if (hasHttpAccessor) {
 					arr.push({
-						name: packageContainer.container.label,
+						label: packageContainer.container.label,
 						value: containerId,
 					})
 				}
@@ -818,27 +819,25 @@ export const StudioPackageManagerSettings = withTranslation()(
 							<div className="field mvs">
 								<label>{t('Package Containers to use for previews')}</label>
 								<div className="mdi">
-									<EditAttribute
+									<EditAttributeMultiSelect
 										attribute="previewContainerIds"
 										obj={this.props.studio}
 										options={this.getAvailablePackageContainers()}
 										label={t('Click to show available Package Containers')}
-										type="multiselect"
 										collection={Studios}
-									></EditAttribute>
+									></EditAttributeMultiSelect>
 								</div>
 							</div>
 							<div className="field mvs">
 								<label>{t('Package Containers to use for thumbnails')}</label>
 								<div className="mdi">
-									<EditAttribute
+									<EditAttributeMultiSelect
 										attribute="thumbnailContainerIds"
 										obj={this.props.studio}
 										options={this.getAvailablePackageContainers()}
 										label={t('Click to show available Package Containers')}
-										type="multiselect"
 										collection={Studios}
-									></EditAttribute>
+									></EditAttributeMultiSelect>
 								</div>
 							</div>
 						</div>

--- a/meteor/client/ui/Settings/Studio/Routings.tsx
+++ b/meteor/client/ui/Settings/Studio/Routings.tsx
@@ -13,7 +13,7 @@ import {
 	StudioRouteSetExclusivityGroup,
 	StudioRouteType,
 } from '../../../../lib/collections/Studios'
-import { EditAttribute, EditAttributeBase } from '../../../lib/EditAttribute'
+import { EditAttribute } from '../../../lib/EditAttribute'
 import { doModalDialog } from '../../../lib/ModalDialog'
 import { Translated } from '../../../lib/ReactMeteorData/react-meteor-data'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -25,6 +25,7 @@ import { MeteorCall } from '../../../../lib/api/methods'
 import { doUserAction, UserAction } from '../../../lib/userAction'
 import { MappingsManifest } from '@sofie-automation/corelib/dist/deviceConfig'
 import { DeviceMappingSettings } from './Mappings'
+import { EditAttributeBase } from '../../../lib/editAttribute/edit-attribute-base'
 
 interface IStudioRoutingsProps {
 	studio: Studio

--- a/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
+++ b/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
@@ -6,6 +6,7 @@ import { Translated } from '../../../lib/ReactMeteorData/react-meteor-data'
 import { ConfigManifestEntry, ConfigManifestEntryType } from '@sofie-automation/corelib/dist/deviceConfig'
 import { ConfigManifestEntry as BlueprintConfigManifestEntry } from '@sofie-automation/blueprints-integration'
 import { MongoCollection } from '../../../../lib/collections/lib'
+import { EditAttributeEnumDropdown } from '../../../lib/editAttribute/edit-attribute-enum-dropdown'
 
 export const renderEditAttribute = (
 	collection: MongoCollection<any>,
@@ -40,12 +41,11 @@ export const renderEditAttribute = (
 		return <EditAttribute {...opts} type="checkbox" className="input input-l"></EditAttribute>
 	} else if (configField.type === ConfigManifestEntryType.ENUM) {
 		return (
-			<EditAttribute
+			<EditAttributeEnumDropdown
 				{...opts}
-				type="dropdown"
 				options={(configField as ConfigManifestEntry).values || []}
 				className="input text-input input-l"
-			></EditAttribute>
+			></EditAttributeEnumDropdown>
 		)
 	} else if (configField.type === ConfigManifestEntryType.OBJECT) {
 		return (

--- a/meteor/client/ui/Settings/components/FilterEditor.tsx
+++ b/meteor/client/ui/Settings/components/FilterEditor.tsx
@@ -22,6 +22,8 @@ import { ShowStyleBase } from '../../../../lib/collections/ShowStyleBases'
 import { SourceLayerType } from '@sofie-automation/blueprints-integration'
 import { withTranslation } from 'react-i18next'
 import { defaultColorPickerPalette } from '../../../lib/colorPicker'
+import { EditAttributeMultiSelect } from '../../../lib/editAttribute/edit-attribute-multi-select'
+import { EditAttributeEnumMultiSelect } from '../../../lib/editAttribute/edit-attribute-enum-multi-select'
 
 interface IProps {
 	item: RundownLayoutBase
@@ -208,14 +210,13 @@ export default withTranslation()(
 							mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
 							mutateUpdateValue={() => undefined}
 						/>
-						<EditAttribute
+						<EditAttributeMultiSelect
 							modifiedClassName="bghl"
 							attribute={`filters.${index}.sourceLayerIds`}
 							obj={item}
 							options={this.props.showStyleBase.sourceLayers.map((l) => {
-								return { name: l.name, value: l._id }
+								return { label: l.name, value: l._id }
 							})}
-							type="multiselect"
 							label={t('Filter Disabled')}
 							collection={RundownLayouts}
 							className="input text-input input-l dropdown"
@@ -234,12 +235,11 @@ export default withTranslation()(
 							mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
 							mutateUpdateValue={() => undefined}
 						/>
-						<EditAttribute
+						<EditAttributeEnumMultiSelect
 							modifiedClassName="bghl"
 							attribute={`filters.${index}.sourceLayerTypes`}
 							obj={item}
 							options={SourceLayerType}
-							type="multiselect"
 							optionsAreNumbers={true}
 							label={t('Filter disabled')}
 							collection={RundownLayouts}
@@ -261,14 +261,13 @@ export default withTranslation()(
 							mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
 							mutateUpdateValue={() => undefined}
 						/>
-						<EditAttribute
+						<EditAttributeMultiSelect
 							modifiedClassName="bghl"
 							attribute={`filters.${index}.outputLayerIds`}
 							obj={item}
 							options={this.props.showStyleBase.outputLayers.map((l) => {
-								return { name: l.name, value: l._id }
+								return { label: l.name, value: l._id }
 							})}
-							type="multiselect"
 							label={t('Filter Disabled')}
 							collection={RundownLayouts}
 							className="input text-input input-l dropdown"
@@ -664,14 +663,13 @@ export default withTranslation()(
 							mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
 							mutateUpdateValue={() => undefined}
 						/>
-						<EditAttribute
+						<EditAttributeMultiSelect
 							modifiedClassName="bghl"
 							attribute={`filters.${index}.sourceLayerIds`}
 							obj={item}
 							options={this.props.showStyleBase.sourceLayers.map((l) => {
-								return { name: l.name, value: l._id }
+								return { label: l.name, value: l._id }
 							})}
-							type="multiselect"
 							label={t('Disabled')}
 							collection={RundownLayouts}
 							className="input text-input input-l dropdown"
@@ -1375,14 +1373,13 @@ export default withTranslation()(
 							mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
 							mutateUpdateValue={() => undefined}
 						/>
-						<EditAttribute
+						<EditAttributeMultiSelect
 							modifiedClassName="bghl"
 							attribute={`filters.${index}.requiredLayerIds`}
 							obj={item}
 							options={this.props.showStyleBase.sourceLayers.map((l) => {
-								return { name: l.name, value: l._id }
+								return { label: l.name, value: l._id }
 							})}
-							type="multiselect"
 							label={t('Disabled')}
 							collection={RundownLayouts}
 							className="input text-input input-l dropdown"
@@ -1402,14 +1399,13 @@ export default withTranslation()(
 							mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
 							mutateUpdateValue={() => undefined}
 						/>
-						<EditAttribute
+						<EditAttributeMultiSelect
 							modifiedClassName="bghl"
 							attribute={`filters.${index}.additionalLayers`}
 							obj={item}
 							options={this.props.showStyleBase.sourceLayers.map((l) => {
-								return { name: l.name, value: l._id }
+								return { label: l.name, value: l._id }
 							})}
-							type="multiselect"
 							label={t('Disabled')}
 							collection={RundownLayouts}
 							className="input text-input input-l dropdown"

--- a/meteor/client/ui/Settings/components/GenericDeviceSettingsComponent.tsx
+++ b/meteor/client/ui/Settings/components/GenericDeviceSettingsComponent.tsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTrash, faPencilAlt, faCheck, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { withTranslation } from 'react-i18next'
 import { PeripheralDevices, PeripheralDeviceId, PeripheralDevice } from '../../../../lib/collections/PeripheralDevices'
-import { EditAttribute, EditAttributeBase } from '../../../lib/EditAttribute'
+import { EditAttribute } from '../../../lib/EditAttribute'
 import { ModalDialog } from '../../../lib/ModalDialog'
 import { Translated } from '../../../lib/ReactMeteorData/react-meteor-data'
 import { Meteor } from 'meteor/meteor'
@@ -19,6 +19,7 @@ import {
 import { ConfigManifestEntryComponent } from './ConfigManifestEntryComponent'
 import { ConfigManifestOAuthFlowComponent } from './ConfigManifestOAuthFlow'
 import { unprotectString } from '../../../../lib/lib'
+import { EditAttributeBase } from '../../../lib/editAttribute/edit-attribute-base'
 
 type EditId = PeripheralDeviceId | string
 interface IGenericDeviceSettingsComponentState {

--- a/meteor/client/ui/Settings/components/rundownLayouts/RundownViewLayoutSettings.tsx
+++ b/meteor/client/ui/Settings/components/rundownLayouts/RundownViewLayoutSettings.tsx
@@ -5,6 +5,7 @@ import { RundownLayoutBase, RundownLayouts } from '../../../../../lib/collection
 import { ShowStyleBase } from '../../../../../lib/collections/ShowStyleBases'
 import { unprotectString } from '../../../../../lib/lib'
 import { EditAttribute } from '../../../../lib/EditAttribute'
+import { EditAttributeMultiSelect } from '../../../../lib/editAttribute/edit-attribute-multi-select'
 
 function filterLayouts(
 	rundownLayouts: RundownLayoutBase[],
@@ -91,14 +92,13 @@ export default function RundownViewLayoutSettings({ showStyleBase, item, layouts
 					mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
 					mutateUpdateValue={() => undefined}
 				/>
-				<EditAttribute
+				<EditAttributeMultiSelect
 					modifiedClassName="bghl"
 					attribute={`liveLineProps.requiredLayerIds`}
 					obj={item}
 					options={showStyleBase.sourceLayers.map((l) => {
-						return { name: l.name, value: l._id }
+						return { label: l.name, value: l._id }
 					})}
-					type="multiselect"
 					label={t('Disabled')}
 					collection={RundownLayouts}
 					className="input text-input input-l dropdown"
@@ -120,14 +120,13 @@ export default function RundownViewLayoutSettings({ showStyleBase, item, layouts
 					mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
 					mutateUpdateValue={() => undefined}
 				/>
-				<EditAttribute
+				<EditAttributeMultiSelect
 					modifiedClassName="bghl"
 					attribute={`liveLineProps.additionalLayers`}
 					obj={item}
 					options={showStyleBase.sourceLayers.map((l) => {
-						return { name: l.name, value: l._id }
+						return { label: l.name, value: l._id }
 					})}
-					type="multiselect"
 					label={t('Disabled')}
 					collection={RundownLayouts}
 					className="input text-input input-l dropdown"
@@ -190,14 +189,13 @@ export default function RundownViewLayoutSettings({ showStyleBase, item, layouts
 					mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
 					mutateUpdateValue={() => undefined}
 				/>
-				<EditAttribute
+				<EditAttributeMultiSelect
 					modifiedClassName="bghl"
 					attribute={`countdownToSegmentRequireLayers`}
 					obj={item}
 					options={showStyleBase.sourceLayers.map((l) => {
-						return { name: l.name, value: l._id }
+						return { label: l.name, value: l._id }
 					})}
-					type="multiselect"
 					label={t('Disabled')}
 					collection={RundownLayouts}
 					className="input text-input input-l dropdown"
@@ -228,7 +226,7 @@ export default function RundownViewLayoutSettings({ showStyleBase, item, layouts
 			<div className="mod mvs mhs">
 				<div className="field">
 					{t('Select visible Source Layers')}
-					<EditAttribute
+					<EditAttributeMultiSelect
 						modifiedClassName="bghl"
 						attribute={'visibleSourceLayers'}
 						obj={item}
@@ -236,19 +234,18 @@ export default function RundownViewLayoutSettings({ showStyleBase, item, layouts
 							.sort((a, b) => a._rank - b._rank)
 							.map((sourceLayer) => ({
 								value: sourceLayer._id,
-								name: sourceLayer.name,
+								label: sourceLayer.name,
 							}))}
-						type="multiselect"
 						mutateUpdateValue={undefinedOnEmptyArray}
 						collection={RundownLayouts}
 						className="input text-input input-l dropdown"
-					></EditAttribute>
+					></EditAttributeMultiSelect>
 				</div>
 			</div>
 			<div className="mod mvs mhs">
 				<div className="field">
 					{t('Select visible Output Groups')}
-					<EditAttribute
+					<EditAttributeMultiSelect
 						modifiedClassName="bghl"
 						attribute={'visibleOutputLayers'}
 						obj={item}
@@ -256,13 +253,12 @@ export default function RundownViewLayoutSettings({ showStyleBase, item, layouts
 							.sort((a, b) => a._rank - b._rank)
 							.map((outputLayer) => ({
 								value: outputLayer._id,
-								name: outputLayer.name,
+								label: outputLayer.name,
 							}))}
-						type="multiselect"
 						mutateUpdateValue={undefinedOnEmptyArray}
 						collection={RundownLayouts}
 						className="input text-input input-l dropdown"
-					></EditAttribute>
+					></EditAttributeMultiSelect>
 				</div>
 			</div>
 			<div className="mod mvs mhs">
@@ -277,14 +273,13 @@ export default function RundownViewLayoutSettings({ showStyleBase, item, layouts
 					mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? false : true)}
 					mutateUpdateValue={() => undefined}
 				/>
-				<EditAttribute
+				<EditAttributeMultiSelect
 					modifiedClassName="bghl"
 					attribute={`showDurationSourceLayers`}
 					obj={item}
 					options={showStyleBase.sourceLayers.map((l) => {
-						return { name: l.name, value: l._id }
+						return { label: l.name, value: l._id }
 					})}
-					type="multiselect"
 					label={t('Disabled')}
 					collection={RundownLayouts}
 					className="input text-input input-l dropdown"

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -82,10 +82,11 @@ const DEFAULT_SETTINGS = Object.freeze<ISettings>({
 	maximumDataAge: 1000 * 60 * 60 * 24 * 100, // 100 days
 	enableNTPTimeChecker: null,
 	defaultShelfDisplayOptions: 'buckets,layout,shelfLayout,inspector',
-	enableKeyboardPreview: false,
+	enableKeyboardPreview: true,
 	keyboardMapLayout: KeyboardLayouts.Names.STANDARD_102_TKL,
 	useCountdownToFreezeFrame: true,
 	confirmKeyCode: 'Enter',
+	customizationClassName: 'tv2',
 })
 
 /**


### PR DESCRIPTION
Deprecated old EditAttributeMultiSelect and EditAttributeDropdown.
Made new EditAttributeMultiSelect and EditAttributDropdown that now binds their value on an id instead of just of a display name.
Moved EditAttributeBase into its own.

This is a small step towards refactoring away from the "One component does all" that is EditAttribute.