### PR TITLE
Sof 1274/change dialog options and duplicated names

### DIFF
--- a/meteor/client/lib/ModalDialog.tsx
+++ b/meteor/client/lib/ModalDialog.tsx
@@ -25,6 +25,7 @@ interface IModalDialogAttributes {
 	actions?: ModalAction[]
 	className?: string
 }
+
 interface ModalInput {
 	type: EditAttributeType
 	label?: string
@@ -32,14 +33,17 @@ interface ModalInput {
 	text?: string
 	defaultValue?: any
 }
+
 interface ModalAction {
 	label: string
 	on: OnAction
 	classNames?: string
 }
+
 type OnAction = (e: SomeEvent, inputResult: ModalInputResult) => void
 export type ModalInputResult = { [attribute: string]: any }
 export type SomeEvent = Event | React.SyntheticEvent<object>
+
 export class ModalDialog extends React.Component<IModalDialogAttributes> {
 	sorensen: Sorensen
 
@@ -298,6 +302,7 @@ class ModalDialogGlobalContainer0 extends React.Component<
 			queue: [],
 		}
 	}
+
 	public addQueue(q: ModalDialogQueueItem) {
 		const queue = this.state.queue
 		queue.push(q)
@@ -305,9 +310,11 @@ class ModalDialogGlobalContainer0 extends React.Component<
 			queue,
 		})
 	}
+
 	public queueHasItems(): boolean {
 		return this.state.queue.length > 0
 	}
+
 	public removeAllQueueItems(): void {
 		const queue = this.state.queue
 		queue.splice(0)
@@ -315,6 +322,7 @@ class ModalDialogGlobalContainer0 extends React.Component<
 			queue,
 		})
 	}
+
 	onAccept = (e: SomeEvent, inputResult: ModalInputResult) => {
 		const queue = this.state.queue
 		const onQueue = queue.shift()
@@ -323,6 +331,7 @@ class ModalDialogGlobalContainer0 extends React.Component<
 			onQueue.onAccept(e, inputResult)
 		}
 	}
+
 	onDiscard = (e: SomeEvent, inputResult: ModalInputResult) => {
 		const queue = this.state.queue
 		const onQueue = queue.shift()
@@ -333,6 +342,7 @@ class ModalDialogGlobalContainer0 extends React.Component<
 			}
 		}
 	}
+
 	onSecondary = (e: SomeEvent, inputResult: ModalInputResult) => {
 		const queue = this.state.queue
 		const onQueue = queue.shift()
@@ -343,6 +353,7 @@ class ModalDialogGlobalContainer0 extends React.Component<
 			}
 		}
 	}
+
 	onAction = (e: SomeEvent, inputResult: ModalInputResult, on: OnAction) => {
 		const queue = this.state.queue
 		const onQueue = queue.shift()
@@ -351,6 +362,7 @@ class ModalDialogGlobalContainer0 extends React.Component<
 			on(e, inputResult)
 		}
 	}
+
 	renderString = (str: string) => {
 		const lines = (str || '').split('\n')
 
@@ -358,6 +370,7 @@ class ModalDialogGlobalContainer0 extends React.Component<
 			return <p key={i}>{line.trim()}</p>
 		})
 	}
+
 	render() {
 		const { t } = this.props
 		const onQueue = _.first(this.state.queue)
@@ -389,6 +402,7 @@ class ModalDialogGlobalContainer0 extends React.Component<
 		} else return null
 	}
 }
