### PR TITLE
chore: allow meteor settings file to be provided to `yarn dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"concurrently": "^7.4.0",
 		"rimraf": "^3.0.2",
 		"semver": "^7.3.7",
-		"snyk-nodejs-lockfile-parser": "^1.43.1"
+		"snyk-nodejs-lockfile-parser": "^1.43.1",
+		"yargs": "^17.7.1"
 	}
 }

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -1,10 +1,13 @@
 const process = require("process");
 const concurrently = require("concurrently");
-const args = process.argv.slice(2);
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+const args = yargs(hideBin(process.argv)).argv;
 
 const config = {
-	uiOnly: args.indexOf("--ui-only") >= 0 || false,
-	inspectMeteor: args.indexOf("--inspect-meteor") >= 0 || false,
+	uiOnly: args['ui-only'],
+	inspectMeteor: args['inspect-meteor'],
+	settings: args['settings'],
 };
 
 function watchPackages() {
@@ -40,7 +43,8 @@ function watchMeteor() {
 		{
 			command:
 				"meteor yarn debug" +
-				(config.inspectMeteor ? " --inspect" : ""),
+				(config.inspectMeteor ? " --inspect" : "") +
+				(config.settings ? ` --settings ${config.settings}` : ""),
 			cwd: "meteor",
 			name: "METEOR",
 			prefixColor: "cyan",

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,6 +395,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 clone-response@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.3.tgz#af2032aa47816399cf5f0a1d0db902f517abb8c3"
@@ -1343,7 +1352,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@^21.0.0:
+yargs-parser@^21.0.0, yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
@@ -1360,3 +1369,16 @@ yargs@^17.3.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yargs@^17.7.1:
+  version "17.7.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
+  integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"


### PR DESCRIPTION
use the `--settings` argument, followed by file name of the json file with settings
example `yarn dev --settings C:\somepath\core-settings.json`