### PR TITLE
No longer tries to place Object as a child for li

### DIFF
--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -782,7 +782,7 @@ export class ConfigManifestSettings<
 	renderConfigValue(item: ConfigManifestEntry, rawValue: ConfigItemValue | undefined) {
 		const { t } = this.props
 
-		const value = rawValue === undefined ? item.defaultVal : rawValue
+		const value = rawValue ?? item.defaultVal
 
 		const rawValueArr = rawValue as any[]
 
@@ -797,9 +797,12 @@ export class ConfigManifestSettings<
 				return _.isArray(value) ? (
 					<React.Fragment>
 						<ul className="table-values-list">
-							{_.map((value as string[]) || [], (val) => (
-								<li key={val}>{val}</li>
-							))}
+							{_.map((value as any[]) || [], (val) => {
+								const object = {
+									value: 'value' in val ? val.value : val,
+								}
+								return <li key={object.value}>{object.value}</li>
+							})}
 						</ul>
 					</React.Fragment>
 				) : (

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -794,20 +794,19 @@ export class ConfigManifestSettings<
 			case ConfigManifestEntryType.SELECT:
 			case ConfigManifestEntryType.LAYER_MAPPINGS:
 			case ConfigManifestEntryType.SOURCE_LAYERS:
-				return _.isArray(value) ? (
-					<React.Fragment>
-						<ul className="table-values-list">
-							{_.map((value as any[]) || [], (val) => {
-								const object = {
-									value: 'value' in val ? val.value : val,
-								}
-								return <li key={object.value}>{object.value}</li>
-							})}
-						</ul>
-					</React.Fragment>
-				) : (
-					value.toString()
-				)
+				if (_.isArray(value)) {
+					return (
+						<React.Fragment>
+							<ul className="table-values-list">
+								{_.map((value as any[]) || [], (val) => {
+									const objectValue = 'value' in val ? val.value : val
+									return <li key={objectValue}>{objectValue}</li>
+								})}
+							</ul>
+						</React.Fragment>
+					)
+				}
+				return typeof value === 'object' && 'value' in value ? value.value : value.toString()
 			case ConfigManifestEntryType.INT:
 				return _.isNumber(value) && item.zeroBased ? (value + 1).toString() : value.toString()
 			default:

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -798,8 +798,8 @@ export class ConfigManifestSettings<
 					return (
 						<React.Fragment>
 							<ul className="table-values-list">
-								{_.map((value as any[]) || [], (val) => {
-									const objectValue = 'value' in val ? val.value : val
+								{_.map((value as (string | { value: string })[]) || [], (val) => {
+									const objectValue = typeof val === 'object' && 'value' in val ? val.value : val
 									return <li key={objectValue}>{objectValue}</li>
 								})}
 							</ul>


### PR DESCRIPTION
With the new Dropdowns we no longer always get a string array but instead the array is sometimes an array of objects.
This fix makes it work with the array is full of objects.
