### PR TITLE
fix: SOF-1181 position dashboard panels based on `rem` instead of `em`

### DIFF
--- a/meteor/client/styles/shelf/dashboard.scss
+++ b/meteor/client/styles/shelf/dashboard.scss
@@ -12,15 +12,11 @@ $dashboard-button-height: 5.625em;
 	right: 2px;
 	overflow: auto;
 
-	--dashboard-button-grid-width: 1.875em;
-	--dashboard-button-grid-height: 1.625em;
-	--dashboard-panel-margin-width: 0.938em;
-	--dashboard-panel-margin-height: 2.75em;
+	--dashboard-button-grid-width: 1.875rem;
+	--dashboard-button-grid-height: 1.625rem;
+	--dashboard-panel-margin-width: 0.938rem;
+	--dashboard-panel-margin-height: 2.75rem;
 	--dashboard-panel-scale: 1;
-
-	.dashboard__panel--font-scaled {
-		font-size: calc(var(--dashboard-panel-scale) * 1.5em);
-	}
 }
 
 .dashboard-panel {

--- a/meteor/client/styles/shelf/miniRundownPanel.scss
+++ b/meteor/client/styles/shelf/miniRundownPanel.scss
@@ -1,16 +1,16 @@
 @import '../colorScheme';
 
 .mini-rundown-panel {
-	--dashboard-panel-scale: 1;
 	position: absolute;
 	user-select: none;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	margin: 0.625rem;
+	display: flex;
+	flex-direction: column;
 
 	.mini-rundown-panel__container {
 		width: 100%;
-		height: calc(100% - var(--dashboard-panel-scale) * 1em);
 		overflow-x: hidden;
 		overflow-y: auto;
 		position: relative;

--- a/meteor/client/styles/tv2/keyboardPreview.scss
+++ b/meteor/client/styles/tv2/keyboardPreview.scss
@@ -24,7 +24,6 @@
 	  max-width: 1em;
 	  height: var(--keyboard-preview-height);
 
-	  font-size: 3em;
 	  margin-right: var(--keyboard-preview-key-margin);
 
 	  &.keyboard-preview__blank-space--spring {
@@ -36,12 +35,9 @@
 
 	.keyboard-preview__key {
 	  position: relative;
-	  min-width: 1em;
-	  max-width: 1em;
 
 	  height: var(--keyboard-preview-height);
 
-	  font-size: 3em;
 	  margin-right: var(--keyboard-preview-key-margin);
 
 	  background: #333;
@@ -72,7 +68,7 @@
 	  }
 
 	  > .keyboard-preview__key__label {
-		font-size: 16px;
+		font-size: 0.59em;
 		font-weight: bold;
 		text-align: right;
 		padding: 3px;
@@ -83,7 +79,7 @@
 	  }
 
 	  > .keyboard-preview__key__function-label {
-		font-size: 16px;
+		font-size: 0.59em;
 		font-weight: bold;
 		text-align: left;
 		padding: 3px;
@@ -138,12 +134,5 @@
 
   > .keyboard-preview {
 	--keyboard-preview-height: calc(100vw / 23 * var(--dashboard-panel-scale));
-
-	.keyboard-preview__key-row .keyboard-preview__key > .keyboard-preview__key__function-label {
-	  font-size: calc(var(--dashboard-panel-scale) * 16px);
-	}
-	.keyboard-preview__key-row .keyboard-preview__key > .keyboard-preview__key__label {
-	  font-size: calc(var(--dashboard-panel-scale) * 16px);
-	}
   }
 }

--- a/meteor/client/ui/Settings/components/FilterEditor.tsx
+++ b/meteor/client/ui/Settings/components/FilterEditor.tsx
@@ -1464,7 +1464,7 @@ export default withTranslation()(
 									type="dropdown"
 									collection={RundownLayouts}
 									className="input text-input"
-									mutateDisplayValue={(v) => (v === undefined ? DashboardPanelUnit.EM : v)}
+									mutateDisplayValue={(v) => (v === undefined ? DashboardPanelUnit.REM : v)}
 								/>
 							</label>
 						</div>
@@ -1489,7 +1489,7 @@ export default withTranslation()(
 									type="dropdown"
 									collection={RundownLayouts}
 									className="input text-input"
-									mutateDisplayValue={(v) => (v === undefined ? DashboardPanelUnit.EM : v)}
+									mutateDisplayValue={(v) => (v === undefined ? DashboardPanelUnit.REM : v)}
 								/>
 							</label>
 						</div>
@@ -1514,7 +1514,7 @@ export default withTranslation()(
 									type="dropdown"
 									collection={RundownLayouts}
 									className="input text-input"
-									mutateDisplayValue={(v) => (v === undefined ? DashboardPanelUnit.EM : v)}
+									mutateDisplayValue={(v) => (v === undefined ? DashboardPanelUnit.REM : v)}
 								/>
 							</label>
 						</div>
@@ -1539,7 +1539,7 @@ export default withTranslation()(
 									type="dropdown"
 									collection={RundownLayouts}
 									className="input text-input"
-									mutateDisplayValue={(v) => (v === undefined ? DashboardPanelUnit.EM : v)}
+									mutateDisplayValue={(v) => (v === undefined ? DashboardPanelUnit.REM : v)}
 								/>
 							</label>
 						</div>

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -131,11 +131,10 @@ export function dashboardElementStyle(el: DashboardPositionableElement): React.C
 					? `calc(${-1 * el.y}% + var(--dashboard-panel-margin-height) / 2)`
 					: `calc(${-1 * el.y - 1} * var(--dashboard-button-grid-height))`
 				: getVerticalOffsetFromHeight(el),
-		fontSize: `calc(var(--dashboard-panel-scale) * 1.5em)`,
+		fontSize: `calc(var(--dashboard-panel-scale) * 1rem)`,
 
 		// @ts-expect-error css variables
 		'--dashboard-panel-scale': el.scale || 1,
-		'--dashboard-panel-scaled-font-size': (el.scale || 1) * 1.5 + 'em',
 	}
 }
 

--- a/meteor/client/ui/Shelf/Keyboard/KeyboardPreview.tsx
+++ b/meteor/client/ui/Shelf/Keyboard/KeyboardPreview.tsx
@@ -204,7 +204,7 @@ export const KeyboardPreviewKey: React.FC<IKeyboardPreviewKeyProps> = React.memo
 				}
 			)}
 			style={{
-				fontSize: props.keyPosition.width >= 0 ? (props.keyPosition.width || 1) + 'em' : undefined,
+				width: props.keyPosition.width >= 0 ? (props.keyPosition.width || 1) + 'em' : undefined,
 				backgroundColor: props.custom?.buttonColor,
 			}}
 			onClick={(e) =>

--- a/meteor/client/ui/Shelf/NextInfoPanel.tsx
+++ b/meteor/client/ui/Shelf/NextInfoPanel.tsx
@@ -54,7 +54,7 @@ export class NextInfoPanelInner extends MeteorReactComponent<INextInfoPanelProps
 					}
 				)}
 			>
-				<div className="dashboard__panel--font-scaled">
+				<div>
 					<span className="next-info-panel__name">{showAny && this.props.panel.name} </span>
 					{segmentName && <span className="next-info-panel__segment">{segmentName}</span>}
 					{partTitle && <span className="next-info-panel__part">{partTitle}</span>}

--- a/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
+++ b/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
@@ -82,7 +82,7 @@ export class PieceCountdownPanelInner extends MeteorReactComponent<
 				}}
 			>
 				<span
-					className={ClassNames('piece-countdown-panel__timecode', 'dashboard__panel--font-scaled', {
+					className={ClassNames('piece-countdown-panel__timecode', {
 						overtime: Math.floor(this.state.displayTimecode / 1000) > 0,
 					})}
 				>

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -265,9 +265,9 @@ export interface RundownLayoutKeyboardPreview extends RundownLayoutElementBase {
 }
 
 export enum DashboardPanelUnit {
-	/** Dashboard panels are defined in absolute (em) units */
-	EM = 'em',
-	/** Dashboard panels are defined in percent so that they scale with container/window size */
+	/** Dashboard panel dimensions are defined in units relative to the root element's font-size */
+	REM = 'rem',
+	/** Dashboard panel dimensions are defined in percent so that they scale with container/window size */
 	PERCENT = '%',
 }
 


### PR DESCRIPTION
Makes positioning in the dashboard more consistent. 
`scale` no longer affects the dimensions and positioning of the panel, only their contents.
Default font-size in is now panels is 1rem.

Current layouts that use `em` positioning may need to be updated if they also used `scale` other than 1 (or 0). Because this is a manual process, no migrations are made to automatically change `em` to `rem`.