### PR TITLE
feat: SOF-1213 string interpolation in Shelf layouts

### DIFF
--- a/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react'
-import {
-	DashboardLayout,
-	DashboardLayoutFilter,
-	RundownLayoutElementAny,
-	RundownLayoutElementBase,
-	RundownLayoutElementType,
-} from '../../../lib/collections/RundownLayouts'
+import { DashboardLayout, DashboardLayoutFilter } from '../../../lib/collections/RundownLayouts'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { TimelineDashboardPanel } from './TimelineDashboardPanel'
 import { DashboardPanel, IDashboardPanelProps } from './DashboardPanel'
@@ -40,7 +34,7 @@ import { ColoredBoxPanel } from './ColoredBoxPanel'
 import { Settings } from '../../../lib/Settings'
 import { KeyboardPreviewPanel } from './Keyboard/KeyboardPreviewPanel'
 import { IAdLibPanelProps } from './AdLibPanel'
-import { double as phrase } from 'paraphrase'
+import { InterpolatedPropsSource, interpolatePanelStrings } from './utils/interpolatePanelStrings'
 
 export interface IShelfDashboardLayoutProps {
 	rundownLayout: DashboardLayout
@@ -258,39 +252,4 @@ export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
 			)}
 		</div>
 	)
-}
-
-export interface InterpolatedPropsSource {
-	studio: Studio
-	showStyleBase: ShowStyleBase
-}
-
-const RUNDOWN_LAYOUT_ELEMENT_INTERPOLABLE_PROPS: {
-	[key in RundownLayoutElementType]?: (keyof Extract<RundownLayoutElementAny, { type: key }>)[]
-} = {
-	[RundownLayoutElementType.FILTER]: ['name'],
-	[RundownLayoutElementType.TEXT_LABEL]: ['name', 'text'],
-	[RundownLayoutElementType.EXTERNAL_FRAME]: ['name', 'url'],
-	[RundownLayoutElementType.NEXT_INFO]: ['name'],
-}
-
-export function interpolatePanelStrings<T extends RundownLayoutElementBase>(
-	panel: T,
-	source: InterpolatedPropsSource
-): T {
-	const interpolableProps = RUNDOWN_LAYOUT_ELEMENT_INTERPOLABLE_PROPS[panel.type ?? RundownLayoutElementType.FILTER]
-	if (!interpolableProps) {
-		return panel
-	}
-
-	const interpolatedPanel: Partial<T> = {}
-	for (const prop of interpolableProps) {
-		if (typeof panel[prop] === 'string') {
-			interpolatedPanel[prop] = phrase(panel[prop], source)
-		}
-	}
-	return {
-		...panel,
-		...interpolatedPanel,
-	}
 }

