### PR TITLE
SOF-1416 Don't check if label has changed if no label is saved to the database

### DIFF
--- a/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
@@ -47,7 +47,7 @@ const WrappedEditAttributeDropdown = wrapEditAttribute(
 
 		private updateSelectedOptionIfLabelIsChanged(): void {
 			const selectedOptionFromDatabase = this.getCurrentlySelectedOption()
-			if (!selectedOptionFromDatabase) {
+			if (!selectedOptionFromDatabase || !('label' in selectedOptionFromDatabase)) {
 				return
 			}
 			const selectedOptionFromAvailableOptions = this.findOptionInAvailableOptions(selectedOptionFromDatabase)


### PR DESCRIPTION
When trying to add a new blueprints-configuration to a Studio or a Showstyle we would enter an inifite loop.
The loop happened because EditAttributeDropdown checks if the label has changed - if it has it will trigger an update.

The use of EditAttributeDropdown for adding blueprints-configurations does not have a label saved, so the label will always be changed. It also overrides the update function and make it call setState() which triggers a rerender, which triggers another check of if the label has changed and so forth.

Updated to only check if the label has changed if there is a saved value for label in the database.