### PR TITLE
SOF-1105 No longer tries to look for a 'value' attribute in a string

### DIFF
--- a/meteor/client/ui/Settings/components/triggeredActions/actionEditors/filterPreviews/AdLibFilter.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/actionEditors/filterPreviews/AdLibFilter.tsx
@@ -216,7 +216,7 @@ function fieldValueMutate(link: IAdLibFilterLink, newValue: any) {
 		case 'sourceLayerId':
 			return Array.isArray(newValue)
 				? newValue.map((layerId) => {
-						if ('value' in layerId) {
+						if (typeof layerId !== 'string' && 'value' in layerId) {
 							return String(layerId.value)
 						}
 						return String(layerId)


### PR DESCRIPTION
One of our dropdowns in the Action Triggers would fail because we tried to use the `in` operator on a String. We no longer try to do that.