### PR TITLE
feat: SOF-1179 add endpoint for uploading shelf layouts by blueprint ID

### DIFF
--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -543,7 +543,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 								method: 'POST',
 								body: uploadFileContents,
 								headers: {
-									'content-type': 'text/javascript',
+									'content-type': 'application/json',
 								},
 							})
 								.then(() => {

--- a/meteor/lib/collections/optimizations.ts
+++ b/meteor/lib/collections/optimizations.ts
@@ -54,7 +54,7 @@ export async function checkStudioExists(studioId: StudioId): Promise<boolean> {
 }
 
 /**
- * Returns a "light" version of the Studio, where the most heavy/large properties are omitted.
+ * Returns a "light" version of the Show Style Base, where the most heavy/large properties are omitted.
  */
 export async function fetchShowStyleBaseLight(showStyleId: ShowStyleBaseId): Promise<ShowStyleBaseLight | undefined> {
 	return ShowStyleBases.findOneAsync(showStyleId, {

--- a/meteor/server/api/__tests__/rundownLayouts.test.ts
+++ b/meteor/server/api/__tests__/rundownLayouts.test.ts
@@ -259,7 +259,7 @@ describe('Rundown Layouts', () => {
 			let showStyleBlueprintId: BlueprintId
 			beforeAll(() => {
 				mockLayout = makeMockLayout(env).rundownLayout
-				const routeName = '/shelfLayouts/uploadByBlueprintId/:showStyleBlueprintId'
+				const routeName = '/shelfLayouts/uploadByShowStyleBlueprintId/:showStyleBlueprintId'
 				route = PickerMock.mockRoutes[routeName]
 				showStyleBlueprintId = env.showStyleBlueprint._id
 			})
@@ -276,7 +276,7 @@ describe('Rundown Layouts', () => {
 				const res = new MockResponse()
 				const req = new MockRequest({
 					method: 'POST',
-					url: `/shelfLayouts/uploadByBlueprintId/${fakeId}`,
+					url: `/shelfLayouts/uploadByShowStyleBlueprintId/${fakeId}`,
 				})
 				req.body = mockLayout
 
@@ -297,7 +297,7 @@ describe('Rundown Layouts', () => {
 				const res = new MockResponse()
 				const req = new MockRequest({
 					method: 'POST',
-					url: `/shelfLayouts/uploadByBlueprintId/${showStyleBlueprintId}`,
+					url: `/shelfLayouts/uploadByShowStyleBlueprintId/${showStyleBlueprintId}`,
 				})
 
 				await route.handler(
@@ -322,7 +322,7 @@ describe('Rundown Layouts', () => {
 				const res = new MockResponse()
 				const req = new MockRequest({
 					method: 'POST',
-					url: `/shelfLayouts/uploadByBlueprintId/${showStyleBlueprintId}`,
+					url: `/shelfLayouts/uploadByShowStyleBlueprintId/${showStyleBlueprintId}`,
 				})
 				req.body = '{ "type": "sometype" }'
 
@@ -348,7 +348,7 @@ describe('Rundown Layouts', () => {
 				const res = new MockResponse()
 				const req = new MockRequest({
 					method: 'POST',
-					url: `/shelfLayouts/uploadByBlueprintId/${showStyleBlueprintId}`,
+					url: `/shelfLayouts/uploadByShowStyleBlueprintId/${showStyleBlueprintId}`,
 				})
 				req.body = { type: 'sometype' }
 
@@ -374,7 +374,7 @@ describe('Rundown Layouts', () => {
 				const res = new MockResponse()
 				const req = new MockRequest({
 					method: 'POST',
-					url: `/shelfLayouts/uploadByBlueprintId/${showStyleBlueprintId}`,
+					url: `/shelfLayouts/uploadByShowStyleBlueprintId/${showStyleBlueprintId}`,
 				})
 				req.body = mockLayout
 

--- a/meteor/server/api/rundownLayouts.ts
+++ b/meteor/server/api/rundownLayouts.ts
@@ -67,8 +67,8 @@ PickerPOST.route('/shelfLayouts/upload/:showStyleBaseId', async (params, req: In
 	try {
 		if (!showStyleBase) throw new Meteor.Error(404, `Show Style Base "${showStyleBaseId}" not found`)
 
-		const body = validateAndGetRestoredLayoutBody(req)
-		await upsertLayout(body, showStyleBase)
+		const rundownLayoutBase = validateAndGetRestoredLayoutBody(req)
+		await upsertLayout(rundownLayoutBase, showStyleBase)
 
 		res.statusCode = 200
 	} catch (e) {
@@ -84,7 +84,7 @@ PickerPOST.route('/shelfLayouts/upload/:showStyleBaseId', async (params, req: In
  * Uploads the layout to the first Show Style Base that uses the given blueprint id
  */
 PickerPOST.route(
-	'/shelfLayouts/uploadByBlueprintId/:showStyleBlueprintId',
+	'/shelfLayouts/uploadByShowStyleBlueprintId/:showStyleBlueprintId',
 	async (params, req: IncomingMessage, res: ServerResponse) => {
 		res.setHeader('Content-Type', 'text/plain')
 
@@ -99,8 +99,8 @@ PickerPOST.route(
 			if (!showStyleBases.length)
 				throw new Meteor.Error(404, `Show Style Base not found for blueprint "${showStyleBlueprintId}"`)
 
-			const body = validateAndGetRestoredLayoutBody(req)
-			await upsertLayout(body, showStyleBases[0])
+			const rundownLayoutBase = validateAndGetRestoredLayoutBody(req)
+			await upsertLayout(rundownLayoutBase, showStyleBases[0])
 
 			res.statusCode = 200
 		} catch (e) {

--- a/meteor/server/api/rundownLayouts.ts
+++ b/meteor/server/api/rundownLayouts.ts
@@ -18,7 +18,11 @@ import { MethodContext, MethodContextAPI } from '../../lib/api/methods'
 import { UserId } from '../../lib/collections/Users'
 import { ShowStyleContentWriteAccess } from '../security/showStyle'
 import { PickerPOST, PickerGET } from './http'
-import { fetchShowStyleBaseLight } from '../../lib/collections/optimizations'
+import {
+	fetchShowStyleBaseLight,
+	fetchShowStyleBasesLight,
+	ShowStyleBaseLight,
+} from '../../lib/collections/optimizations'
 
 export async function createRundownLayout(
 	name: string,
@@ -61,22 +65,10 @@ PickerPOST.route('/shelfLayouts/upload/:showStyleBaseId', async (params, req: In
 
 	let content = ''
 	try {
-		if (!showStyleBase) throw new Meteor.Error(404, `ShowStylebase "${showStyleBaseId}" not found`)
+		if (!showStyleBase) throw new Meteor.Error(404, `Show Style Base "${showStyleBaseId}" not found`)
 
-		const body = req.body
-		if (!body) throw new Meteor.Error(400, 'Restore Shelf Layout: Missing request body')
-
-		if (typeof body !== 'string' || body.length < 10)
-			throw new Meteor.Error(400, 'Restore Shelf Layout: Invalid request body')
-
-		const layout = JSON.parse(body) as RundownLayoutBase
-		check(layout._id, Match.Optional(String))
-		check(layout.name, String)
-		check(layout.type, String)
-
-		layout.showStyleBaseId = showStyleBase._id
-
-		await RundownLayouts.upsertAsync(layout._id, layout)
+		const body = validateAndGetRestoredLayoutBody(req)
+		await upsertLayout(body, showStyleBase)
 
 		res.statusCode = 200
 	} catch (e) {
@@ -87,6 +79,39 @@ PickerPOST.route('/shelfLayouts/upload/:showStyleBaseId', async (params, req: In
 
 	res.end(content)
 })
+
+/**
+ * Uploads the layout to the first Show Style Base that uses the given blueprint id
+ */
+PickerPOST.route(
+	'/shelfLayouts/uploadByBlueprintId/:showStyleBlueprintId',
+	async (params, req: IncomingMessage, res: ServerResponse) => {
+		res.setHeader('Content-Type', 'text/plain')
+
+		const showStyleBlueprintId: BlueprintId = protectString(params.showStyleBlueprintId)
+
+		check(showStyleBlueprintId, String)
+
+		const showStyleBases = await fetchShowStyleBasesLight({ blueprintId: showStyleBlueprintId })
+
+		let content = ''
+		try {
+			if (!showStyleBases.length)
+				throw new Meteor.Error(404, `Show Style Base not found for blueprint "${showStyleBlueprintId}"`)
+
+			const body = validateAndGetRestoredLayoutBody(req)
+			await upsertLayout(body, showStyleBases[0])
+
+			res.statusCode = 200
+		} catch (e) {
+			res.statusCode = 500
+			content = e + ''
+			logger.error('Shelf Layout restore failed: ' + e)
+		}
+
+		res.end(content)
+	}
+)
 
 PickerGET.route('/shelfLayouts/download/:id', async (params, _req: IncomingMessage, res: ServerResponse) => {
 	const layoutId: RundownLayoutId = protectString(params.id)
@@ -115,6 +140,26 @@ PickerGET.route('/shelfLayouts/download/:id', async (params, _req: IncomingMessa
 
 	res.end(content)
 })
+
+function validateAndGetRestoredLayoutBody(req: IncomingMessage): RundownLayoutBase {
+	if (!req.body) throw new Meteor.Error(400, 'Restore Shelf Layout: Missing request body')
+
+	if (typeof req.body !== 'object') throw new Meteor.Error(400, 'Restore Shelf Layout: Invalid request body')
+
+	const layout: Partial<RundownLayoutBase> = req.body
+
+	check(layout._id, Match.Optional(String))
+	check(layout.name, String)
+	check(layout.type, String)
+
+	return layout as RundownLayoutBase
+}
+
+async function upsertLayout(layout: RundownLayoutBase, showStyleBase: ShowStyleBaseLight) {
+	layout.showStyleBaseId = showStyleBase._id
+
+	await RundownLayouts.upsertAsync(layout._id, layout)
+}
 
 /** Add RundownLayout into showStyleBase */
 async function apiCreateRundownLayout(


### PR DESCRIPTION
Makes it possible to upload shelf layouts for Show Styles associated with the given blueprint id so that we don't have to query Core for the id of the Show Style when automating this process. The first matching Show Style is chosen - a limitation due to the layouts having unique ids that wouldn't let the layout to be uploaded to more than one Show Style anyway (not a problem for us).
Also fixes use of an incorrect content type in the existing endpoint.
