### PR TITLE
SOF-1418 Map sourceLayerIds to a string array

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1502,7 +1502,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			return {
 				shelfLayout:
 					selectedShelfLayout && RundownLayoutsAPI.isLayoutForShelf(selectedShelfLayout)
-						? selectedShelfLayout
+						? RundownView.mapSourceLayerIdsToStringArray(selectedShelfLayout)
 						: undefined,
 				rundownViewLayout:
 					selectedViewLayout && RundownLayoutsAPI.isLayoutForRundownView(selectedViewLayout)
@@ -1522,6 +1522,26 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				sourceLayerLookup: resultSourceLayerLookup,
 				miniShelfFilter,
 			}
+		}
+
+		/**
+		 * This is a hack/quickfix for fixing that sourceLayerIds are now stored as "{label: string, value: string}" instead of just "string".
+		 * To fix it properly we need to change RundownLayoutFilterBase.sourceLayerIds interface from string[] to support the new type, which is an extensive change.
+		 */
+		static mapSourceLayerIdsToStringArray(shelfLayout: RundownLayoutShelfBase): RundownLayoutShelfBase {
+			shelfLayout.filters = shelfLayout.filters.map((filter) => {
+				if (!('sourceLayerIds' in filter) || !filter['sourceLayerIds']) {
+					return filter
+				}
+				const filterWithSourceLayerIds = filter as RundownLayoutFilterBase
+				filterWithSourceLayerIds.sourceLayerIds = filterWithSourceLayerIds.sourceLayerIds?.map((sourceLayerId) => {
+					return typeof sourceLayerId === 'object' && 'value' in sourceLayerId
+						? (sourceLayerId as any).value
+						: sourceLayerId
+				})
+				return filterWithSourceLayerIds
+			})
+			return shelfLayout
 		}
 
 		componentDidMount() {


### PR DESCRIPTION
After SOF-1240 we changed the datatype of the data selected by a dropdown. This new datatype is currently not supported by the entire RundownLayout code in the frontend. 

This is a hack/quickfix mapping the new datatype into the old, so layouts still work.

To fix it properly would be to change the interfaces to use the new datatype, which unfortunately is an too extensive task with our current deadlines...