+
 export const ModalDialogGlobalContainer = withTranslation()(ModalDialogGlobalContainer0)
 let modalDialogGlobalContainerSingleton: ModalDialogGlobalContainer0
 /**
@@ -421,9 +435,9 @@ export function isModalShowing(): boolean {
 }
 
 export function removeAllQueueItems(): void {
-	if (modalDialogGlobalContainerSingleton) {
-		modalDialogGlobalContainerSingleton.removeAllQueueItems()
-	} else {
+	if (!modalDialogGlobalContainerSingleton) {
 		logger.error('modalDialogGlobalContainerSingleton not set!')
+		return
 	}
+	modalDialogGlobalContainerSingleton.removeAllQueueItems()
 }

--- a/meteor/client/lib/ModalDialog.tsx
+++ b/meteor/client/lib/ModalDialog.tsx
@@ -298,17 +298,13 @@ class ModalDialogGlobalContainer0 extends React.Component<
 		}
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		modalDialogGlobalContainerSingleton = this
-		this.state = {
-			queue: [],
-		}
+		this.state = { queue: [] }
 	}
 
 	public addQueue(q: ModalDialogQueueItem) {
 		const queue = this.state.queue
 		queue.push(q)
-		this.setState({
-			queue,
-		})
+		this.setState({ queue })
 	}
 
 	public queueHasItems(): boolean {
@@ -318,9 +314,7 @@ class ModalDialogGlobalContainer0 extends React.Component<
 	public removeAllQueueItems(): void {
 		const queue = this.state.queue
 		queue.splice(0)
-		this.setState({
-			queue,
-		})
+		this.setState({ queue })
 	}
 
 	onAccept = (e: SomeEvent, inputResult: ModalInputResult) => {

--- a/meteor/client/lib/ModalDialog.tsx
+++ b/meteor/client/lib/ModalDialog.tsx
@@ -119,6 +119,7 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 			this.props.onSecondary(e, this.inputResult)
 		}
 	}
+
 	handleAction = (e: SomeEvent, on: OnAction) => {
 		if (on && typeof on === 'function') {
 			on(e, this.inputResult)
@@ -132,9 +133,11 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 			this.handleSecondary(e)
 		}
 	}
+
 	updatedInput = (edit: EditAttributeBase, newValue: any) => {
 		this.inputResult[edit.props.attribute || ''] = newValue
 	}
+
 	render() {
 		return this.props.show ? (
 			<Escape to="viewport">
@@ -305,6 +308,13 @@ class ModalDialogGlobalContainer0 extends React.Component<
 	public queueHasItems(): boolean {
 		return this.state.queue.length > 0
 	}
+	public removeAllQueueItems(): void {
+		const queue = this.state.queue
+		queue.splice(0)
+		this.setState({
+			queue,
+		})
+	}
 	onAccept = (e: SomeEvent, inputResult: ModalInputResult) => {
 		const queue = this.state.queue
 		const onQueue = queue.shift()
@@ -408,4 +418,12 @@ export function isModalShowing(): boolean {
 		return modalDialogGlobalContainerSingleton.queueHasItems()
 	}
 	return false
+}
+
+export function removeAllQueueItems(): void {
+	if (modalDialogGlobalContainerSingleton) {
+		modalDialogGlobalContainerSingleton.removeAllQueueItems()
+	} else {
+		logger.error('modalDialogGlobalContainerSingleton not set!')
+	}
 }

--- a/meteor/client/lib/ShowStyleVariantImportButton.tsx
+++ b/meteor/client/lib/ShowStyleVariantImportButton.tsx
@@ -109,7 +109,7 @@ export const ShowStyleVariantImportButton = withTranslation()(
 								new Notification(
 									undefined,
 									NoticeLevel.TIP,
-									t('Skipped Variant {{name}}.', {
+									t('Skipped import of Variant {{name}}.', {
 										name: showStyleVariant.name,
 									}),
 									'VariantSettings'

--- a/meteor/client/lib/ShowStyleVariantImportButton.tsx
+++ b/meteor/client/lib/ShowStyleVariantImportButton.tsx
@@ -1,5 +1,5 @@
 import { ShowStyleVariant } from '../../lib/collections/ShowStyleVariants'
-import { doModalDialog } from './ModalDialog'
+import { doModalDialog, removeAllQueueItems } from './ModalDialog'
 import { MeteorCall } from '../../lib/api/methods'
 import { logger } from '../../lib/logging'
 import React from 'react'
@@ -97,8 +97,26 @@ export const ShowStyleVariantImportButton = withTranslation()(
 				title: t('Do you want to replace this variant?'),
 				yes: t('Replace'),
 				no: t('Keep both variants'),
+				onDiscard: () => removeAllQueueItems(),
 				onAccept: () => this.replaceShowStyleVariant(showStyleVariant),
 				onSecondary: () => this.importDuplicatedShowStyleVariant(showStyleVariant),
+				actions: [
+					{
+						label: t('Skip'),
+						classNames: 'btn mlm',
+						on: () =>
+							NotificationCenter.push(
+								new Notification(
+									undefined,
+									NoticeLevel.TIP,
+									t('Skipped Variant {{name}}.', {
+										name: showStyleVariant.name,
+									}),
+									'VariantSettings'
+								)
+							),
+					},
+				],
 				message: (
 					<React.Fragment>
 						<p>

--- a/meteor/client/ui/Settings/ShowStyle/VariantListItem.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/VariantListItem.tsx
@@ -161,7 +161,7 @@ export const VariantListItem: React.FunctionComponent<IShowStyleVariantItemProps
 				<React.Fragment>
 					<p>
 						{t(
-							'Do you want to keep the newly created Variant: "{{showStyleVariantName}}" as a duplicate or replace it?',
+							'Do you want to keep the newly created Variant: "{{showStyleVariantName}}" as a duplicate or use it to replace the existing one?',
 							{
 								showStyleVariantName: props.showStyleVariant.name,
 							}

--- a/meteor/client/ui/Settings/ShowStyle/VariantListItem.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/VariantListItem.tsx
@@ -96,16 +96,20 @@ export const VariantListItem: React.FunctionComponent<IShowStyleVariantItemProps
 	}
 
 	function showStyleVariantNameAlreadyExists(): boolean {
-		return props.dragDropVariants.some((variantToCheck: ShowStyleVariant) => {
-			const nameToCheck = variantToCheck.name
-			return nameToCheck === props.showStyleVariant.name && variantToCheck._id !== props.showStyleVariant._id
+		return props.dragDropVariants.some((variant: ShowStyleVariant) => {
+			return variant.name === props.showStyleVariant.name && variant._id !== props.showStyleVariant._id
 		})
 	}
 
-	function addDuplicationCountToName(showStyleVariant: ShowStyleVariant): void {
+	function addDuplicationCountToName(showStyleVariant: ShowStyleVariant, duplicatorIncrement?: number): void {
+		const increment = duplicatorIncrement ?? 0
 		showStyleVariant.name = getNameWithRemovedDuplicateIndicator(showStyleVariant)
-		showStyleVariant.name += ' (' + getDuplicatedShowStyleVariantCount(showStyleVariant) + ')'
-		MeteorCall.showstyles.renameShowStyleVariant(props.showStyleBase._id, props.showStyleVariant).catch(logger.warn)
+		showStyleVariant.name += ' (' + (getDuplicatedShowStyleVariantCount(showStyleVariant) + increment) + ')'
+		if (showStyleVariantNameAlreadyExists()) {
+			addDuplicationCountToName(showStyleVariant, increment + 1)
+		} else {
+			MeteorCall.showstyles.renameShowStyleVariant(props.showStyleBase._id, props.showStyleVariant).catch(logger.warn)
+		}
 	}
 
 	function getDuplicatedShowStyleVariantCount(showStyleVariant: ShowStyleVariant): number {

--- a/meteor/client/ui/Settings/ShowStyle/VariantListItem.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/VariantListItem.tsx
@@ -102,17 +102,17 @@ export const VariantListItem: React.FunctionComponent<IShowStyleVariantItemProps
 	}
 
 	function showStyleVariantNameAlreadyExists(showStyleVariant: ShowStyleVariant): boolean {
-		return props.dragDropVariants.some((variant: ShowStyleVariant) => {
-			return variant.name === showStyleVariant.name && variant._id !== showStyleVariant._id
-		})
+		return props.dragDropVariants.some(
+			(variant: ShowStyleVariant) => variant.name === showStyleVariant.name && variant._id !== showStyleVariant._id
+		)
 	}
 
-	function addDuplicationCountToName(showStyleVariant: ShowStyleVariant, duplicatorIncrement?: number): void {
-		const increment = duplicatorIncrement ?? 0
-		showStyleVariant.name = getNameWithRemovedDuplicateIndicator(showStyleVariant)
-		showStyleVariant.name += ' (' + (getDuplicatedShowStyleVariantCount(showStyleVariant) + increment) + ')'
+	function addDuplicationCountToName(showStyleVariant: ShowStyleVariant, duplicatorIncrement: number = 0): void {
+		showStyleVariant.name = `${getNameWithRemovedDuplicateIndicator(showStyleVariant)} (${
+			getDuplicatedShowStyleVariantCount(showStyleVariant) + duplicatorIncrement
+		})`
 		if (showStyleVariantNameAlreadyExists(showStyleVariant)) {
-			addDuplicationCountToName(showStyleVariant, increment + 1)
+			addDuplicationCountToName(showStyleVariant, duplicatorIncrement + 1)
 		} else {
 			MeteorCall.showstyles.renameShowStyleVariant(props.showStyleBase._id, props.showStyleVariant).catch(logger.warn)
 		}
@@ -142,8 +142,8 @@ export const VariantListItem: React.FunctionComponent<IShowStyleVariantItemProps
 
 	function provideDuplicatedNameOptions() {
 		doModalDialog({
-			title: t('Two variants have the same name, do you want to keep both?'),
-			yes: t('Keep both'),
+			title: t('Two or more variants have the same name'),
+			yes: t('Keep'),
 			no: t('Replace'),
 			onAccept: () => {
 				addDuplicationCountToName(props.showStyleVariant)
@@ -160,9 +160,12 @@ export const VariantListItem: React.FunctionComponent<IShowStyleVariantItemProps
 			message: (
 				<React.Fragment>
 					<p>
-						{t('Do you want to replace "{{showStyleVariantName}}"?', {
-							showStyleVariantName: props.showStyleVariant.name,
-						})}
+						{t(
+							'Do you want to keep the newly created Variant: "{{showStyleVariantName}}" as a duplicate or replace it?',
+							{
+								showStyleVariantName: props.showStyleVariant.name,
+							}
+						)}
 					</p>
 				</React.Fragment>
 			),

--- a/meteor/lib/api/showStyles.ts
+++ b/meteor/lib/api/showStyles.ts
@@ -9,7 +9,10 @@ export interface NewShowStylesAPI {
 	removeShowStyleBase(showStyleBaseId: ShowStyleBaseId): Promise<void>
 	removeShowStyleVariant(showStyleVariantId: ShowStyleVariantId): Promise<void>
 	reorderAllShowStyleVariants(showStyleBaseId: ShowStyleBaseId, orderedVariants: ShowStyleVariant[]): Promise<void>
-	renameShowStyleVariant(showStyleBaseId: ShowStyleBaseId, renamedShowStyleVariant: ShowStyleVariant): Promise<void>
+	renameShowStyleVariant(
+		showStyleBaseId: ShowStyleBaseId,
+		renamedShowStyleVariant: Pick<ShowStyleVariant, '_id' | 'name'>
+	): Promise<void>
 }
 
 export enum ShowStylesAPIMethods {

--- a/meteor/lib/api/showStyles.ts
+++ b/meteor/lib/api/showStyles.ts
@@ -9,6 +9,7 @@ export interface NewShowStylesAPI {
 	removeShowStyleBase(showStyleBaseId: ShowStyleBaseId): Promise<void>
 	removeShowStyleVariant(showStyleVariantId: ShowStyleVariantId): Promise<void>
 	reorderAllShowStyleVariants(showStyleBaseId: ShowStyleBaseId, orderedVariants: ShowStyleVariant[]): Promise<void>
+	renameShowStyleVariant(showStyleBaseId: ShowStyleBaseId, renamedShowStyleVariant: ShowStyleVariant): Promise<void>
 }
 
 export enum ShowStylesAPIMethods {
@@ -19,4 +20,5 @@ export enum ShowStylesAPIMethods {
 	'removeShowStyleBase' = 'showstyles.removeShowStyleBase',
 	'removeShowStyleVariant' = 'showstyles.removeShowStyleVariant',
 	'reorderAllShowStyleVariants' = 'showstyles.reorderAllShowStyleVariants',
+	'renameShowStyleVariant' = 'showstyles.renameShowStyleVariant',
 }

--- a/meteor/server/api/showStyles.ts
+++ b/meteor/server/api/showStyles.ts
@@ -188,6 +188,19 @@ async function reassignShowStyleVariantIndexes(orderedVariants: ShowStyleVariant
 	)
 }
 
+export async function renameShowStyleVariant(
+	context: MethodContext,
+	showStyleBaseId: ShowStyleBaseId,
+	renamedShowStyleVariant: ShowStyleVariant
+): Promise<void> {
+	await assertShowStyleBaseAccess(context, showStyleBaseId)
+	await ShowStyleVariants.updateAsync(renamedShowStyleVariant._id, {
+		$set: {
+			name: renamedShowStyleVariant.name,
+		},
+	})
+}
+
 class ServerShowStylesAPI extends MethodContextAPI implements NewShowStylesAPI {
 	async insertShowStyleBase() {
 		return insertShowStyleBase(this)
@@ -209,6 +222,9 @@ class ServerShowStylesAPI extends MethodContextAPI implements NewShowStylesAPI {
 	}
 	async reorderAllShowStyleVariants(showStyleBaseId: ShowStyleBaseId, orderedVariants: ShowStyleVariant[]) {
 		return reorderAllShowStyleVariants(this, showStyleBaseId, orderedVariants)
+	}
+	async renameShowStyleVariant(showStyleBaseId: ShowStyleBaseId, renamedShowStyleVariant: ShowStyleVariant) {
+		return renameShowStyleVariant(this, showStyleBaseId, renamedShowStyleVariant)
 	}
 }
 registerClassToMeteorMethods(ShowStylesAPIMethods, ServerShowStylesAPI, false)

--- a/meteor/server/api/showStyles.ts
+++ b/meteor/server/api/showStyles.ts
@@ -191,7 +191,7 @@ async function reassignShowStyleVariantIndexes(orderedVariants: ShowStyleVariant
 export async function renameShowStyleVariant(
 	context: MethodContext,
 	showStyleBaseId: ShowStyleBaseId,
-	renamedShowStyleVariant: ShowStyleVariant
+	renamedShowStyleVariant: Pick<ShowStyleVariant, '_id' | 'name'>
 ): Promise<void> {
 	await assertShowStyleBaseAccess(context, showStyleBaseId)
 	await ShowStyleVariants.updateAsync(renamedShowStyleVariant._id, {
@@ -223,7 +223,10 @@ class ServerShowStylesAPI extends MethodContextAPI implements NewShowStylesAPI {
 	async reorderAllShowStyleVariants(showStyleBaseId: ShowStyleBaseId, orderedVariants: ShowStyleVariant[]) {
 		return reorderAllShowStyleVariants(this, showStyleBaseId, orderedVariants)
 	}
-	async renameShowStyleVariant(showStyleBaseId: ShowStyleBaseId, renamedShowStyleVariant: ShowStyleVariant) {
+	async renameShowStyleVariant(
+		showStyleBaseId: ShowStyleBaseId,
+		renamedShowStyleVariant: Pick<ShowStyleVariant, '_id' | 'name'>
+	) {
 		return renameShowStyleVariant(this, showStyleBaseId, renamedShowStyleVariant)
 	}
 }


### PR DESCRIPTION
This PR is a fix to include some desired behaviour for show style variants, discovered during testing. 
The PR introduces the ability to cancel the entire import by pressing the X of the import dialog. To do this, it required a method for clearing the ModalDialog queue. 
The import dialog now includes a Skip-button. Furthermore, you can no longer edit and provide the same name to a variant without a dialog asking you to either replace or rename. 