### PR TITLE
SOF 964/Accommodate Filtering for GFX Defaults

### DIFF
--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -142,9 +142,13 @@ function getSourceValuesFromComparisonMapping(
 	comparisonMapping: ComparisonMapping
 ): SelectOption[] {
 	const targetValue = targetRow[comparisonMapping.targetColumnId]
-	const isMatched = sourceRow[comparisonMapping.sourceColumnId].some(
-		(sourceValue) => sourceValue.label === targetValue.label
-	)
+
+	const isMatched = sourceRow[comparisonMapping.sourceColumnId].some((sourceValue) => {
+		if (!sourceValue.label || !targetValue.label) {
+			return false
+		}
+		return sourceValue.label === targetValue.label
+	})
 
 	return isMatched ? sourceRow[sourceValueColumnId] : []
 }

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -81,7 +81,7 @@ function filterLayerMappings(
 	return result
 }
 
-function filterGfxDefaults<DBInterface extends { _id: ProtectedString<any> }>(
+function getFilteredTableValues<DBInterface extends { _id: ProtectedString<any> }>(
 	item: ConfigManifestEntrySelectPickedFromColumn<boolean>,
 	configPath: string,
 	object: DBInterface,
@@ -95,8 +95,7 @@ function filterGfxDefaults<DBInterface extends { _id: ProtectedString<any> }>(
 	const defaultRow = toTable.filter((row) => {
 		return typeof row === 'object' && row[item.toColumnId] !== undefined
 	})
-
-	if (!Array.isArray(fromTable) && !Array.isArray(toTable)) {
+	if ((!Array.isArray(fromTable) && !Array.isArray(toTable)) || defaultRow.length < 1) {
 		return result
 	}
 
@@ -104,7 +103,6 @@ function filterGfxDefaults<DBInterface extends { _id: ProtectedString<any> }>(
 		if (!(typeof row === 'object' && row[item.fromColumnId] !== undefined)) {
 			return
 		}
-
 		row[item.compareId].forEach((compareColumn) => {
 			if (compareColumn === defaultRow[0][item.toColumnId] && Array.isArray(row[item.fromColumnId])) {
 				row[item.fromColumnId].forEach((column) => {
@@ -293,7 +291,7 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
 					attribute={attribute}
 					obj={object}
 					type={item.multiple ? 'multiselect' : 'dropdown'}
-					options={filterGfxDefaults(item, configPath, object, alternateObject)}
+					options={getFilteredTableValues(item, configPath, object, alternateObject)}
 					collection={collection}
 					className="input text-input dropdown input-l"
 				/>
@@ -611,49 +609,55 @@ export class ConfigManifestTable<
 											)}
 										</td>
 									))}
-									<td>
-										<button
-											className={ClassNames('btn btn-danger', {
-												'btn-tight': this.props.subPanel,
-											})}
-											onClick={() => this.removeRow(val._id, baseAttribute)}
-										>
-											<FontAwesomeIcon icon={faTrash} />
-										</button>
-									</td>
+									{configEntry.disableRowManipulation === true || (
+										<td>
+											<button
+												className={ClassNames('btn btn-danger', {
+													'btn-tight': this.props.subPanel,
+												})}
+												onClick={() => this.removeRow(val._id, baseAttribute)}
+											>
+												<FontAwesomeIcon icon={faTrash} />
+											</button>
+										</td>
+									)}
 								</tr>
 							))}
 						</tbody>
 					</table>
 				</div>
-				<button
-					className={ClassNames('btn btn-primary', {
-						'btn-tight': this.props.subPanel,
-					})}
-					onClick={() => this.addRow(configEntry, baseAttribute)}
-				>
-					<FontAwesomeIcon icon={faPlus} />
-				</button>
-				<button
-					className={ClassNames('btn mlm btn-secondary', {
-						'btn-tight': this.props.subPanel,
-					})}
-					onClick={() => this.exportJSON(configEntry, vals)}
-				>
-					<FontAwesomeIcon icon={faDownload} />
-					&nbsp;{t('Export')}
-				</button>
-				<UploadButton
-					className={ClassNames('btn btn-secondary mls', {
-						'btn-tight': this.props.subPanel,
-					})}
-					accept="application/json,.json"
-					onChange={(e) => this.importJSON(e, configEntry, baseAttribute)}
-					key={this.state.uploadFileKey}
-				>
-					<FontAwesomeIcon icon={faUpload} />
-					&nbsp;{t('Import')}
-				</UploadButton>
+				{configEntry.disableRowManipulation === true || (
+					<div>
+						<button
+							className={ClassNames('btn btn-primary', {
+								'btn-tight': this.props.subPanel,
+							})}
+							onClick={() => this.addRow(configEntry, baseAttribute)}
+						>
+							<FontAwesomeIcon icon={faPlus} />
+						</button>
+						<button
+							className={ClassNames('btn mlm btn-secondary', {
+								'btn-tight': this.props.subPanel,
+							})}
+							onClick={() => this.exportJSON(configEntry, vals)}
+						>
+							<FontAwesomeIcon icon={faDownload} />
+							&nbsp;{t('Export')}
+						</button>
+						<UploadButton
+							className={ClassNames('btn btn-secondary mls', {
+								'btn-tight': this.props.subPanel,
+							})}
+							accept="application/json,.json"
+							onChange={(e) => this.importJSON(e, configEntry, baseAttribute)}
+							key={this.state.uploadFileKey}
+						>
+							<FontAwesomeIcon icon={faUpload} />
+							&nbsp;{t('Import')}
+						</UploadButton>
+					</div>
+				)}
 			</div>
 		)
 	}

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -144,7 +144,7 @@ function getSourceValuesFromComparisonMapping(
 	const targetValue = targetRow[comparisonMapping.targetColumnId]
 
 	const isMatched = sourceRow[comparisonMapping.sourceColumnId].some((sourceValue) => {
-		if (!sourceValue.label || !targetValue.label) {
+		if (!sourceValue || !targetValue) {
 			return false
 		}
 		return sourceValue.label === targetValue.label

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -106,7 +106,6 @@ function filterGfxDefaults<DBInterface extends { _id: ProtectedString<any> }>(
 		}
 
 		row[item.compareId].forEach((compareColumn) => {
-			console.log(row[item.fromColumnId])
 			if (compareColumn === defaultRow[0][item.toColumnId] && Array.isArray(row[item.fromColumnId])) {
 				row[item.fromColumnId].forEach((column) => {
 					if (!result.includes(column)) {

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -93,7 +93,7 @@ function getFilteredGfxDefaultTableValues<DBInterface extends { _id: ProtectedSt
 	const targetTable = objectPathGet(object, targetAttribute) ?? objectPathGet(alternateObject, targetAttribute)
 	const defaultRow = targetTable.find((row) => typeof row === 'object' && row[item.targetCompareColumnId] !== undefined)
 	const result: string[] = []
-	if (!Array.isArray(sourceTable) || !Array.isArray(targetTable) || defaultRow.length < 1) {
+	if (!Array.isArray(sourceTable) || !Array.isArray(targetTable) || !defaultRow) {
 		return result
 	}
 
@@ -103,7 +103,7 @@ function getFilteredGfxDefaultTableValues<DBInterface extends { _id: ProtectedSt
 		}
 		if (gfxSchemaIsUnavailable(row, item)) {
 			item.sourceCompareColumnId = 'GfxSetup'
-			item.targetCompareColumnId = 'SelectedGfxSetupName'
+			item.targetCompareColumnId = 'DefaultSetupName'
 		}
 		filterAndCollectGfxDefaultValues(row, item, defaultRow[item.targetCompareColumnId], result)
 	})

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -20,7 +20,7 @@ import {
 	ConfigManifestEntryLayerMappings,
 	SourceLayerType,
 	ConfigManifestEntrySelectFromColumn,
-	ConfigManifestEntryFilterSelectedFromColumn,
+	ConfigManifestEntryFilterDefaultsFromShowMapping,
 	ConfigManifestEntryBoolean,
 	ConfigManifestEntryEnum,
 	ConfigManifestEntryFloat,
@@ -82,7 +82,7 @@ function filterLayerMappings(
 }
 
 function getFilteredGfxDefaultTableValues<DBInterface extends { _id: ProtectedString<any> }>(
-	item: ConfigManifestEntryFilterSelectedFromColumn<boolean>,
+	item: ConfigManifestEntryFilterDefaultsFromShowMapping<boolean>,
 	configPath: string,
 	object: DBInterface,
 	alternateObject?: any
@@ -113,7 +113,7 @@ function getFilteredGfxDefaultTableValues<DBInterface extends { _id: ProtectedSt
 
 function filterAndCollectGfxDefaultValues(
 	tableRow: any,
-	item: ConfigManifestEntryFilterSelectedFromColumn<boolean>,
+	item: ConfigManifestEntryFilterDefaultsFromShowMapping<boolean>,
 	targetColumnId: string,
 	result: string[]
 ) {
@@ -136,7 +136,7 @@ function pushColumnToArray(tableRow: any, columnId: string, resultArray: string[
 	})
 }
 
-function gfxSchemaIsUnavailable(row: any, item: ConfigManifestEntryFilterSelectedFromColumn<boolean>): boolean {
+function gfxSchemaIsUnavailable(row: any, item: ConfigManifestEntryFilterDefaultsFromShowMapping<boolean>): boolean {
 	return row[item.sourceCompareColumnId].length === 0
 }
 
@@ -304,7 +304,7 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
 					className="input text-input dropdown input-l"
 				/>
 			)
-		case ConfigManifestEntryType.FILTER_SELECTED_FROM_COLUMN:
+		case ConfigManifestEntryType.FILTER_DEFAULTS_FROM_SHOW_MAPPING:
 			return (
 				<EditAttribute
 					modifiedClassName="bghl"
@@ -330,7 +330,7 @@ type ResolvedBasicConfigManifestEntry =
 	| ConfigManifestEntryEnum
 	| ConfigManifestEntrySelectFromOptions<boolean>
 	| (ConfigManifestEntrySelectFromColumn<boolean> & { options: string[] })
-	| ConfigManifestEntryFilterSelectedFromColumn<boolean>
+	| ConfigManifestEntryFilterDefaultsFromShowMapping<boolean>
 	| (ConfigManifestEntrySourceLayers<boolean> & { options: Array<{ name: string; value: string }> })
 	| (ConfigManifestEntryLayerMappings<boolean> & { options: Array<{ name: string; value: string }> })
 	| ConfigManifestEntryJson
@@ -867,7 +867,7 @@ export class ConfigManifestSettings<
 				)
 			case ConfigManifestEntryType.SELECT:
 			case ConfigManifestEntryType.SELECT_FROM_COLUMN:
-			case ConfigManifestEntryType.FILTER_SELECTED_FROM_COLUMN:
+			case ConfigManifestEntryType.FILTER_DEFAULTS_FROM_SHOW_MAPPING:
 			case ConfigManifestEntryType.LAYER_MAPPINGS:
 			case ConfigManifestEntryType.SOURCE_LAYERS:
 				return (

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -95,7 +95,7 @@ function getFilteredTableValues<DBInterface extends { _id: ProtectedString<any> 
 	const defaultRow = toTable.filter((row) => {
 		return typeof row === 'object' && row[item.toColumnId] !== undefined
 	})
-	if ((!Array.isArray(fromTable) && !Array.isArray(toTable)) || defaultRow.length < 1) {
+	if (!Array.isArray(fromTable) || !Array.isArray(toTable) || defaultRow.length < 1) {
 		return result
 	}
 
@@ -126,7 +126,7 @@ function getFilteredTableValues<DBInterface extends { _id: ProtectedString<any> 
 }
 
 function gfxSetupShouldBeUsed(item: ConfigManifestEntrySelectPickedFromColumn<boolean>, fromTable: any): boolean {
-	if (!(item.compareId === 'Schema' && item.toColumnId === 'DefaultSchema')) {
+	if (!(item.compareId === 'Schema' && item.toColumnId === 'DefaultSchema') || !Array.isArray(fromTable)) {
 		return false
 	}
 	return fromTable.find((row) => {

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -218,7 +218,7 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
 			const selectWithComparisonOptions =
 				'options' in item
 					? item.options
-					: configurationTableEntrySelector.getFilteredTableValuesFromComparison(
+					: configurationTableEntrySelector.getFilteredSelectOptionsFromComparison(
 							attribute,
 							item,
 							configPath,
@@ -494,7 +494,7 @@ export class ConfigManifestTable<
 						case ConfigManifestEntryType.SELECT_FROM_TABLE_ENTRY_WITH_COMPARISON_MAPPINGS:
 							return {
 								...column,
-								options: configurationTableEntrySelector.getFilteredTableValuesFromComparison(
+								options: configurationTableEntrySelector.getFilteredSelectOptionsFromComparison(
 									props.baseAttribute,
 									column,
 									props.configPath,

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -99,6 +99,11 @@ function getFilteredTableValues<DBInterface extends { _id: ProtectedString<any> 
 		return result
 	}
 
+	if (gfxSetupShouldBeUsed(item, fromTable)) {
+		item.compareId = 'GfxSetup'
+		item.toColumnId = 'SelectedGfxSetupName'
+	}
+
 	fromTable.forEach((row) => {
 		if (!(typeof row === 'object' && row[item.fromColumnId] !== undefined)) {
 			return
@@ -118,6 +123,15 @@ function getFilteredTableValues<DBInterface extends { _id: ProtectedString<any> 
 		})
 	})
 	return result
+}
+
+function gfxSetupShouldBeUsed(item: ConfigManifestEntrySelectPickedFromColumn<boolean>, fromTable: any): boolean {
+	if (!(item.compareId === 'Schema' && item.toColumnId === 'DefaultSchema')) {
+		return false
+	}
+	return fromTable.find((row) => {
+		return row[item.compareId].length === 0
+	})
 }
 
 function getTableColumnValues<DBInterface extends { _id: ProtectedString<any> }>(

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -98,7 +98,7 @@ function getFilteredGfxDefaultTableValues<DBInterface extends { _id: ProtectedSt
 	}
 
 	sourceTable.forEach((row) => {
-		if (!(typeof row === 'object' && row[item.sourceCollectColumnId] !== undefined)) {
+		if (typeof row !== 'object' || row[item.sourceCollectColumnId] === undefined) {
 			return
 		}
 		if (gfxSchemaIsUnavailable(row, item)) {
@@ -534,9 +534,7 @@ export class ConfigManifestTable<
 						case ConfigManifestEntryType.SELECT_FROM_COLUMN:
 							return {
 								...column,
-								options: props.layerMappings
-									? getTableColumnValues(column, props.configPath, props.object, props.alternateObject)
-									: [],
+								options: getTableColumnValues(column, props.configPath, props.object, props.alternateObject),
 							}
 						default:
 							return column
@@ -625,11 +623,14 @@ export class ConfigManifestTable<
 												this.props.configPath,
 												this.props.object,
 												col,
-												`${baseAttribute}.${sortedIndices[i]}.${col.id}`
+												`${baseAttribute}.${sortedIndices[i]}.${col.id}`,
+												undefined,
+												undefined,
+												this.props.alternateObject
 											)}
 										</td>
 									))}
-									{configEntry.disableRowManipulation === true || (
+									{!configEntry.disableRowManipulation && (
 										<td>
 											<button
 												className={ClassNames('btn btn-danger', {

--- a/meteor/client/ui/Settings/helpers/config-manifest-table-entry-selector.ts
+++ b/meteor/client/ui/Settings/helpers/config-manifest-table-entry-selector.ts
@@ -1,0 +1,107 @@
+import {
+	ComparisonMapping,
+	ConfigManifestEntrySelectFromColumn,
+	ConfigManifestEntrySelectFromTableEntryWithComparisonMappings,
+	TableConfigItemValue,
+} from '@sofie-automation/blueprints-integration'
+import { ProtectedString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
+import { objectPathGet } from '@sofie-automation/corelib/dist/lib'
+import { SelectOption } from '../ConfigManifestSettings'
+
+export const DEFAULT_VALUE_FOR_NO_VIABLE_SELECTION = 'N/A'
+
+class ConfigManifestTableEntrySelector {
+	public getFilteredTableValuesFromComparison<DBInterface extends { _id: ProtectedString<any> }>(
+		targetFullAttribute: string,
+		item: ConfigManifestEntrySelectFromTableEntryWithComparisonMappings<boolean>,
+		configPath: string,
+		dbObject: DBInterface,
+		alternateDbObject?: DBInterface
+	): SelectOption[] {
+		const sourceAttribute = `${configPath}.${item.sourceTableId}`
+		const targetAttribute = `${targetFullAttribute}.${0}`
+
+		const sourceTable: TableConfigItemValue[] =
+			objectPathGet(dbObject, sourceAttribute) ?? objectPathGet(alternateDbObject, sourceAttribute)
+		const targetRow: TableConfigItemValue =
+			objectPathGet(dbObject, targetAttribute) ?? objectPathGet(alternateDbObject, targetAttribute)
+
+		if (!Array.isArray(sourceTable) || !targetRow) {
+			return []
+		}
+
+		const result = sourceTable.flatMap((sourceRow) => {
+			if (!this.hasRowEntryWithValue(sourceRow, item.sourceColumnIdWithValue)) {
+				return []
+			}
+			const comparisonMapping = this.getComparisonMapping(item.comparisonMappings, sourceRow)
+			if (!comparisonMapping) {
+				return []
+			}
+
+			return this.getSourceValuesFromComparisonMapping(
+				sourceRow,
+				targetRow,
+				item.sourceColumnIdWithValue,
+				comparisonMapping
+			)
+		})
+		result.push({ value: DEFAULT_VALUE_FOR_NO_VIABLE_SELECTION, label: DEFAULT_VALUE_FOR_NO_VIABLE_SELECTION })
+		return result
+	}
+
+	public getComparisonMapping(
+		comparisonMappings: ComparisonMapping[],
+		sourceRow: TableConfigItemValue
+	): ComparisonMapping | undefined {
+		return comparisonMappings.find((mapping) => this.isRowEntryAvailable(sourceRow, mapping.sourceColumnId))
+	}
+
+	public isRowEntryAvailable(tableRow: TableConfigItemValue, columnId: string): boolean {
+		return tableRow[columnId] && tableRow[columnId].length > 0
+	}
+
+	public hasRowEntryWithValue(row: TableConfigItemValue, columnId: string): boolean {
+		return typeof row === 'object' && row[columnId] !== undefined
+	}
+
+	public getSourceValuesFromComparisonMapping(
+		sourceRow: TableConfigItemValue,
+		targetRow: TableConfigItemValue,
+		sourceValueColumnId: string,
+		comparisonMapping: ComparisonMapping
+	): SelectOption[] {
+		const targetValue = targetRow[comparisonMapping.targetColumnId]
+
+		const isMatched = sourceRow[comparisonMapping.sourceColumnId].some((sourceValue) => {
+			if (!sourceValue || !targetValue) {
+				return false
+			}
+			return sourceValue.label === targetValue.label
+		})
+
+		return isMatched ? sourceRow[sourceValueColumnId] : []
+	}
+
+	public getTableColumnValues<DBInterface extends { _id: ProtectedString<any> }>(
+		item: ConfigManifestEntrySelectFromColumn<boolean>,
+		configPath: string,
+		dbObject: DBInterface,
+		alternateDbObject?: DBInterface
+	): SelectOption[] {
+		const attribute = `${configPath}.${item.tableId}`
+		const table: TableConfigItemValue[] =
+			objectPathGet(dbObject, attribute) ?? objectPathGet(alternateDbObject, attribute)
+		if (!Array.isArray(table)) {
+			return []
+		}
+		return table
+			.filter((row) => typeof row === 'object' && row[item.columnId] !== undefined)
+			.map((row) => ({
+				value: row['_id'],
+				label: row[item.columnId],
+			}))
+	}
+}
+
+export default new ConfigManifestTableEntrySelector()

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -69,7 +69,6 @@ export interface ISettings {
 const DEFAULT_SETTINGS = Object.freeze<ISettings>({
 	// frameRate: 25,
 	autoRewindLeavingSegment: true,
-	customizationClassName: 'tv2',
 	disableBlurBorder: false,
 	defaultTimeScale: 1,
 	allowGrabbingTimeline: true,

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -69,6 +69,7 @@ export interface ISettings {
 const DEFAULT_SETTINGS = Object.freeze<ISettings>({
 	// frameRate: 25,
 	autoRewindLeavingSegment: true,
+	customizationClassName: 'tv2',
 	disableBlurBorder: false,
 	defaultTimeScale: 1,
 	allowGrabbingTimeline: true,

--- a/packages/blueprints-integration/src/config.ts
+++ b/packages/blueprints-integration/src/config.ts
@@ -14,7 +14,7 @@ export enum ConfigManifestEntryType {
 	SOURCE_LAYERS = 'source_layers',
 	LAYER_MAPPINGS = 'layer_mappings',
 	SELECT_FROM_COLUMN = 'select_from_column',
-	SELECT_PICKED_FROM_COLUMN = 'select_column_picked',
+	FILTER_SELECTED_FROM_COLUMN = 'filter_selected_from_column',
 	JSON = 'json',
 }
 
@@ -29,8 +29,8 @@ export type BasicConfigManifestEntry =
 	| ConfigManifestEntrySelectFromOptions<false>
 	| ConfigManifestEntrySelectFromColumn<true>
 	| ConfigManifestEntrySelectFromColumn<false>
-	| ConfigManifestEntrySelectPickedFromColumn<true>
-	| ConfigManifestEntrySelectPickedFromColumn<false>
+	| ConfigManifestEntryFilterSelectedFromColumn<true>
+	| ConfigManifestEntryFilterSelectedFromColumn<false>
 	| ConfigManifestEntrySourceLayers<true>
 	| ConfigManifestEntrySourceLayers<false>
 	| ConfigManifestEntryLayerMappings<true>
@@ -113,14 +113,14 @@ export interface ConfigManifestEntrySelectFromColumn<Multiple extends boolean>
 	columnId: string
 }
 
-export interface ConfigManifestEntrySelectPickedFromColumn<Multiple extends boolean>
+export interface ConfigManifestEntryFilterSelectedFromColumn<Multiple extends boolean>
 	extends ConfigManifestEntrySelectBase<Multiple> {
-	type: ConfigManifestEntryType.SELECT_PICKED_FROM_COLUMN
-	toTableId: string
-	toColumnId: string
-	fromTableId: string
-	fromColumnId: string
-	compareId: string
+	type: ConfigManifestEntryType.FILTER_SELECTED_FROM_COLUMN
+	targetTableId: string
+	targetCompareColumnId: string
+	sourceTableId: string
+	sourceCompareColumnId: string
+	sourceCollectColumnId: string
 }
 
 export interface ConfigManifestEntrySourceLayers<Multiple extends boolean>

--- a/packages/blueprints-integration/src/config.ts
+++ b/packages/blueprints-integration/src/config.ts
@@ -116,10 +116,16 @@ export interface ConfigManifestEntrySelectFromColumn<Multiple extends boolean>
 export interface ConfigManifestEntryFilterDefaultsFromShowMapping<Multiple extends boolean>
 	extends ConfigManifestEntrySelectBase<Multiple> {
 	type: ConfigManifestEntryType.FILTER_DEFAULTS_FROM_SHOW_MAPPING
+	/** The id of the ConfigManifestEntryTable that should receive the filtered values */
 	targetTableId: string
+	/** The id of the BasicConfigManifestEntry that should receive the filtered values */
 	targetCompareColumnId: string
+	/** The id of the ConfigManifestEntryTable from where values are gathered */
 	sourceTableId: string
+	/** The id of the BasicConfigManifestEntry from which related values should be filtered and found
+	 e.g: If you want to find GFX Schema Templates based on a GFX Setup, you make this the GFX Setup id **/
 	sourceCompareColumnId: string
+	/** The id of the BasicConfigManifestEntry from where the wanted values are collected */
 	sourceCollectColumnId: string
 }
 

--- a/packages/blueprints-integration/src/config.ts
+++ b/packages/blueprints-integration/src/config.ts
@@ -14,7 +14,7 @@ export enum ConfigManifestEntryType {
 	SOURCE_LAYERS = 'source_layers',
 	LAYER_MAPPINGS = 'layer_mappings',
 	SELECT_FROM_COLUMN = 'select_from_column',
-	FILTER_DEFAULTS_FROM_SHOW_MAPPING = 'filter_defaults_from_show_mapping',
+	SELECT_FROM_TABLE_ENTRY_WITH_COMPARISON_MAPPINGS = 'select_from_table_entry_with_comparison_mappings',
 	JSON = 'json',
 }
 
@@ -29,8 +29,8 @@ export type BasicConfigManifestEntry =
 	| ConfigManifestEntrySelectFromOptions<false>
 	| ConfigManifestEntrySelectFromColumn<true>
 	| ConfigManifestEntrySelectFromColumn<false>
-	| ConfigManifestEntryFilterDefaultsFromShowMapping<true>
-	| ConfigManifestEntryFilterDefaultsFromShowMapping<false>
+	| ConfigManifestEntrySelectFromTableEntryWithComparisonMappings<true>
+	| ConfigManifestEntrySelectFromTableEntryWithComparisonMappings<false>
 	| ConfigManifestEntrySourceLayers<true>
 	| ConfigManifestEntrySourceLayers<false>
 	| ConfigManifestEntryLayerMappings<true>
@@ -113,20 +113,17 @@ export interface ConfigManifestEntrySelectFromColumn<Multiple extends boolean>
 	columnId: string
 }
 
-export interface ConfigManifestEntryFilterDefaultsFromShowMapping<Multiple extends boolean>
+export type ComparisonMapping = { targetColumnId: string; sourceColumnId: string }
+
+export interface ConfigManifestEntrySelectFromTableEntryWithComparisonMappings<Multiple extends boolean>
 	extends ConfigManifestEntrySelectBase<Multiple> {
-	type: ConfigManifestEntryType.FILTER_DEFAULTS_FROM_SHOW_MAPPING
-	/** The id of the ConfigManifestEntryTable that should receive the filtered values */
-	targetTableId: string
-	/** The id of the BasicConfigManifestEntry that should receive the filtered values */
-	targetCompareColumnId: string
-	/** The id of the ConfigManifestEntryTable from where values are gathered */
+	type: ConfigManifestEntryType.SELECT_FROM_TABLE_ENTRY_WITH_COMPARISON_MAPPINGS
+
 	sourceTableId: string
-	/** The id of the BasicConfigManifestEntry from which related values should be filtered and found
-	 e.g: If you want to find GFX Schema Templates based on a GFX Setup, you make this the GFX Setup id **/
-	sourceCompareColumnId: string
-	/** The id of the BasicConfigManifestEntry from where the wanted values are collected */
-	sourceCollectColumnId: string
+
+	comparisonMappings: ComparisonMapping[]
+
+	sourceColumnIdWithValue: string
 }
 
 export interface ConfigManifestEntrySourceLayers<Multiple extends boolean>

--- a/packages/blueprints-integration/src/config.ts
+++ b/packages/blueprints-integration/src/config.ts
@@ -14,6 +14,7 @@ export enum ConfigManifestEntryType {
 	SOURCE_LAYERS = 'source_layers',
 	LAYER_MAPPINGS = 'layer_mappings',
 	SELECT_FROM_COLUMN = 'select_from_column',
+	SELECT_PICKED_FROM_COLUMN = 'select_column_picked',
 	JSON = 'json',
 }
 
@@ -28,6 +29,8 @@ export type BasicConfigManifestEntry =
 	| ConfigManifestEntrySelectFromOptions<false>
 	| ConfigManifestEntrySelectFromColumn<true>
 	| ConfigManifestEntrySelectFromColumn<false>
+	| ConfigManifestEntrySelectPickedFromColumn<true>
+	| ConfigManifestEntrySelectPickedFromColumn<false>
 	| ConfigManifestEntrySourceLayers<true>
 	| ConfigManifestEntrySourceLayers<false>
 	| ConfigManifestEntryLayerMappings<true>
@@ -107,6 +110,16 @@ export interface ConfigManifestEntrySelectFromColumn<Multiple extends boolean>
 	tableId: string
 	/** The id of a BasicConfigManifestEntry in the table */
 	columnId: string
+}
+
+export interface ConfigManifestEntrySelectPickedFromColumn<Multiple extends boolean>
+	extends ConfigManifestEntrySelectBase<Multiple> {
+	type: ConfigManifestEntryType.SELECT_PICKED_FROM_COLUMN
+	toTableId: string
+	toColumnId: string
+	fromTableId: string
+	fromColumnId: string
+	compareId: string
 }
 
 export interface ConfigManifestEntrySourceLayers<Multiple extends boolean>

--- a/packages/blueprints-integration/src/config.ts
+++ b/packages/blueprints-integration/src/config.ts
@@ -90,6 +90,7 @@ export interface ConfigManifestEntryTable extends ConfigManifestEntryBase {
 		rank: number
 	})[]
 	defaultVal: TableConfigItemValue
+	disableRowManipulation?: boolean
 }
 
 interface ConfigManifestEntrySelectBase<Multiple extends boolean> extends ConfigManifestEntryBase {

--- a/packages/blueprints-integration/src/config.ts
+++ b/packages/blueprints-integration/src/config.ts
@@ -14,7 +14,7 @@ export enum ConfigManifestEntryType {
 	SOURCE_LAYERS = 'source_layers',
 	LAYER_MAPPINGS = 'layer_mappings',
 	SELECT_FROM_COLUMN = 'select_from_column',
-	FILTER_SELECTED_FROM_COLUMN = 'filter_selected_from_column',
+	FILTER_DEFAULTS_FROM_SHOW_MAPPING = 'filter_defaults_from_show_mapping',
 	JSON = 'json',
 }
 
@@ -29,8 +29,8 @@ export type BasicConfigManifestEntry =
 	| ConfigManifestEntrySelectFromOptions<false>
 	| ConfigManifestEntrySelectFromColumn<true>
 	| ConfigManifestEntrySelectFromColumn<false>
-	| ConfigManifestEntryFilterSelectedFromColumn<true>
-	| ConfigManifestEntryFilterSelectedFromColumn<false>
+	| ConfigManifestEntryFilterDefaultsFromShowMapping<true>
+	| ConfigManifestEntryFilterDefaultsFromShowMapping<false>
 	| ConfigManifestEntrySourceLayers<true>
 	| ConfigManifestEntrySourceLayers<false>
 	| ConfigManifestEntryLayerMappings<true>
@@ -113,9 +113,9 @@ export interface ConfigManifestEntrySelectFromColumn<Multiple extends boolean>
 	columnId: string
 }
 
-export interface ConfigManifestEntryFilterSelectedFromColumn<Multiple extends boolean>
+export interface ConfigManifestEntryFilterDefaultsFromShowMapping<Multiple extends boolean>
 	extends ConfigManifestEntrySelectBase<Multiple> {
-	type: ConfigManifestEntryType.FILTER_SELECTED_FROM_COLUMN
+	type: ConfigManifestEntryType.FILTER_DEFAULTS_FROM_SHOW_MAPPING
 	targetTableId: string
 	targetCompareColumnId: string
 	sourceTableId: string


### PR DESCRIPTION
This PR has the purpose of making it possible to create the GFX Defaults table by filtering values from GFX Show Mapping. This required changes to blueprints-integration. It also makes it possible to have a table only hold a single row, thereby removing the ability to add and delete rows. 