### PR TITLE
SOF-1423 Revert updateFunction back to not fetch .value

### DIFF
--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -974,7 +974,7 @@ export class ConfigManifestSettings<
 								<EditAttributeDropdown
 									modifiedClassName="bghl"
 									options={this.getAddOptions()}
-									updateFunction={(_e, v) => this.setState({ addItemId: (v as { value: string }).value })}
+									updateFunction={(_e, v) => this.setState({ addItemId: v })}
 									overrideDisplayValue={this.state.addItemId}
 								/>
 							</div>


### PR DESCRIPTION
After we are able to decide wether or not the EditAttributeDropdown component will save the data with a label or not, we need to revert this usage of the EditAttributeDropdown back since it does no longer receive `{ value: string, label: string }`