### PR TITLE
fix: SOF-1424 prevent duplicated options in dropdowns

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -476,7 +476,7 @@ const DeprecatedEditAttributeDropdown = wrapEditAttribute(
 				if (!currentOption) {
 					// if currentOption not found, then add it to the list:
 					options.push({
-						name: 'Value: ' + currentValue,
+						name: 'N/A: ' + currentValue,
 						value: currentValue,
 					})
 				}
@@ -621,7 +621,7 @@ const DeprecatedEditAttributeDropdownText = wrapEditAttribute(
 				if (!currentOption) {
 					// if currentOption not found, then add it to the list:
 					options.push({
-						name: 'Value: ' + currentValue,
+						name: 'N/A: ' + currentValue,
 						value: currentValue,
 					})
 				}

--- a/meteor/client/lib/editAttribute/edit-attribute-base.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-base.tsx
@@ -30,7 +30,10 @@ interface IEditAttributeBaseState {
 	editing: boolean
 }
 
-export class EditAttributeBase extends React.Component<IEditAttributeBaseProps, IEditAttributeBaseState> {
+export class EditAttributeBase<Props extends IEditAttributeBaseProps = IEditAttributeBaseProps> extends React.Component<
+	Props,
+	IEditAttributeBaseState
+> {
 	constructor(props) {
 		super(props)
 
@@ -139,14 +142,14 @@ export class EditAttributeBase extends React.Component<IEditAttributeBaseProps, 
 		if (this.props.updateFunction && typeof this.props.updateFunction === 'function') {
 			this.props.updateFunction(this, newValue)
 		} else {
-			if (this.props.collection && this.props.attribute) {
+			if (this.props.collection && this.props.attribute && this.props.obj) {
 				if (newValue === undefined) {
 					const m = {}
-					m[this.props.attribute] = 1
+					m[this.props.attribute as string] = 1
 					this.props.collection.update(this.props.obj._id, { $unset: m })
 				} else {
 					const m = {}
-					m[this.props.attribute] = newValue
+					m[this.props.attribute as string] = newValue
 					this.props.collection.update(this.props.obj._id, { $set: m })
 				}
 			}

--- a/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
@@ -3,8 +3,7 @@ import ClassNames from 'classnames'
 import * as React from 'react'
 
 export interface DropdownOption {
-	value: string
-	alternativeValue?: string
+	value: string | number
 	label?: string
 }
 
@@ -69,17 +68,13 @@ const WrappedEditAttributeDropdown = wrapEditAttribute(
 		}
 
 		private findOptionInAvailableOptions(optionToCheck: DropdownOption): DropdownOption | undefined {
-			return this.getAvailableOptions().find(
-				(option) =>
-					option.value.toLowerCase() === optionToCheck.value.toLowerCase() ||
-					(option.alternativeValue && option.alternativeValue === optionToCheck.value.toLowerCase())
-			)
+			return this.getAvailableOptions().find((option) => option.value === optionToCheck.value)
 		}
 
 		private handleChange(event) {
 			const selectedOptionValue: string = event.target.value
 			const selectedOption: DropdownOption | undefined = this.getAvailableOptions().find(
-				(option) => option.value === selectedOptionValue || option.alternativeValue === selectedOptionValue
+				(option) => option.value.toString() === selectedOptionValue
 			)
 			if (!selectedOption) {
 				return
@@ -90,14 +85,14 @@ const WrappedEditAttributeDropdown = wrapEditAttribute(
 
 		private getCurrentlySelectedOption(): DropdownOption {
 			let attribute = this.getAttribute()
-			if (!!attribute && !attribute.value) {
-				attribute = { value: attribute + '' }
+			if (attribute !== undefined && attribute.value === undefined) {
+				attribute = { value: attribute }
 			}
 			return attribute
 		}
 
 		private getAvailableOptions(): DropdownOption[] {
-			return (this.props as EditAttributeDropdownProps).options
+			return this.props.options
 		}
 
 		private getMissingOptions(): DropdownOption[] {
@@ -106,34 +101,13 @@ const WrappedEditAttributeDropdown = wrapEditAttribute(
 				return []
 			}
 			const selectedIsAnAvailableOption = this.getAvailableOptions().some(
-				(option) =>
-					option.value.toLowerCase() === selectedOption.value.toLowerCase() ||
-					(option.alternativeValue && option.alternativeValue === selectedOption.value.toLowerCase())
+				(option) => option.value === selectedOption.value
 			)
 			return !selectedIsAnAvailableOption ? [selectedOption] : []
 		}
 
-		private getAvailableOptionsUsingAlternativeValueIfNecessary(): DropdownOption[] {
-			const currentlySelectedOption = this.getCurrentlySelectedOption()
-			const availableOptions = this.getAvailableOptions()
-
-			const matchOnValue = availableOptions.some((option) => option.value === currentlySelectedOption?.value)
-			const matchOnAlternativeValue = availableOptions.some(
-				(option) => option.alternativeValue === currentlySelectedOption?.value
-			)
-
-			if (matchOnValue || !matchOnAlternativeValue) {
-				return availableOptions
-			}
-
-			return availableOptions.map((option) => ({
-				value: option.alternativeValue ?? '',
-				label: option.label ?? option.value,
-			}))
-		}
-
 		render() {
-			const availableOptions = this.getAvailableOptionsUsingAlternativeValueIfNecessary()
+			const availableOptions = this.getAvailableOptions()
 			const missingOptions = this.getMissingOptions()
 			const currentlySelectedOption = this.getCurrentlySelectedOption()
 

--- a/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-dropdown.tsx
@@ -1,6 +1,7 @@
 import { EditAttributeBase, IEditAttributeBaseProps, wrapEditAttribute } from './edit-attribute-base'
 import ClassNames from 'classnames'
 import * as React from 'react'
+import { WithTranslation, withTranslation } from 'react-i18next'
 
 export interface DropdownOption {
 	value: string | number
@@ -10,126 +11,124 @@ export interface DropdownOption {
 interface EditAttributeDropdownProps extends IEditAttributeBaseProps {
 	options: DropdownOption[]
 	shouldSaveLabel?: boolean
+	allowNoSelection?: boolean
 }
 
 export function EditAttributeDropdown(props: EditAttributeDropdownProps) {
 	return <WrappedEditAttributeDropdown {...props} />
 }
 
-const WrappedEditAttributeDropdown = wrapEditAttribute(
-	class EditAttributeDropdown extends EditAttributeBase {
-		constructor(props) {
-			super(props)
+const WrappedEditAttributeDropdown = withTranslation()(
+	wrapEditAttribute(
+		class EditAttributeDropdown extends EditAttributeBase<EditAttributeDropdownProps & WithTranslation> {
+			constructor(props: EditAttributeDropdownProps) {
+				super(props)
 
-			this.handleChange = this.handleChange.bind(this)
-		}
-
-		componentDidMount() {
-			this.populateFromFirstAvailableOptionIfNoValueIsSelected()
-			this.updateSelectedOptionIfLabelIsChanged()
-		}
-
-		private populateFromFirstAvailableOptionIfNoValueIsSelected() {
-			const currentlySelectedOption = this.getCurrentlySelectedOption()
-			const availableOptions = this.getAvailableOptions()
-			if (!!currentlySelectedOption || availableOptions.length === 0) {
-				return
-			}
-			this.handleChange({ target: { value: availableOptions[0].value } })
-		}
-
-		componentDidUpdate(prevProps: Readonly<IEditAttributeBaseProps>) {
-			if (prevProps === this.props) {
-				return
-			}
-			this.updateSelectedOptionIfLabelIsChanged()
-		}
-
-		private updateSelectedOptionIfLabelIsChanged(): void {
-			const props = this.props as EditAttributeDropdownProps
-			if (!props.shouldSaveLabel) {
-				return
+				this.handleChange = this.handleChange.bind(this)
 			}
 
-			const selectedOptionFromDatabase = this.getCurrentlySelectedOption()
-			if (!selectedOptionFromDatabase || !('label' in selectedOptionFromDatabase)) {
-				return
+			componentDidMount() {
+				this.updateSelectedOptionIfLabelIsChanged()
 			}
-			const selectedOptionFromAvailableOptions = this.findOptionInAvailableOptions(selectedOptionFromDatabase)
-			if (!selectedOptionFromAvailableOptions) {
-				return
+
+			componentDidUpdate(prevProps: Readonly<IEditAttributeBaseProps>) {
+				if (prevProps === this.props) {
+					return
+				}
+				this.updateSelectedOptionIfLabelIsChanged()
 			}
-			const selectedOptionHasChangedLabel =
-				selectedOptionFromDatabase.label !== selectedOptionFromAvailableOptions.label
-			if (!selectedOptionHasChangedLabel) {
-				return
+
+			private updateSelectedOptionIfLabelIsChanged(): void {
+				const props = this.props as EditAttributeDropdownProps
+				if (!props.shouldSaveLabel) {
+					return
+				}
+
+				const selectedOptionFromDatabase = this.getCurrentlySelectedOption()
+				if (!selectedOptionFromDatabase || !('label' in selectedOptionFromDatabase)) {
+					return
+				}
+				const selectedOptionFromAvailableOptions = this.findOptionInAvailableOptions(selectedOptionFromDatabase)
+				if (!selectedOptionFromAvailableOptions) {
+					return
+				}
+				const selectedOptionHasChangedLabel =
+					selectedOptionFromDatabase.label !== selectedOptionFromAvailableOptions.label
+				if (!selectedOptionHasChangedLabel) {
+					return
+				}
+				this.handleUpdate(selectedOptionFromAvailableOptions)
 			}
-			this.handleUpdate(selectedOptionFromAvailableOptions)
-		}
 
-		private findOptionInAvailableOptions(optionToCheck: DropdownOption): DropdownOption | undefined {
-			return this.getAvailableOptions().find((option) => option.value === optionToCheck.value)
-		}
-
-		private handleChange(event) {
-			const selectedOptionValue: string = event.target.value
-			const selectedOption: DropdownOption | undefined = this.getAvailableOptions().find(
-				(option) => option.value.toString() === selectedOptionValue
-			)
-			if (!selectedOption) {
-				return
+			private findOptionInAvailableOptions(optionToCheck: DropdownOption): DropdownOption | undefined {
+				return this.getAvailableOptions().find((option) => option.value === optionToCheck.value)
 			}
-			const props = this.props as EditAttributeDropdownProps
-			this.handleUpdate(props.shouldSaveLabel ? selectedOption : selectedOption.value)
-		}
 
-		private getCurrentlySelectedOption(): DropdownOption {
-			let attribute = this.getAttribute()
-			if (attribute !== undefined && attribute.value === undefined) {
-				attribute = { value: attribute }
+			private handleChange(event) {
+				const selectedOptionValue: string = event.target.value
+				const selectedOption: DropdownOption | undefined = this.getAvailableOptions().find(
+					(option) => option.value.toString() === selectedOptionValue
+				)
+				if (!selectedOption) {
+					return
+				}
+				const props = this.props as EditAttributeDropdownProps
+				this.handleUpdate(props.shouldSaveLabel ? selectedOption : selectedOption.value)
 			}
-			return attribute
-		}
 
-		private getAvailableOptions(): DropdownOption[] {
-			return this.props.options
-		}
-
-		private getMissingOptions(): DropdownOption[] {
-			const selectedOption: DropdownOption = this.getCurrentlySelectedOption()
-			if (!selectedOption) {
-				return []
+			private getCurrentlySelectedOption(): DropdownOption {
+				let attribute = this.getAttribute()
+				if (attribute !== undefined && attribute.value === undefined) {
+					attribute = { value: attribute }
+				}
+				return attribute
 			}
-			const selectedIsAnAvailableOption = this.getAvailableOptions().some(
-				(option) => option.value === selectedOption.value
-			)
-			return !selectedIsAnAvailableOption ? [selectedOption] : []
-		}
 
-		render() {
-			const availableOptions = this.getAvailableOptions()
-			const missingOptions = this.getMissingOptions()
-			const currentlySelectedOption = this.getCurrentlySelectedOption()
+			private getAvailableOptions(): DropdownOption[] {
+				const { t } = this.props
+				return this.props.allowNoSelection
+					? [{ value: '', label: t('None') }, ...this.props.options]
+					: this.props.options
+			}
 
-			return (
-				<select
-					className={ClassNames(
-						'form-control',
-						this.props.className,
-						this.state.editing && this.props.modifiedClassName,
-						missingOptions.length > 0 && 'option-missing'
-					)}
-					value={currentlySelectedOption?.value}
-					onChange={this.handleChange}
-					disabled={this.props.disabled}
-				>
-					{availableOptions.concat(missingOptions).map((option) => (
-						<option key={option.value} value={option.value}>
-							{option.label ?? option.value}
-						</option>
-					))}
-				</select>
-			)
+			private getMissingOptions(): DropdownOption[] {
+				const selectedOption: DropdownOption = this.getCurrentlySelectedOption()
+				if (!selectedOption) {
+					return []
+				}
+				const selectedIsAnAvailableOption = this.getAvailableOptions().some(
+					(option) => option.value === selectedOption.value
+				)
+				return !selectedIsAnAvailableOption
+					? [{ value: selectedOption.value, label: `N/A: ${selectedOption.label ?? selectedOption.value}` }]
+					: []
+			}
+
+			render() {
+				const availableOptions = this.getAvailableOptions()
+				const missingOptions = this.getMissingOptions()
+				const currentlySelectedOption = this.getCurrentlySelectedOption()
+
+				return (
+					<select
+						className={ClassNames(
+							'form-control',
+							this.props.className,
+							this.state.editing && this.props.modifiedClassName,
+							missingOptions.length > 0 && 'option-missing'
+						)}
+						value={currentlySelectedOption?.value}
+						onChange={this.handleChange}
+						disabled={this.props.disabled}
+					>
+						{availableOptions.concat(missingOptions).map((option) => (
+							<option key={option.value} value={option.value}>
+								{option.label ?? option.value}
+							</option>
+						))}
+					</select>
+				)
+			}
 		}
-	}
+	)
 )

--- a/meteor/client/lib/editAttribute/edit-attribute-enum-dropdown.tsx
+++ b/meteor/client/lib/editAttribute/edit-attribute-enum-dropdown.tsx
@@ -2,9 +2,10 @@ import { DropdownOption, EditAttributeDropdown } from './edit-attribute-dropdown
 import { IEditAttributeBaseProps } from './edit-attribute-base'
 import * as React from 'react'
 import { useMemo } from 'react'
+import { EnumLike } from '@sofie-automation/corelib/dist/deviceConfig'
 
 interface EditAttributeEnumDropdownProps extends IEditAttributeBaseProps {
-	options: object
+	options: EnumLike
 }
 
 export function EditAttributeEnumDropdown(props: EditAttributeEnumDropdownProps) {
@@ -12,16 +13,8 @@ export function EditAttributeEnumDropdown(props: EditAttributeEnumDropdownProps)
 	return <EditAttributeDropdown {...props} options={options} />
 }
 
-function mapToDropdownOptions(options: object): DropdownOption[] {
-	if (isStringArray(options)) {
-		return options.map((option) => ({ value: option, alternativeValue: option }))
-	}
-
+function mapToDropdownOptions(options: EnumLike): DropdownOption[] {
 	return Object.entries(options)
-		.filter(([enumName, _value]) => Number.isNaN(Number(enumName)))
-		.map(([enumName, value]) => ({ value: enumName, alternativeValue: value + '' }))
-}
-
-function isStringArray(value: object): value is string[] {
-	return Array.isArray(value) && value.every((v) => typeof v === 'string')
+		.filter(([enumName]) => Number.isNaN(Number(enumName)))
+		.map(([enumName, value]) => ({ label: enumName, value }))
 }

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -96,8 +96,10 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
 	attribute: string,
 	layerMappings?: { [key: string]: MappingsExt },
 	sourceLayers?: Array<{ name: string; value: string; type: SourceLayerType }>,
-	alternateObject?: any
+	alternateObject?: any,
+	allowEmptyDropdown?: boolean
 ) {
+	const allowNoSelection = !item.required && allowEmptyDropdown
 	switch (item.type) {
 		case ConfigManifestEntryType.STRING:
 			return (
@@ -188,21 +190,21 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
 			if (item.multiple) {
 				return renderMultiSelect(attribute, object, selectOptions, collection)
 			}
-			return renderDropdown(attribute, object, selectOptions, collection)
+			return renderDropdown(attribute, object, selectOptions, collection, undefined, allowNoSelection)
 		}
 		case ConfigManifestEntryType.SOURCE_LAYERS: {
 			const filterSourceLayerOptions = 'options' in item ? item.options : filterSourceLayers(item, sourceLayers ?? [])
 			if (item.multiple) {
 				return renderMultiSelect(attribute, object, filterSourceLayerOptions, collection)
 			}
-			return renderDropdown(attribute, object, filterSourceLayerOptions, collection)
+			return renderDropdown(attribute, object, filterSourceLayerOptions, collection, undefined, allowNoSelection)
 		}
 		case ConfigManifestEntryType.LAYER_MAPPINGS: {
 			const layerMappingOptions = 'options' in item ? item.options : filterLayerMappings(item, layerMappings ?? {})
 			if (item.multiple) {
 				return renderMultiSelect(attribute, object, layerMappingOptions, collection)
 			}
-			return renderDropdown(attribute, object, layerMappingOptions, collection)
+			return renderDropdown(attribute, object, layerMappingOptions, collection, undefined, allowNoSelection)
 		}
 		case ConfigManifestEntryType.SELECT_FROM_COLUMN: {
 			const selectFromOptions =
@@ -212,7 +214,7 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
 			if (item.multiple) {
 				return renderMultiSelect(attribute, object, selectFromOptions, collection, true)
 			}
-			return renderDropdown(attribute, object, selectFromOptions, collection, true)
+			return renderDropdown(attribute, object, selectFromOptions, collection, true, allowNoSelection)
 		}
 		case ConfigManifestEntryType.SELECT_FROM_TABLE_ENTRY_WITH_COMPARISON_MAPPINGS: {
 			const selectWithComparisonOptions =
@@ -228,7 +230,7 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
 			if (item.multiple) {
 				return renderMultiSelect(attribute, object, selectWithComparisonOptions, collection, true)
 			}
-			return renderDropdown(attribute, object, selectWithComparisonOptions, collection, true)
+			return renderDropdown(attribute, object, selectWithComparisonOptions, collection, true, allowNoSelection)
 		}
 		default:
 			return null
@@ -260,7 +262,8 @@ function renderDropdown(
 	obj: any,
 	options: DropdownOption[],
 	collection: MongoCollection<any>,
-	shouldSaveLabel: boolean = false
+	shouldSaveLabel: boolean = false,
+	allowNoSelection: boolean = false
 ) {
 	return (
 		<EditAttributeDropdown
@@ -271,6 +274,7 @@ function renderDropdown(
 			collection={collection}
 			className="input text-input dropdown input-l"
 			shouldSaveLabel={shouldSaveLabel}
+			allowNoSelection={allowNoSelection}
 		/>
 	)
 }
@@ -601,7 +605,8 @@ export class ConfigManifestTable<
 												`${baseAttribute}.${sortedIndices[i]}.${col.id}`,
 												undefined,
 												undefined,
-												this.props.alternateObject
+												this.props.alternateObject,
+												true
 											)}
 										</td>
 									))}

--- a/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
+++ b/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
@@ -43,7 +43,7 @@ export const renderEditAttribute = (
 		return (
 			<EditAttributeEnumDropdown
 				{...opts}
-				options={(configField as ConfigManifestEntry).values || []}
+				options={configField.values}
 				className="input text-input input-l"
 			></EditAttributeEnumDropdown>
 		)

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -665,7 +665,7 @@ const MAPPING_MANIFEST: ImplementedMappingsManifest = {
 		{
 			id: 'mappingType',
 			type: ConfigManifestEntryType.ENUM,
-			values: Object.values(MappingTriCasterType),
+			values: MappingTriCasterType,
 			name: 'Mapping Type',
 			includeInSummary: true,
 		},

--- a/packages/shared-lib/src/core/deviceConfigManifest.ts
+++ b/packages/shared-lib/src/core/deviceConfigManifest.ts
@@ -52,6 +52,11 @@ export enum ConfigManifestEntryType {
 	ENUM = 'enum',
 }
 
+/**
+ * An enum-like type
+ */
+export type EnumLike = Record<string, string | number>
+
 export type ConfigManifestEntry =
 	// | ConfigManifestEntryBase
 	| ConfigManifestEnumEntry
@@ -71,7 +76,7 @@ export interface ConfigManifestEntryBase {
 	name: string
 	type: ConfigManifestEntryType
 	/** Used in enums */
-	values?: any
+	values?: EnumLike
 	/** Short label to display when value is undefined (default value) */
 	placeholder?: string
 	/** Longer description */
@@ -80,8 +85,8 @@ export interface ConfigManifestEntryBase {
 }
 export interface ConfigManifestEnumEntry extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.ENUM
-	values: any // for enum
-	defaultVal?: any
+	values: EnumLike
+	defaultVal?: string | number
 }
 
 export interface ConfigManifestBooleanEntry extends ConfigManifestEntryBase {
@@ -113,7 +118,7 @@ export interface ConfigManifestFloatEntry extends ConfigManifestEntryBase {
 }
 export interface ConfigManifestEnumEntry extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.ENUM
-	values: any // for enum
+	values: EnumLike
 }
 
 export interface TableConfigManifestEntry extends ConfigManifestEntryBase {


### PR DESCRIPTION
Fixes a bug that caused some dropdowns to show duplicated values when the selected value was missing among the available options, also includes the following improvements:

- does no longer autoselect the first option in a dropdown when mounted;
- it now says 'N/A: <label or value>' when the selected value is missing in the available options;
- it now allows not-required dropdowns to have no value;