### PR TITLE
fix: infinites continuations capped too soon by pieces with non-zero start

### DIFF
--- a/packages/corelib/src/playout/__tests__/pieces.test.ts
+++ b/packages/corelib/src/playout/__tests__/pieces.test.ts
@@ -92,7 +92,8 @@ describe('Pieces', () => {
 			priority: 123,
 			classes: undefined,
 		})
-		const partGroup = { id: 'randomId9003' } as any as TimelineObjRundown
+		const parentGroup = { id: 'randomId9003' } as any as TimelineObjRundown
+		const partGroup = { id: 'randomId9004' } as any as TimelineObjRundown
 
 		test('Basic piece', () => {
 			const res = createPieceGroupAndCap(playlistId, simplePieceInstance)
@@ -102,31 +103,31 @@ describe('Pieces', () => {
 			expect(res.controlObj).toStrictEqual(simplePieceControl)
 		})
 		test('Basic piece with a partGroup', () => {
-			const res = createPieceGroupAndCap(playlistId, simplePieceInstance, [], partGroup)
+			const res = createPieceGroupAndCap(playlistId, simplePieceInstance, [], partGroup, parentGroup)
 
 			expect(res.capObjs).toHaveLength(0)
 			expect(res.childGroup).toStrictEqual({
 				...simplePieceGroup,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 			})
 			expect(res.controlObj).toStrictEqual({
 				...simplePieceControl,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 				classes: [],
 			})
 		})
 		test('override enable', () => {
 			const enable: TimelineEnable = { start: 'abc + 3', end: 999 }
-			const res = createPieceGroupAndCap(playlistId, simplePieceInstance, [], partGroup, enable)
+			const res = createPieceGroupAndCap(playlistId, simplePieceInstance, [], partGroup, parentGroup, enable)
 
 			expect(res.capObjs).toHaveLength(0)
 			expect(res.childGroup).toStrictEqual({
 				...simplePieceGroup,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 			})
 			expect(res.controlObj).toStrictEqual({
 				...simplePieceControl,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 				classes: [],
 				enable,
 			})
@@ -140,16 +141,16 @@ describe('Pieces', () => {
 					...simplePieceInstance,
 					resolvedEndCap: 800,
 				}
-				const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+				const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 
 				expect(res.capObjs).toHaveLength(0)
 				expect(res.childGroup).toStrictEqual({
 					...simplePieceGroup,
-					inGroup: partGroup.id,
+					inGroup: parentGroup.id,
 				})
 				expect(res.controlObj).toStrictEqual({
 					...simplePieceControl,
-					inGroup: partGroup.id,
+					inGroup: parentGroup.id,
 					classes: [],
 					enable: {
 						...enable,
@@ -164,16 +165,16 @@ describe('Pieces', () => {
 					...simplePieceInstance,
 					resolvedEndCap: 8000,
 				}
-				const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+				const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 
 				expect(res.capObjs).toHaveLength(0)
 				expect(res.childGroup).toStrictEqual({
 					...simplePieceGroup,
-					inGroup: partGroup.id,
+					inGroup: parentGroup.id,
 				})
 				expect(res.controlObj).toStrictEqual({
 					...simplePieceControl,
-					inGroup: partGroup.id,
+					inGroup: parentGroup.id,
 					classes: [],
 					enable,
 				})
@@ -187,16 +188,16 @@ describe('Pieces', () => {
 					...simplePieceInstance,
 					resolvedEndCap: 800,
 				}
-				const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+				const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 
 				expect(res.capObjs).toHaveLength(0)
 				expect(res.childGroup).toStrictEqual({
 					...simplePieceGroup,
-					inGroup: partGroup.id,
+					inGroup: parentGroup.id,
 				})
 				expect(res.controlObj).toStrictEqual({
 					...simplePieceControl,
-					inGroup: partGroup.id,
+					inGroup: parentGroup.id,
 					classes: [],
 					enable: {
 						start: enable.start,
@@ -212,7 +213,7 @@ describe('Pieces', () => {
 					...simplePieceInstance,
 					resolvedEndCap: 800,
 				}
-				const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+				const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 
 				expect(res.capObjs).toStrictEqual([
 					{
@@ -232,7 +233,7 @@ describe('Pieces', () => {
 				])
 				expect(res.childGroup).toStrictEqual({
 					...simplePieceGroup,
-					inGroup: partGroup.id,
+					inGroup: parentGroup.id,
 				})
 				expect(res.controlObj).toStrictEqual({
 					...simplePieceControl,
@@ -249,20 +250,20 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: 800,
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 
 			expect(res.capObjs).toHaveLength(0)
 			expect(res.childGroup).toStrictEqual({
 				...simplePieceGroup,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 			})
 			expect(res.controlObj).toStrictEqual({
 				...simplePieceControl,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 				classes: [],
 				enable: {
 					...enable,
-					end: 800,
+					end: `#${partGroup.id}.start + 800`,
 				},
 			})
 		})
@@ -274,7 +275,7 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: 'now',
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 
 			expect(res.capObjs).toStrictEqual([
 				{
@@ -293,7 +294,7 @@ describe('Pieces', () => {
 					content: { deviceType: 0, type: 'group' },
 					enable: { end: '#piece_group_control_randomId9000_cap_now.start', start: 0 },
 					id: 'piece_group_control_randomId9000_cap',
-					inGroup: partGroup.id,
+					inGroup: parentGroup.id,
 					isGroup: true,
 					layer: '',
 					objectType: 'rundown',
@@ -305,7 +306,7 @@ describe('Pieces', () => {
 			])
 			expect(res.childGroup).toStrictEqual({
 				...simplePieceGroup,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 			})
 			expect(res.controlObj).toStrictEqual({
 				...simplePieceControl,
@@ -322,7 +323,7 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: 'now',
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 
 			expect(res.capObjs).toStrictEqual([
 				{
@@ -339,11 +340,11 @@ describe('Pieces', () => {
 			])
 			expect(res.childGroup).toStrictEqual({
 				...simplePieceGroup,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 			})
 			expect(res.controlObj).toStrictEqual({
 				...simplePieceControl,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 				classes: [],
 				enable: {
 					...enable,
@@ -359,7 +360,7 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: 'now',
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 
 			expect(res.capObjs).toStrictEqual([
 				{
@@ -378,7 +379,7 @@ describe('Pieces', () => {
 					content: { deviceType: 0, type: 'group' },
 					enable: { end: '#piece_group_control_randomId9000_cap_now.start', start: 0 },
 					id: 'piece_group_control_randomId9000_cap',
-					inGroup: partGroup.id,
+					inGroup: parentGroup.id,
 					isGroup: true,
 					layer: '',
 					objectType: 'rundown',
@@ -390,7 +391,7 @@ describe('Pieces', () => {
 			])
 			expect(res.childGroup).toStrictEqual({
 				...simplePieceGroup,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 			})
 			expect(res.controlObj).toStrictEqual({
 				...simplePieceControl,
@@ -407,7 +408,7 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: 'aaa + 99',
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 
 			expect(res.capObjs).toStrictEqual([
 				{
@@ -415,7 +416,7 @@ describe('Pieces', () => {
 					content: { deviceType: 0, type: 'group' },
 					enable: { end: pieceInstance.resolvedEndCap, start: 0 },
 					id: 'piece_group_control_randomId9000_cap',
-					inGroup: partGroup.id,
+					inGroup: parentGroup.id,
 					isGroup: true,
 					layer: '',
 					objectType: 'rundown',
@@ -427,7 +428,7 @@ describe('Pieces', () => {
 			])
 			expect(res.childGroup).toStrictEqual({
 				...simplePieceGroup,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 			})
 			expect(res.controlObj).toStrictEqual({
 				...simplePieceControl,
@@ -444,16 +445,16 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: 'aaa + 99',
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 
 			expect(res.capObjs).toHaveLength(0)
 			expect(res.childGroup).toStrictEqual({
 				...simplePieceGroup,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 			})
 			expect(res.controlObj).toStrictEqual({
 				...simplePieceControl,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 				classes: [],
 				enable: {
 					...enable,
@@ -471,36 +472,36 @@ describe('Pieces', () => {
 			}
 
 			// No offset
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable)
 			expect(res.capObjs).toHaveLength(0)
 			expect(res.childGroup).toStrictEqual({
 				...simplePieceGroup,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 			})
 			expect(res.controlObj).toStrictEqual({
 				...simplePieceControl,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 				classes: [],
 				enable: {
 					...enable,
-					end: 500,
+					end: `#${partGroup.id}.start + 500`,
 				},
 			})
 
 			// Factor in offset
-			const res2 = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, enable, 100)
+			const res2 = createPieceGroupAndCap(playlistId, pieceInstance, [], partGroup, parentGroup, enable, 100)
 			expect(res2.capObjs).toHaveLength(0)
 			expect(res2.childGroup).toStrictEqual({
 				...simplePieceGroup,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 			})
 			expect(res2.controlObj).toStrictEqual({
 				...simplePieceControl,
-				inGroup: partGroup.id,
+				inGroup: parentGroup.id,
 				classes: [],
 				enable: {
 					...enable,
-					end: 400,
+					end: `#${partGroup.id}.start + 400`,
 				},
 			})
 		})

--- a/packages/corelib/src/playout/pieces.ts
+++ b/packages/corelib/src/playout/pieces.ts
@@ -83,7 +83,7 @@ export function createPieceGroupAndCap(
 			callBackStopped: PlayoutChangedType.PIECE_PLAYBACK_STOPPED, // Will cause a callback to be called, when the object stops playing:
 		},
 		classes: controlObjClasses,
-		inGroup: parentGroup && parentGroup.id,
+		inGroup: parentGroup?.id,
 		metaData: {
 			isPieceTimeline: true,
 		},
@@ -97,7 +97,7 @@ export function createPieceGroupAndCap(
 			type: TimelineContentTypeOther.GROUP,
 		},
 		children: [],
-		inGroup: parentGroup && parentGroup.id,
+		inGroup: parentGroup?.id,
 		isGroup: true,
 		pieceInstanceId: unprotectString(pieceInstance._id),
 		infinitePieceInstanceId: pieceInstance.infinite?.infiniteInstanceId,
@@ -124,7 +124,7 @@ export function createPieceGroupAndCap(
 			enable: {
 				start: 'now',
 			},
-			inGroup: parentGroup && parentGroup.id,
+			inGroup: parentGroup?.id,
 			layer: '',
 			content: {
 				deviceType: TSR.DeviceType.ABSTRACT,
@@ -204,7 +204,7 @@ export function createPieceGroupAndCap(
 						type: TimelineContentTypeOther.GROUP,
 					},
 					isGroup: true,
-					inGroup: parentGroup && parentGroup.id,
+					inGroup: parentGroup?.id,
 					partInstanceId: controlObj.partInstanceId,
 					metaData: literal<PieceTimelineMetadata>({
 						isPieceTimeline: true,

--- a/packages/corelib/src/playout/pieces.ts
+++ b/packages/corelib/src/playout/pieces.ts
@@ -40,6 +40,7 @@ export function createPieceGroupAndCap(
 	>,
 	controlObjClasses?: string[],
 	partGroup?: TimelineObjRundown,
+	parentGroup?: TimelineObjRundown,
 	pieceEnable?: TSR.Timeline.TimelineEnable,
 	pieceStartOffset?: number
 ): {
@@ -82,7 +83,7 @@ export function createPieceGroupAndCap(
 			callBackStopped: PlayoutChangedType.PIECE_PLAYBACK_STOPPED, // Will cause a callback to be called, when the object stops playing:
 		},
 		classes: controlObjClasses,
-		inGroup: partGroup && partGroup.id,
+		inGroup: parentGroup && parentGroup.id,
 		metaData: {
 			isPieceTimeline: true,
 		},
@@ -96,7 +97,7 @@ export function createPieceGroupAndCap(
 			type: TimelineContentTypeOther.GROUP,
 		},
 		children: [],
-		inGroup: partGroup && partGroup.id,
+		inGroup: parentGroup && parentGroup.id,
 		isGroup: true,
 		pieceInstanceId: unprotectString(pieceInstance._id),
 		infinitePieceInstanceId: pieceInstance.infinite?.infiniteInstanceId,
@@ -123,7 +124,7 @@ export function createPieceGroupAndCap(
 			enable: {
 				start: 'now',
 			},
-			inGroup: partGroup && partGroup.id,
+			inGroup: parentGroup && parentGroup.id,
 			layer: '',
 			content: {
 				deviceType: TSR.DeviceType.ABSTRACT,
@@ -203,7 +204,7 @@ export function createPieceGroupAndCap(
 						type: TimelineContentTypeOther.GROUP,
 					},
 					isGroup: true,
-					inGroup: partGroup && partGroup.id,
+					inGroup: parentGroup && parentGroup.id,
 					partInstanceId: controlObj.partInstanceId,
 					metaData: literal<PieceTimelineMetadata>({
 						isPieceTimeline: true,
@@ -214,6 +215,9 @@ export function createPieceGroupAndCap(
 			controlObj.inGroup = pieceEndCapGroup.id
 		}
 	} else {
+		if (typeof resolvedEndCap === 'number' && partGroup) {
+			resolvedEndCap = `#${partGroup.id}.start + ${resolvedEndCap}`
+		}
 		controlObj.enable.end = resolvedEndCap
 	}
 

--- a/packages/job-worker/src/playout/__tests__/timeline.test.ts
+++ b/packages/job-worker/src/playout/__tests__/timeline.test.ts
@@ -736,7 +736,7 @@ describe('Timeline', () => {
 							// No delay applied as it started before this part, so should be left untouched
 							partGroup: { start: `#part_group_${currentPartInstance?._id}.start` },
 							pieceGroup: {
-								controlObj: { start: 0 },
+								controlObj: { start: 500 },
 								childGroup: { preroll: 0, postroll: 0 },
 							},
 						},
@@ -1140,7 +1140,7 @@ describe('Timeline', () => {
 							piece000: {
 								controlObj: {
 									start: 500, // This one gave the preroll
-									end: pieceOffset, // This is expected to match the start of the adlib
+									end: `#${getPartGroupId(currentPartInstance!)}.start + ${pieceOffset}`, // This is expected to match the start of the adlib
 								},
 								childGroup: {
 									preroll: 500,
@@ -1303,7 +1303,7 @@ describe('Timeline', () => {
 							piece000: {
 								controlObj: {
 									start: 500, // This one gave the preroll
-									end: pieceOffset,
+									end: `#${getPartGroupId(currentPartInstance!)}.start + ${pieceOffset}`,
 								},
 								childGroup: {
 									preroll: 500,
@@ -1439,7 +1439,10 @@ describe('Timeline', () => {
 						previousPart: { end: `#${getPartGroupId(currentPartInstance!)}.start + 1000` },
 						currentPieces: {
 							piece010: {
-								controlObj: { start: 500, end: 12560 },
+								controlObj: {
+									start: 500,
+									end: `#${getPartGroupId(currentPartInstance!)}.start + ${pieceOffset}`,
+								},
 								childGroup: { preroll: 0, postroll: 0 },
 							},
 							// transition piece

--- a/packages/job-worker/src/playout/timeline/part.ts
+++ b/packages/job-worker/src/playout/timeline/part.ts
@@ -80,6 +80,7 @@ export function transformPartIntoTimeline(
 			...transformPieceGroupAndObjects(
 				playlistId,
 				parentGroup,
+				parentGroup,
 				nowInParentGroup,
 				pieceInstance,
 				pieceEnable,

--- a/packages/job-worker/src/playout/timeline/piece.ts
+++ b/packages/job-worker/src/playout/timeline/piece.ts
@@ -18,7 +18,8 @@ import { hasPieceInstanceDefinitelyEnded } from './lib'
 
 export function transformPieceGroupAndObjects(
 	playlistId: RundownPlaylistId,
-	partGroup: TimelineObjGroupPart & OnGenerateTimelineObjExt,
+	partGroup: TimelineObjGroupPart,
+	parentGroup: TimelineObjGroupPart & OnGenerateTimelineObjExt,
 	nowInPart: number,
 	pieceInstance: ReadonlyDeep<PieceInstanceWithTimings>,
 	pieceEnable: TSR.Timeline.TimelineEnable,
@@ -37,6 +38,7 @@ export function transformPieceGroupAndObjects(
 		pieceInstance,
 		controlObjClasses,
 		partGroup,
+		parentGroup,
 		pieceEnable,
 		pieceStartOffset
 	)
@@ -74,7 +76,7 @@ export function transformPieceGroupAndObjects(
 				objectType: TimelineObjType.RUNDOWN,
 				pieceInstanceId: unprotectString(pieceInstance._id),
 				infinitePieceInstanceId: pieceInstance.infinite?.infiniteInstanceId,
-				partInstanceId: partGroup.partInstanceId,
+				partInstanceId: parentGroup.partInstanceId,
 			})
 		}
 

--- a/packages/job-worker/src/playout/timeline/rundown.ts
+++ b/packages/job-worker/src/playout/timeline/rundown.ts
@@ -253,7 +253,7 @@ function generateCurrentInfinitePieceObjects(
 		// The infiniteGroupStart is a timestamp of the actual start of the piece controlObj,
 		// which includes the value of `pieceEnable.start` so we need to offset by that value and avoid trimming
 		// the start of the piece group
-		if (typeof pieceEnable.start === 'number' && pieceEnable.start !== null) {
+		if (typeof pieceEnable.start === 'number') {
 			infiniteGroupStart -= pieceEnable.start
 		} else {
 			// We should never hit this, but in case pieceEnable.start is "now"

--- a/packages/job-worker/src/playout/timeline/rundown.ts
+++ b/packages/job-worker/src/playout/timeline/rundown.ts
@@ -240,18 +240,32 @@ function generateCurrentInfinitePieceObjects(
 	if (previousPartInfinites.get(pieceInstance.infinite.infiniteInstanceId)) {
 		groupClasses.push('continues_infinite')
 	}
+	const pieceEnable = getPieceEnableInsidePart(pieceInstance, currentPartInstanceTimings, currentPartGroup.id)
 
 	let nowInParent = currentPartInfo.nowInPart
-	let isAbsoluteInfinitePartGroup = false
 	if (pieceInstance.startedPlayback) {
 		// Make the start time stick
 		infiniteGroup.enable = { start: pieceInstance.startedPlayback }
-		nowInParent = currentTime - pieceInstance.startedPlayback
-		isAbsoluteInfinitePartGroup = true
+		let infiniteGroupStart = pieceInstance.startedPlayback
+
+		// infiniteGroupStart had an actual timestamp inside and pieceEnable.start being a number
+		// means that it expects an offset from it's parent
+		// The infiniteGroupStart is a timestamp of the actual start of the piece controlObj,
+		// which includes the value of `pieceEnable.start` so we need to offset by that value and avoid trimming
+		// the start of the piece group
+		if (typeof pieceEnable.start === 'number' && pieceEnable.start !== null) {
+			infiniteGroupStart -= pieceEnable.start
+		} else {
+			// We should never hit this, but in case pieceEnable.start is "now"
+			pieceEnable.start = 0
+		}
+
+		infiniteGroup.enable = { start: infiniteGroupStart }
 
 		// If an absolute time has been set by a hotkey, then update the duration to be correct
 		if (pieceInstance.userDuration && pieceInstance.piece.enable.start !== 'now') {
 			infiniteGroup.enable.duration = pieceInstance.userDuration.end - pieceInstance.piece.enable.start
+			nowInParent = currentTime - pieceInstance.startedPlayback
 		}
 	}
 
@@ -287,24 +301,6 @@ function generateCurrentInfinitePieceObjects(
 		}
 	}
 
-	const isInfiniteContinuation =
-		pieceInstance.infinite && pieceInstance.piece.startPartId !== currentPartInfo.partInstance.part._id
-
-	let pieceEnable: TSR.Timeline.TimelineEnable
-	let pieceStartOffset = 0
-	if (isAbsoluteInfinitePartGroup || isInfiniteContinuation) {
-		pieceEnable = { start: 0 }
-
-		if (pieceInstance.piece.enable.start !== 'now') pieceStartOffset = pieceInstance.piece.enable.start
-	} else {
-		pieceEnable = getPieceEnableInsidePart(pieceInstance, currentPartInstanceTimings, currentPartGroup.id)
-	}
-
-	if (pieceInstance.userDuration) {
-		pieceEnable.end = pieceInstance.userDuration.end
-		delete pieceEnable.duration
-	}
-
 	// Still show objects flagged as 'HoldMode.EXCEPT' if this is a infinite continuation as they belong to the previous too
 	const isOriginOfInfinite = pieceInstance.piece.startPartId !== currentPartInfo.partInstance.part._id
 	const isInHold = activePlaylist.holdState === RundownHoldState.ACTIVE
@@ -313,11 +309,12 @@ function generateCurrentInfinitePieceObjects(
 		infiniteGroup,
 		...transformPieceGroupAndObjects(
 			activePlaylist._id,
+			currentPartGroup,
 			infiniteGroup,
 			nowInParent,
 			pieceInstance,
 			pieceEnable,
-			pieceStartOffset,
+			0,
 			groupClasses,
 			isInHold,
 			isOriginOfInfinite


### PR DESCRIPTION
Fixes the case of an infinite piece continuing from a previous part not being effective on the timeline (although visible in the UI) when the taken part has a piece with non-zero start time on the same layer