### PR TITLE
SOF-1240 Reflect attribute changes

### DIFF
--- a/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
@@ -26,6 +26,7 @@ const WrappedEditAttributeDropdown = wrapEditAttribute(
 
 		componentDidMount() {
 			this.populateFromFirstAvailableOptionIfNoValueIsSelected()
+			this.updateSelectedOptionIfLabelIsChanged()
 		}
 
 		private populateFromFirstAvailableOptionIfNoValueIsSelected() {
@@ -35,6 +36,37 @@ const WrappedEditAttributeDropdown = wrapEditAttribute(
 				return
 			}
 			this.handleChange({ target: { value: availableOptions[0].value } })
+		}
+
+		componentDidUpdate(prevProps: Readonly<IEditAttributeBaseProps>) {
+			if (prevProps === this.props) {
+				return
+			}
+			this.updateSelectedOptionIfLabelIsChanged()
+		}
+
+		private updateSelectedOptionIfLabelIsChanged(): void {
+			const selectedOptionFromDatabase = this.getCurrentlySelectedOption()
+			if (!selectedOptionFromDatabase) {
+				return
+			}
+			const selectedOptionFromAvailableOptions = this.findOptionInAvailableOptions(selectedOptionFromDatabase)
+			if (!selectedOptionFromAvailableOptions) {
+				return
+			}
+			const selectedOptionHasChangedLabel = selectedOptionFromDatabase.label !== selectedOptionFromAvailableOptions.label
+			if (!selectedOptionHasChangedLabel) {
+				return
+			}
+			this.handleUpdate(selectedOptionFromAvailableOptions)
+		}
+
+		private findOptionInAvailableOptions(optionToCheck: DropdownOption): DropdownOption | undefined {
+			return this.getAvailableOptions().find(
+				(option) =>
+					option.value.toLowerCase() === optionToCheck.value.toLowerCase() ||
+					(option.alternativeValue && option.alternativeValue === optionToCheck.value.toLowerCase())
+			)
 		}
 
 		private handleChange(event) {
@@ -60,12 +92,12 @@ const WrappedEditAttributeDropdown = wrapEditAttribute(
 			return (this.props as EditAttributeDropdownProps).options
 		}
 
-		private getMissingOptions(availableOptions: DropdownOption[]): DropdownOption[] {
+		private getMissingOptions(): DropdownOption[] {
 			const selectedOption: DropdownOption = this.getCurrentlySelectedOption()
 			if (!selectedOption) {
 				return []
 			}
-			const selectedIsAnAvailableOption = availableOptions.some(
+			const selectedIsAnAvailableOption = this.getAvailableOptions().some(
 				(option) =>
 					option.value.toLowerCase() === selectedOption.value.toLowerCase() ||
 					(option.alternativeValue && option.alternativeValue === selectedOption.value.toLowerCase())
@@ -75,7 +107,7 @@ const WrappedEditAttributeDropdown = wrapEditAttribute(
 
 		render() {
 			const availableOptions = this.getAvailableOptions()
-			const missingOptions = this.getMissingOptions(availableOptions)
+			const missingOptions = this.getMissingOptions()
 			const currentlySelectedOption = this.getCurrentlySelectedOption()
 			return (
 				<select

--- a/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
@@ -54,7 +54,8 @@ const WrappedEditAttributeDropdown = wrapEditAttribute(
 			if (!selectedOptionFromAvailableOptions) {
 				return
 			}
-			const selectedOptionHasChangedLabel = selectedOptionFromDatabase.label !== selectedOptionFromAvailableOptions.label
+			const selectedOptionHasChangedLabel =
+				selectedOptionFromDatabase.label !== selectedOptionFromAvailableOptions.label
 			if (!selectedOptionHasChangedLabel) {
 				return
 			}

--- a/meteor/client/lib/editAttribute/edit-attribute-multi-select.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-multi-select.tsx
@@ -23,6 +23,47 @@ const WrappedEditAttributeMultiSelect = wrapEditAttribute(
 			this.handleUpdate(changedOptions)
 		}
 
+		componentDidMount() {
+			this.updateSelectedOptionsIfLabelsHasChanged()
+		}
+
+		componentDidUpdate(prevProps: Readonly<IEditAttributeBaseProps>) {
+			if (prevProps === this.props) {
+				return
+			}
+			this.updateSelectedOptionsIfLabelsHasChanged()
+		}
+
+		private updateSelectedOptionsIfLabelsHasChanged(): void {
+			const selectedOptionsFromDatabase = this.getCurrentlySelectedOptions()
+			if (!selectedOptionsFromDatabase || selectedOptionsFromDatabase.length === 0) {
+				return
+			}
+			const availableOptions = this.getAvailableOptions()
+			if (!availableOptions || availableOptions.length === 0) {
+				return
+			}
+			// This introduces a side effect in the .map() below, but it's a quick way of ensuring we only update when a label has changed
+			let selectedOptionsNeedsToBeUpdated: boolean = false
+			const optionsToUpdate = selectedOptionsFromDatabase.map(option => {
+				const availableOption = availableOptions.find(availableOption => availableOption.value.toLowerCase() === option.value.toLowerCase())
+				if (!availableOption) {
+					// SelectedOption is not in the current available options, so we shouldn't update anything on it
+					return option
+				}
+				if (availableOption.label === option.label) {
+					// SelectedOption has the same label as its corresponding available option so no need to update it
+					return option
+				}
+				selectedOptionsNeedsToBeUpdated = true
+				// We can just return the available option instead of setting the label on the selected option because they have the same 'value'
+				return availableOption
+			})
+			if (selectedOptionsNeedsToBeUpdated) {
+				this.handleChange(optionsToUpdate)
+			}
+		}
+
 		private getCurrentlySelectedOptions(): MultiSelectOption[] {
 			const attribute = this.getAttribute()
 			if (!attribute || !Array.isArray(attribute)) {

--- a/meteor/client/lib/editAttribute/edit-attribute-multi-select.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-multi-select.tsx
@@ -45,8 +45,10 @@ const WrappedEditAttributeMultiSelect = wrapEditAttribute(
 			}
 			// This introduces a side effect in the .map() below, but it's a quick way of ensuring we only update when a label has changed
 			let selectedOptionsNeedsToBeUpdated: boolean = false
-			const optionsToUpdate = selectedOptionsFromDatabase.map(option => {
-				const availableOption = availableOptions.find(availableOption => availableOption.value.toLowerCase() === option.value.toLowerCase())
+			const optionsToUpdate = selectedOptionsFromDatabase.map((option) => {
+				const availableOption = availableOptions.find(
+					(availableOption) => availableOption.value.toLowerCase() === option.value.toLowerCase()
+				)
 				if (!availableOption) {
 					// SelectedOption is not in the current available options, so we shouldn't update anything on it
 					return option

--- a/meteor/client/ui/Settings/helpers/show-style-variant-configuration-verifier.ts
+++ b/meteor/client/ui/Settings/helpers/show-style-variant-configuration-verifier.ts
@@ -124,6 +124,9 @@ class ShowStyleVariantConfigurationVerifier {
 		const sourceTable: TableConfigItemValue[] = showStyleBase.blueprintConfig[
 			manifestEntry.sourceTableId
 		] as any as TableConfigItemValue[]
+		if (!sourceTable) {
+			return false
+		}
 		const validOptions = sourceTable.flatMap((row) =>
 			this.configManifestTableEntrySelector.getOptionsFromSourceRow(row, targetTable[0], manifestEntry)
 		)


### PR DESCRIPTION
EditAttributeDropdown and MultiSelect now updates their database entry when their selected option has a changed label.

When an attribute which was the target of a SELECT_FROM_COLUMN (or other similar ConfigEntries) had their values updated it was not reflected in the attributes that was targeting them. I.e. GfxDefaults was using GfxShowMappings to the get a Design and GfxShowMapping was getting the Design from the Design table. When the Design changed its name then GfxShowMapping didn't save the updated name in the database which meant that GfxDefaults was still getting the old Design name. 

The reason the database wasn't updated was because EditAttributeDropdown and EditAttributeMultiSelect only updated their data when the user selected a new value from their dropdown.

Now every time they get new props they check to see if their selected options has a new name in the props - if yes, it updates it's data in the database.

This has the downside that the value is only updated when the Dropdown or MultiSelect is actually rendered, but this is an accepted sideeffect for now. 