--- a/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
@@ -278,9 +278,6 @@ export function interpolatePanelStrings<T extends RundownLayoutElementBase>(
 	panel: T,
 	source: InterpolatedPropsSource
 ): T {
-	if (!Settings.interpolateStringsInLayouts) {
-		return panel
-	}
 	const interpolableProps = RUNDOWN_LAYOUT_ELEMENT_INTERPOLABLE_PROPS[panel.type ?? RundownLayoutElementType.FILTER]
 	if (!interpolableProps) {
 		return panel

--- a/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react'
-import { DashboardLayout, DashboardLayoutFilter } from '../../../lib/collections/RundownLayouts'
+import {
+	DashboardLayout,
+	DashboardLayoutFilter,
+	RundownLayoutElementAny,
+	RundownLayoutElementBase,
+	RundownLayoutElementType,
+} from '../../../lib/collections/RundownLayouts'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { TimelineDashboardPanel } from './TimelineDashboardPanel'
-import { DashboardPanel } from './DashboardPanel'
+import { DashboardPanel, IDashboardPanelProps } from './DashboardPanel'
 import { ExternalFramePanel } from './ExternalFramePanel'
 import { DashboardActionButtonGroup } from './DashboardActionButtonGroup'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
@@ -33,6 +39,8 @@ import { PartNamePanel } from './PartNamePanel'
 import { ColoredBoxPanel } from './ColoredBoxPanel'
 import { Settings } from '../../../lib/Settings'
 import { KeyboardPreviewPanel } from './Keyboard/KeyboardPreviewPanel'
+import { IAdLibPanelProps } from './AdLibPanel'
+import { double as phrase } from 'paraphrase'
 
 export interface IShelfDashboardLayoutProps {
 	rundownLayout: DashboardLayout
@@ -51,209 +59,195 @@ export interface IShelfDashboardLayoutProps {
 
 export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
 	const { rundownLayout } = props
+	const interpolableSource: InterpolatedPropsSource = {
+		studio: props.studio,
+		showStyleBase: props.showStyleBase,
+	}
+
 	return (
 		<div className="dashboard">
-			{rundownLayout.filters &&
-				rundownLayout.filters
-					.sort((a, b) => a.rank - b.rank)
-					.map((panel) => {
-						if (RundownLayoutsAPI.isFilter(panel)) {
-							return (panel as DashboardLayoutFilter).showAsTimeline ? (
-								<TimelineDashboardPanel
-									key={panel._id}
-									includeGlobalAdLibs={true}
-									filter={panel}
-									visible={!(panel as DashboardLayoutFilter).hide}
-									playlist={props.playlist}
-									showStyleBase={props.showStyleBase}
-									studioMode={props.studioMode}
-									shouldQueue={props.shouldQueue}
-									studio={props.studio}
-									selectedPiece={props.selectedPiece}
-									onSelectPiece={props.onSelectPiece}
-								/>
-							) : (
-								<DashboardPanel
-									key={panel._id}
-									includeGlobalAdLibs={true}
-									filter={panel}
-									visible={!(panel as DashboardLayoutFilter).hide}
-									playlist={props.playlist}
-									showStyleBase={props.showStyleBase}
-									studioMode={props.studioMode}
-									shouldQueue={props.shouldQueue}
-									studio={props.studio}
-									selectedPiece={props.selectedPiece}
-									onSelectPiece={props.onSelectPiece}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isExternalFrame(panel)) {
-							return (
-								<ExternalFramePanel
-									key={panel._id}
-									panel={panel}
-									layout={rundownLayout}
-									visible={true}
-									playlist={props.playlist}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isAdLibRegion(panel)) {
-							return (
-								<AdLibRegionPanel
-									key={panel._id}
-									includeGlobalAdLibs={true}
-									filter={RundownLayoutsAPI.adLibRegionToFilter(panel)}
-									panel={panel}
-									adlibRank={panel.adlibRank}
-									layout={rundownLayout}
-									visible={true}
-									playlist={props.playlist}
-									showStyleBase={props.showStyleBase}
-									studioMode={props.studioMode}
-									selectedPiece={props.selectedPiece}
-									onSelectPiece={props.onSelectPiece}
-									studio={props.studio}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isPieceCountdown(panel)) {
-							return (
-								<PieceCountdownPanel
-									key={panel._id}
-									panel={panel}
-									layout={rundownLayout}
-									playlist={props.playlist}
-									showStyleBase={props.showStyleBase}
-									visible={true}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isNextInfo(panel)) {
-							return (
-								<NextInfoPanel
-									key={panel._id}
-									panel={panel}
-									layout={rundownLayout}
-									playlist={props.playlist}
-									visible={true}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isPlaylistStartTimer(panel)) {
-							return (
-								<PlaylistStartTimerPanel
-									key={panel._id}
-									playlist={props.playlist}
-									layout={rundownLayout}
-									panel={panel}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isPlaylistEndTimer(panel)) {
-							return (
-								<PlaylistEndTimerPanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
-							)
-						} else if (RundownLayoutsAPI.isEndWords(panel)) {
-							return (
-								<EndWordsPanel
-									key={panel._id}
-									playlist={props.playlist}
-									layout={rundownLayout}
-									panel={panel}
-									showStyleBase={props.showStyleBase}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isSegmentTiming(panel)) {
-							return (
-								<SegmentTimingPanel
-									key={panel._id}
-									playlist={props.playlist}
-									layout={rundownLayout}
-									panel={panel}
-									showStyleBase={props.showStyleBase}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isPartTiming(panel)) {
-							return (
-								<PartTimingPanel
-									key={panel._id}
-									playlist={props.playlist}
-									layout={rundownLayout}
-									panel={panel}
-									showStyleBase={props.showStyleBase}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isTextLabel(panel)) {
-							return <TextLabelPanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
-						} else if (RundownLayoutsAPI.isPlaylistName(panel)) {
-							return (
-								<PlaylistNamePanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
-							)
-						} else if (RundownLayoutsAPI.isStudioName(panel)) {
-							return (
-								<StudioNamePanel
-									key={panel._id}
-									studio={props.studio}
-									playlist={props.playlist}
-									layout={rundownLayout}
-									panel={panel}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isSegmentName(panel)) {
-							return <SegmentNamePanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
-						} else if (RundownLayoutsAPI.isPartName(panel)) {
-							return (
-								<PartNamePanel
-									key={panel._id}
-									playlist={props.playlist}
-									layout={rundownLayout}
-									panel={panel}
-									showStyleBase={props.showStyleBase}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isTimeOfDay(panel)) {
-							return <TimeOfDayPanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
-						} else if (RundownLayoutsAPI.isSystemStatus(panel)) {
-							return (
-								<SystemStatusPanel
-									key={panel._id}
-									playlist={props.playlist}
-									layout={rundownLayout}
-									panel={panel}
-									studio={props.studio}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isShowStyleDisplay(panel)) {
-							return (
-								<ShowStylePanel
-									key={panel._id}
-									playlist={props.playlist}
-									layout={rundownLayout}
-									panel={panel}
-									showStyleBase={props.showStyleBase}
-									showStyleVariant={props.showStyleVariant}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isColoredBox(panel)) {
-							return <ColoredBoxPanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
-						} else if (Settings.enableKeyboardPreview && RundownLayoutsAPI.isKeyboardMap(panel)) {
-							return (
-								<KeyboardPreviewPanel
-									key={panel._id}
-									visible={true}
-									showStyleBase={props.showStyleBase}
-									layout={rundownLayout}
-									panel={panel}
-								/>
-							)
-						} else if (RundownLayoutsAPI.isMiniRundown(panel)) {
-							return (
-								<MiniRundownPanel
-									key={panel._id}
-									panel={panel}
-									layout={rundownLayout}
-									playlist={props.playlist}
-									visible={true}
-								/>
-							)
+			{rundownLayout.filters
+				?.sort((a, b) => a.rank - b.rank)
+				.map((panel) => interpolatePanelStrings(panel, interpolableSource))
+				.map((panel) => {
+					if (RundownLayoutsAPI.isFilter(panel)) {
+						const commonProps: IAdLibPanelProps & IDashboardPanelProps = {
+							includeGlobalAdLibs: true,
+							filter: panel,
+							visible: !(panel as DashboardLayoutFilter).hide,
+							playlist: props.playlist,
+							showStyleBase: props.showStyleBase,
+							studioMode: props.studioMode,
+							shouldQueue: props.shouldQueue,
+							studio: props.studio,
+							selectedPiece: props.selectedPiece,
+							onSelectPiece: props.onSelectPiece,
 						}
-					})}
+						return (panel as DashboardLayoutFilter).showAsTimeline ? (
+							<TimelineDashboardPanel key={panel._id} {...commonProps} />
+						) : (
+							<DashboardPanel key={panel._id} {...commonProps} />
+						)
+					} else if (RundownLayoutsAPI.isExternalFrame(panel)) {
+						return (
+							<ExternalFramePanel
+								key={panel._id}
+								panel={panel}
+								layout={rundownLayout}
+								visible={true}
+								playlist={props.playlist}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isAdLibRegion(panel)) {
+						return (
+							<AdLibRegionPanel
+								key={panel._id}
+								includeGlobalAdLibs={true}
+								filter={RundownLayoutsAPI.adLibRegionToFilter(panel)}
+								panel={panel}
+								adlibRank={panel.adlibRank}
+								layout={rundownLayout}
+								visible={true}
+								playlist={props.playlist}
+								showStyleBase={props.showStyleBase}
+								studioMode={props.studioMode}
+								selectedPiece={props.selectedPiece}
+								onSelectPiece={props.onSelectPiece}
+								studio={props.studio}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isPieceCountdown(panel)) {
+						return (
+							<PieceCountdownPanel
+								key={panel._id}
+								panel={panel}
+								layout={rundownLayout}
+								playlist={props.playlist}
+								showStyleBase={props.showStyleBase}
+								visible={true}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isNextInfo(panel)) {
+						return (
+							<NextInfoPanel
+								key={panel._id}
+								panel={panel}
+								layout={rundownLayout}
+								playlist={props.playlist}
+								visible={true}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isPlaylistStartTimer(panel)) {
+						return (
+							<PlaylistStartTimerPanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
+						)
+					} else if (RundownLayoutsAPI.isPlaylistEndTimer(panel)) {
+						return (
+							<PlaylistEndTimerPanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
+						)
+					} else if (RundownLayoutsAPI.isEndWords(panel)) {
+						return (
+							<EndWordsPanel
+								key={panel._id}
+								playlist={props.playlist}
+								layout={rundownLayout}
+								panel={panel}
+								showStyleBase={props.showStyleBase}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isSegmentTiming(panel)) {
+						return (
+							<SegmentTimingPanel
+								key={panel._id}
+								playlist={props.playlist}
+								layout={rundownLayout}
+								panel={panel}
+								showStyleBase={props.showStyleBase}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isPartTiming(panel)) {
+						return (
+							<PartTimingPanel
+								key={panel._id}
+								playlist={props.playlist}
+								layout={rundownLayout}
+								panel={panel}
+								showStyleBase={props.showStyleBase}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isTextLabel(panel)) {
+						return <TextLabelPanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
+					} else if (RundownLayoutsAPI.isPlaylistName(panel)) {
+						return <PlaylistNamePanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
+					} else if (RundownLayoutsAPI.isStudioName(panel)) {
+						return (
+							<StudioNamePanel
+								key={panel._id}
+								studio={props.studio}
+								playlist={props.playlist}
+								layout={rundownLayout}
+								panel={panel}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isSegmentName(panel)) {
+						return <SegmentNamePanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
+					} else if (RundownLayoutsAPI.isPartName(panel)) {
+						return (
+							<PartNamePanel
+								key={panel._id}
+								playlist={props.playlist}
+								layout={rundownLayout}
+								panel={panel}
+								showStyleBase={props.showStyleBase}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isTimeOfDay(panel)) {
+						return <TimeOfDayPanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
+					} else if (RundownLayoutsAPI.isSystemStatus(panel)) {
+						return (
+							<SystemStatusPanel
+								key={panel._id}
+								playlist={props.playlist}
+								layout={rundownLayout}
+								panel={panel}
+								studio={props.studio}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isShowStyleDisplay(panel)) {
+						return (
+							<ShowStylePanel
+								key={panel._id}
+								playlist={props.playlist}
+								layout={rundownLayout}
+								panel={panel}
+								showStyleBase={props.showStyleBase}
+								showStyleVariant={props.showStyleVariant}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isColoredBox(panel)) {
+						return <ColoredBoxPanel key={panel._id} playlist={props.playlist} layout={rundownLayout} panel={panel} />
+					} else if (Settings.enableKeyboardPreview && RundownLayoutsAPI.isKeyboardMap(panel)) {
+						return (
+							<KeyboardPreviewPanel
+								key={panel._id}
+								visible={true}
+								showStyleBase={props.showStyleBase}
+								layout={rundownLayout}
+								panel={panel}
+							/>
+						)
+					} else if (RundownLayoutsAPI.isMiniRundown(panel)) {
+						return (
+							<MiniRundownPanel
+								key={panel._id}
+								panel={panel}
+								layout={rundownLayout}
+								playlist={props.playlist}
+								visible={true}
+							/>
+						)
+					}
+				})}
 			{rundownLayout.actionButtons && (
 				<DashboardActionButtonGroup
 					playlist={props.playlist}
@@ -264,4 +258,42 @@ export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
 			)}
 		</div>
 	)
+}
+
+export interface InterpolatedPropsSource {
+	studio: Studio
+	showStyleBase: ShowStyleBase
+}
+
+const RUNDOWN_LAYOUT_ELEMENT_INTERPOLABLE_PROPS: {
+	[key in RundownLayoutElementType]?: (keyof Extract<RundownLayoutElementAny, { type: key }>)[]
+} = {
+	[RundownLayoutElementType.FILTER]: ['name'],
+	[RundownLayoutElementType.TEXT_LABEL]: ['name', 'text'],
+	[RundownLayoutElementType.EXTERNAL_FRAME]: ['name', 'url'],
+	[RundownLayoutElementType.NEXT_INFO]: ['name'],
+}
+
+export function interpolatePanelStrings<T extends RundownLayoutElementBase>(
+	panel: T,
+	source: InterpolatedPropsSource
+): T {
+	if (!Settings.interpolateStringsInLayouts) {
+		return panel
+	}
+	const interpolableProps = RUNDOWN_LAYOUT_ELEMENT_INTERPOLABLE_PROPS[panel.type ?? RundownLayoutElementType.FILTER]
+	if (!interpolableProps) {
+		return panel
+	}
+
+	const interpolatedPanel: Partial<T> = {}
+	for (const prop of interpolableProps) {
+		if (typeof panel[prop] === 'string') {
+			interpolatedPanel[prop] = phrase(panel[prop], source)
+		}
+	}
+	return {
+		...panel,
+		...interpolatedPanel,
+	}
 }

--- a/meteor/client/ui/Shelf/ShelfRundownLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfRundownLayout.tsx
@@ -16,6 +16,7 @@ import { PieceUi } from '../SegmentTimeline/SegmentTimelineContainer'
 import { useTranslation } from 'react-i18next'
 import { BucketAdLibItem } from './RundownViewBuckets'
 import { IAdLibListItem } from './AdLibListItem'
+import { InterpolatedPropsSource, interpolatePanelStrings } from './ShelfDashboardLayout'
 
 export interface IShelfRundownLayoutProps {
 	rundownLayout: RundownLayout | undefined
@@ -118,30 +119,7 @@ export function ShelfRundownLayout(props: IShelfRundownLayoutProps) {
 						></GlobalAdLibPanel>
 					</>
 				) : (
-					rundownLayout.filters.map((panel) =>
-						RundownLayoutsAPI.isFilter(panel) ? (
-							<AdLibPanel
-								key={panel._id}
-								visible={(props.selectedTab || SHELF_DEFAULT_TAB) === `${ShelfTabs.ADLIB_LAYOUT_FILTER}_${panel._id}`}
-								includeGlobalAdLibs={true}
-								filter={panel}
-								selectedPiece={props.selectedPiece}
-								onSelectPiece={props.onSelectPiece}
-								playlist={props.playlist}
-								showStyleBase={props.showStyleBase}
-								studioMode={props.studioMode}
-								studio={props.studio}
-							/>
-						) : RundownLayoutsAPI.isExternalFrame(panel) ? (
-							<ExternalFramePanel
-								key={panel._id}
-								panel={panel}
-								layout={rundownLayout}
-								visible={(props.selectedTab || SHELF_DEFAULT_TAB) === `${ShelfTabs.ADLIB_LAYOUT_FILTER}_${panel._id}`}
-								playlist={props.playlist}
-							/>
-						) : undefined
-					)
+					renderLayout(rundownLayout, props)
 				)}
 				<HotkeyHelpPanel
 					visible={(props.selectedTab || SHELF_DEFAULT_TAB) === ShelfTabs.SYSTEM_HOTKEYS}
@@ -151,4 +129,36 @@ export function ShelfRundownLayout(props: IShelfRundownLayoutProps) {
 			</div>
 		</>
 	)
+}
+function renderLayout(rundownLayout: RundownLayout, props: IShelfRundownLayoutProps) {
+	const interpolableSource: InterpolatedPropsSource = {
+		studio: props.studio,
+		showStyleBase: props.showStyleBase,
+	}
+	return rundownLayout.filters
+		.map((panel) => interpolatePanelStrings(panel, interpolableSource))
+		.map((panel) =>
+			RundownLayoutsAPI.isFilter(panel) ? (
+				<AdLibPanel
+					key={panel._id}
+					visible={(props.selectedTab || SHELF_DEFAULT_TAB) === `${ShelfTabs.ADLIB_LAYOUT_FILTER}_${panel._id}`}
+					includeGlobalAdLibs={true}
+					filter={panel}
+					selectedPiece={props.selectedPiece}
+					onSelectPiece={props.onSelectPiece}
+					playlist={props.playlist}
+					showStyleBase={props.showStyleBase}
+					studioMode={props.studioMode}
+					studio={props.studio}
+				/>
+			) : RundownLayoutsAPI.isExternalFrame(panel) ? (
+				<ExternalFramePanel
+					key={panel._id}
+					panel={panel}
+					layout={rundownLayout}
+					visible={(props.selectedTab || SHELF_DEFAULT_TAB) === `${ShelfTabs.ADLIB_LAYOUT_FILTER}_${panel._id}`}
+					playlist={props.playlist}
+				/>
+			) : undefined
+		)
 }

--- a/meteor/client/ui/Shelf/ShelfRundownLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfRundownLayout.tsx
@@ -16,7 +16,7 @@ import { PieceUi } from '../SegmentTimeline/SegmentTimelineContainer'
 import { useTranslation } from 'react-i18next'
 import { BucketAdLibItem } from './RundownViewBuckets'
 import { IAdLibListItem } from './AdLibListItem'
-import { InterpolatedPropsSource, interpolatePanelStrings } from './ShelfDashboardLayout'
+import { InterpolatedPropsSource, interpolatePanelStrings } from './utils/interpolatePanelStrings'
 
 export interface IShelfRundownLayoutProps {
 	rundownLayout: RundownLayout | undefined
@@ -130,6 +130,7 @@ export function ShelfRundownLayout(props: IShelfRundownLayoutProps) {
 		</>
 	)
 }
+
 function renderLayout(rundownLayout: RundownLayout, props: IShelfRundownLayoutProps) {
 	const interpolableSource: InterpolatedPropsSource = {
 		studio: props.studio,

--- a/meteor/client/ui/Shelf/utils/interpolatePanelStrings.ts
+++ b/meteor/client/ui/Shelf/utils/interpolatePanelStrings.ts
@@ -1,0 +1,43 @@
+import {
+	RundownLayoutElementAny,
+	RundownLayoutElementBase,
+	RundownLayoutElementType,
+} from '../../../../lib/collections/RundownLayouts'
+import { double as phrase } from 'paraphrase'
+import { ShowStyleBase } from '../../../../lib/collections/ShowStyleBases'
+import { Studio } from '../../../../lib/collections/Studios'
+
+export interface InterpolatedPropsSource {
+	studio: Studio
+	showStyleBase: ShowStyleBase
+}
+
+const RUNDOWN_LAYOUT_ELEMENT_INTERPOLABLE_PROPS: {
+	[key in RundownLayoutElementType]?: (keyof Extract<RundownLayoutElementAny, { type: key }>)[]
+} = {
+	[RundownLayoutElementType.FILTER]: ['name'],
+	[RundownLayoutElementType.TEXT_LABEL]: ['name', 'text'],
+	[RundownLayoutElementType.EXTERNAL_FRAME]: ['name', 'url'],
+	[RundownLayoutElementType.NEXT_INFO]: ['name'],
+}
+
+export function interpolatePanelStrings<T extends RundownLayoutElementBase>(
+	panel: T,
+	source: InterpolatedPropsSource
+): T {
+	const interpolableProps = RUNDOWN_LAYOUT_ELEMENT_INTERPOLABLE_PROPS[panel.type ?? RundownLayoutElementType.FILTER]
+	if (!interpolableProps) {
+		return panel
+	}
+
+	const interpolatedPanel: Partial<T> = {}
+	for (const prop of interpolableProps) {
+		if (typeof panel[prop] === 'string') {
+			interpolatedPanel[prop] = phrase(panel[prop], source)
+		}
+	}
+	return {
+		...panel,
+		...interpolatedPanel,
+	}
+}

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -61,6 +61,12 @@ export interface ISettings {
 	 * in such cases this must be set to 'Enter' to exclude it.
 	 */
 	confirmKeyCode: 'Enter' | 'AnyEnter'
+
+	/**
+	 * If true, strings in selected fields of Shelf Layouts will be treated as templates and interpolated.
+	 * The syntax is `{{variable.nestedProp}}`. `studio` (`DBStudio`) and `showStyleBase` (`DBShowStyleBase`) are exposed.
+	 */
+	interpolateStringsInLayouts: boolean
 }
 
 /**
@@ -87,6 +93,7 @@ const DEFAULT_SETTINGS = Object.freeze<ISettings>({
 	useCountdownToFreezeFrame: true,
 	confirmKeyCode: 'Enter',
 	customizationClassName: 'tv2',
+	interpolateStringsInLayouts: false,
 })
 
 /**

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -61,12 +61,6 @@ export interface ISettings {
 	 * in such cases this must be set to 'Enter' to exclude it.
 	 */
 	confirmKeyCode: 'Enter' | 'AnyEnter'
-
-	/**
-	 * If true, strings in selected fields of Shelf Layouts will be treated as templates and interpolated.
-	 * The syntax is `{{variable.nestedProp}}`. `studio` (`DBStudio`) and `showStyleBase` (`DBShowStyleBase`) are exposed.
-	 */
-	interpolateStringsInLayouts: boolean
 }
 
 /**
@@ -93,7 +87,6 @@ const DEFAULT_SETTINGS = Object.freeze<ISettings>({
 	useCountdownToFreezeFrame: true,
 	confirmKeyCode: 'Enter',
 	customizationClassName: 'tv2',
-	interpolateStringsInLayouts: false,
 })
 
 /**

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -287,6 +287,30 @@ export interface DashboardPanelUnits {
 	heightUnit?: DashboardPanelUnit
 }
 
+export type RundownLayoutElementAny =
+	| RundownLayoutExternalFrame
+	| RundownLayoutAdLibRegion
+	| RundownLayoutPieceCountdown
+	| RundownLayoutNextInfo
+	| RundownLayoutPlaylistStartTimer
+	| RundownLayoutNextBreakTiming
+	| RundownLayoutPlaylistEndTimer
+	| RundownLayoutEndWords
+	| RundownLayoutSegmentTiming
+	| RundownLayoutPartTiming
+	| RundownLayoutTextLabel
+	| RundownLayoutPlaylistName
+	| RundownLayoutStudioName
+	| RundownLayoutTimeOfDay
+	| RundownLayoutSytemStatus
+	| RundownLayoutShowStyleDisplay
+	| RundownLayoutSegmentName
+	| RundownLayoutPartName
+	| RundownLayoutColoredBox
+	| RundownLayoutKeyboardPreview
+	| RundownLayoutMiniRundown
+	| RundownLayoutFilterBase
+
 type DashboardPanel<T> = T & DashboardPanelBase & DashboardPanelUnits
 
 export type DashboardLayoutExternalFrame = DashboardPanel<RundownLayoutExternalFrame>

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -109,7 +109,8 @@
 		"vm2": "^3.9.11",
 		"webmidi": "^2.5.3",
 		"winston": "^3.8.2",
-		"xmlbuilder": "^15.1.1"
+		"xmlbuilder": "^15.1.1",
+		"paraphrase": "^3.1.1"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.19.1",

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -7847,6 +7847,11 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
+paraphrase@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/paraphrase/-/paraphrase-3.1.1.tgz#99dc60a142ee8520f39bc25b63130936e7652d67"
+  integrity sha512-3vWTmqzNhEsFdYJO996Hmzofdp2yL+OaspIpVYs7DKTlxMi5nrDcRzNcbelsn91eI5pHQyqu3SI6Znxhq5LBtg==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -9832,10 +9837,10 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.5.0.tgz#02ca12128cbc0df84e630d0da8c66a1d44e5f172"
-  integrity sha512-DdKXdQf+By8ssBKqd3qfAAhERehlKTorWb3tYK6G6z1vmADSJT+MVAvY0GpLx5/qKe0e3HbutQ2CMlh7b00QIA==
+"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.5.1.tgz#9362ec90183babb8183914a7e36664218e2eb5e1"
+  integrity sha512-yBAI2d7cnWPuDtFsYkbFB/GBkN4p0Q7Ne4TqKCDl4haqFU4PNtIzI1shH9AOEMOcsmNh0ZxHTzgAG85zrGGXpQ==
   dependencies:
     tslib "^2.3.1"
 


### PR DESCRIPTION
When `interpolateStringsInLayouts` setting is enabled, selected panel props in the Shelf will be treated as templates and values from the `studio` and `showStyleBase` will be resolved. 
This removes then need for having different Shelf layouts in each installation due to things like external frame URLs. Now such URL can look like this: `multiview.{{studio.settings.sofieUrl}}`.