### PR TITLE
feat: add OutOnRundownChangeWithSegmentLookback lifespan

### DIFF
--- a/meteor/client/ui/Shelf/Renderers/L3rdListItemRenderer.tsx
+++ b/meteor/client/ui/Shelf/Renderers/L3rdListItemRenderer.tsx
@@ -41,6 +41,7 @@ export const L3rdListItemRenderer: React.FunctionComponent<ILayerItemRendererPro
 			case PieceLifespan.OutOnSegmentEnd:
 				sourceDuration = t('Until end of segment') as string
 				break
+			case PieceLifespan.OutOnRundownChangeWithSegmentLookback:
 			case PieceLifespan.OutOnRundownChange:
 				sourceDuration = t('Until next rundown') as string
 				break

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -573,6 +573,10 @@ export enum PieceLifespan {
 	/** The Piece will only exist in it's designated Rundown. It will begin playing when taken and will stop when the
 	 * playhead leaves the Rundown */
 	OutOnRundownChange = 'rundown-change',
+	/** The Piece will only exist in its designated Rundown. It will begin playing when taken and will stop when the
+	 * playhead leaves the Rundown. It will begin playing when entering the Segment through any Part, and any preceding
+	 * Part in that Segment includes this piece. */
+	OutOnRundownChangeWithSegmentLookback = 'rundown-change-segment-lookback',
 	/** The Piece will only exist in it's designated Rundown. It will begin playing when taken and will stop when the
 	 * playhead leaves the Rundown or the playhead moves before the beginning of the Piece */
 	OutOnRundownEnd = 'rundown-end',

--- a/packages/job-worker/src/playout/adlib.ts
+++ b/packages/job-worker/src/playout/adlib.ts
@@ -638,6 +638,7 @@ export function innerStopPieces(
 			switch (pieceInstance.piece.lifespan) {
 				case PieceLifespan.WithinPart:
 				case PieceLifespan.OutOnSegmentChange:
+				case PieceLifespan.OutOnRundownChangeWithSegmentLookback:
 				case PieceLifespan.OutOnRundownChange: {
 					logger.info(`Blueprint action: Cropping PieceInstance "${pieceInstance._id}" to ${stopAt}`)
 					const up: Partial<PieceInstance> = {


### PR DESCRIPTION
Adds new piece lifespan called `OutOnRundownChangeWithSegmentLookback`. A piece with this lifespan follows the playhead like an `OutOnRundownChange` piece, but starts like an `OutOnSegmentEnd` piece (it will start when it's in a Part preceding the Part through which the segment was entered).