### PR TITLE
Sof 1520/Expose Endpoint to Fetch Rundowns

### DIFF
--- a/meteor/package.json
+++ b/meteor/package.json
@@ -82,6 +82,7 @@
 		"object-path": "^0.11.8",
 		"p-lazy": "^3.1.0",
 		"p-queue": "^7.3.0",
+		"paraphrase": "^3.1.1",
 		"promise.allsettled": "^1.0.5",
 		"prop-types": "^15.8.1",
 		"query-string": "^6.14.1",
@@ -111,10 +112,9 @@
 		"velocity-react": "^1.4.3",
 		"vm2": "^3.9.11",
 		"webmidi": "^2.5.3",
-		"ws": "^8.13.0",
 		"winston": "^3.8.2",
-		"xmlbuilder": "^15.1.1",
-		"paraphrase": "^3.1.1"
+		"ws": "^8.13.0",
+		"xmlbuilder": "^15.1.1"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.19.1",
@@ -158,6 +158,7 @@
 		"meteor-babel": "^7.10.7",
 		"meteor-promise": "0.9.0",
 		"mock-http": "^1.1.0",
+		"mongodb-memory-server": "^8.14.0",
 		"open-cli": "^7.0.1",
 		"sinon": "^14.0.0",
 		"standard-version": "^9.5.0",

--- a/meteor/sofie-server/data-access/facades/repository-facade.ts
+++ b/meteor/sofie-server/data-access/facades/repository-facade.ts
@@ -13,6 +13,7 @@ import { MongoTimelineRepository } from '../repositories/mongo/mongo-timeline-re
 import { AdLibPieceRepository } from '../repositories/interfaces/ad-lib-piece-repository'
 import { MongoAdLibPieceRepository } from '../repositories/mongo/mongo-ad-lib-piece-repository'
 import { CachedRundownRepository } from '../repositories/cache/cached-rundown-repository'
+import { MongoRundownPlaylistRepository } from '../repositories/mongo/mongo-rundown-playlist-repository'
 
 export class RepositoryFacade {
 	public static createRundownRepository(): RundownRepository {
@@ -21,7 +22,13 @@ export class RepositoryFacade {
 			new MongoEntityConverter(),
 			this.createSegmentRepository()
 		)
-		return CachedRundownRepository.getInstance(mongoRundownRepository)
+
+		const mongoRundownPlaylistRepository = new MongoRundownPlaylistRepository(
+			MongoDatabase.getInstance(),
+			new MongoEntityConverter(),
+			mongoRundownRepository
+		)
+		return CachedRundownRepository.getInstance(mongoRundownPlaylistRepository)
 	}
 
 	public static createSegmentRepository(): SegmentRepository {

--- a/meteor/sofie-server/data-access/facades/repository-facade.ts
+++ b/meteor/sofie-server/data-access/facades/repository-facade.ts
@@ -23,7 +23,7 @@ export class RepositoryFacade {
 			this.createSegmentRepository()
 		)
 
-		const mongoRundownPlaylistRepository = new MongoRundownPlaylistRepository(
+		const mongoRundownPlaylistRepository: MongoRundownPlaylistRepository = new MongoRundownPlaylistRepository(
 			MongoDatabase.getInstance(),
 			new MongoEntityConverter(),
 			mongoRundownRepository

--- a/meteor/sofie-server/data-access/facades/repository-facade.ts
+++ b/meteor/sofie-server/data-access/facades/repository-facade.ts
@@ -23,7 +23,7 @@ export class RepositoryFacade {
 			this.createSegmentRepository()
 		)
 
-		const mongoRundownPlaylistRepository: MongoRundownPlaylistRepository = new MongoRundownPlaylistRepository(
+		const mongoRundownPlaylistRepository: RundownRepository = new MongoRundownPlaylistRepository(
 			MongoDatabase.getInstance(),
 			new MongoEntityConverter(),
 			mongoRundownRepository

--- a/meteor/sofie-server/data-access/repositories/cache/cached-rundown-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/cache/cached-rundown-repository.ts
@@ -1,5 +1,6 @@
 import { RundownRepository } from '../interfaces/rundown-repository'
 import { Rundown } from '../../../model/entities/rundown'
+import { BasicRundown } from '../../../model/entities/basic-rundown'
 
 export class CachedRundownRepository implements RundownRepository {
 	private static instance: RundownRepository
@@ -24,13 +25,8 @@ export class CachedRundownRepository implements RundownRepository {
 		return this.cachedRundowns.get(rundownId) as Rundown
 	}
 
-	public async getBasicRundowns(): Promise<Rundown[]> {
-		if (this.cachedRundowns.size === 0) {
-			console.log('### No ingested rundowns found in cache. Loading rundowns from database...')
-			const rundowns: Rundown[] = await this.rundownRepository.getBasicRundowns()
-			rundowns.forEach((rundown) => this.cachedRundowns.set(rundown.id, rundown))
-		}
-		return Array.from(this.cachedRundowns.values())
+	public async getBasicRundowns(): Promise<BasicRundown[]> {
+		return await this.rundownRepository.getBasicRundowns()
 	}
 
 	// Only save in memory for now

--- a/meteor/sofie-server/data-access/repositories/cache/cached-rundown-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/cache/cached-rundown-repository.ts
@@ -1,6 +1,5 @@
 import { RundownRepository } from '../interfaces/rundown-repository'
 import { Rundown } from '../../../model/entities/rundown'
-import { Identifier } from '../../../model/interfaces/identifier'
 
 export class CachedRundownRepository implements RundownRepository {
 	private static instance: RundownRepository
@@ -25,8 +24,13 @@ export class CachedRundownRepository implements RundownRepository {
 		return this.cachedRundowns.get(rundownId) as Rundown
 	}
 
-	public async getRundownIdentifiers(): Promise<Identifier[]> {
-		return this.rundownRepository.getRundownIdentifiers()
+	public async getBasicRundowns(): Promise<Rundown[]> {
+		if (this.cachedRundowns.size === 0) {
+			console.log('### No ingested rundowns found in cache. Loading rundowns from database...')
+			const rundowns: Rundown[] = await this.rundownRepository.getBasicRundowns()
+			rundowns.forEach((rundown) => this.cachedRundowns.set(rundown.id, rundown))
+		}
+		return Array.from(this.cachedRundowns.values())
 	}
 
 	// Only save in memory for now

--- a/meteor/sofie-server/data-access/repositories/interfaces/rundown-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/interfaces/rundown-repository.ts
@@ -1,7 +1,8 @@
 import { Rundown } from '../../../model/entities/rundown'
+import { BasicRundown } from '../../../model/entities/basic-rundown'
 
 export interface RundownRepository {
-	getBasicRundowns(): Promise<Rundown[]>
+	getBasicRundowns(): Promise<BasicRundown[]>
 	getRundown(rundownId: string): Promise<Rundown>
 	saveRundown(rundown: Rundown): void
 }

--- a/meteor/sofie-server/data-access/repositories/interfaces/rundown-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/interfaces/rundown-repository.ts
@@ -1,8 +1,7 @@
 import { Rundown } from '../../../model/entities/rundown'
-import { Identifier } from '../../../model/interfaces/identifier'
 
 export interface RundownRepository {
-	getRundownIdentifiers(): Promise<Identifier[]>
+	getBasicRundowns(): Promise<Rundown[]>
 	getRundown(rundownId: string): Promise<Rundown>
 	saveRundown(rundown: Rundown): void
 }

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-ad-lib-piece-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-ad-lib-piece-repository.ts
@@ -18,7 +18,7 @@ export class MongoAdLibPieceRepository extends BaseMongoRepository implements Ad
 	}
 
 	public async getAdLibPieceIdentifiers(rundownId: string): Promise<Identifier[]> {
-		this.assertDatabaseConnection('getAdLibIdentifiers')
+		this.assertDatabaseConnection(this.getAdLibPieceIdentifiers.name)
 		const mongoAdLibPieces: MongoAdLibPiece[] = (await this.getCollection()
 			.find({ rundownId: rundownId })
 			.toArray()) as unknown as MongoAdLibPiece[]
@@ -26,7 +26,7 @@ export class MongoAdLibPieceRepository extends BaseMongoRepository implements Ad
 	}
 
 	public async getAdLibPiece(adLibPieceId: string): Promise<AdLibPiece> {
-		this.assertDatabaseConnection('getAdLibPiece')
+		this.assertDatabaseConnection(this.getAdLibPiece.name)
 		const mongoAdLibPiece: MongoAdLibPiece = (await this.getCollection().findOne({
 			_id: adLibPieceId,
 		})) as unknown as MongoAdLibPiece

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -7,6 +7,7 @@ import { Timeline } from '../../../model/entities/timeline'
 import { Identifier } from '../../../model/interfaces/identifier'
 import { AdLibPiece } from '../../../model/entities/ad-lib-piece'
 import { PieceLifeSpan } from '../../../model/enums/piece-life-span'
+import { BasicRundown } from '../../../model/entities/basic-rundown'
 
 export interface MongoIdentifier {
 	_id: string
@@ -107,7 +108,7 @@ export class MongoEntityConverter {
 		return new Rundown({
 			id: mongoRundown._id,
 			name: mongoRundown.name,
-			isActive: false,
+			isRundownActive: false,
 			segments: [],
 			lastTimeModified: mongoRundown.modified,
 		})
@@ -115,6 +116,14 @@ export class MongoEntityConverter {
 
 	public convertRundowns(mongoRundowns: MongoRundown[]): Rundown[] {
 		return mongoRundowns.map(this.convertRundown)
+	}
+
+	public convertBasicRundown(mongoRundown: MongoRundown): BasicRundown {
+		return new BasicRundown(mongoRundown._id, mongoRundown.name, false, mongoRundown.modified)
+	}
+
+	public convertBasicRundowns(mongoRundowns: MongoRundown[]): BasicRundown[] {
+		return mongoRundowns.map(this.convertBasicRundown)
 	}
 
 	public convertSegment(mongoSegment: MongoSegment): Segment {

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -14,14 +14,10 @@ export interface MongoIdentifier {
 	name: string
 }
 
-export interface MongoRundownPlaylist extends Document {
+export interface MongoRundownPlaylist {
 	_id: string
-	created: number
-	rundownIdsInOrder: string[]
 	externalId: string
-	studioId: string
 	name: string
-	rehearsal: string
 	activationId: string
 }
 
@@ -110,7 +106,7 @@ export class MongoEntityConverter {
 			name: mongoRundown.name,
 			isRundownActive: false,
 			segments: [],
-			lastTimeModified: mongoRundown.modified,
+			modifiedAt: mongoRundown.modified,
 		})
 	}
 

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -13,6 +13,17 @@ export interface MongoIdentifier {
 	name: string
 }
 
+export interface MongoRundownPlaylist extends Document {
+	_id: string
+	created: number
+	rundownIdsInOrder: string[]
+	externalId: string
+	studioId: string
+	name: string
+	rehearsal: string
+	activationId: string
+}
+
 export interface MongoRundown {
 	_id: string
 	externalId: string
@@ -32,6 +43,7 @@ export interface MongoRundown {
 	studioId: string
 	showStyleVariantId: string
 	showStyleBaseId: string
+	modified: number
 }
 
 export interface MongoSegment {
@@ -97,6 +109,7 @@ export class MongoEntityConverter {
 			name: mongoRundown.name,
 			isActive: false,
 			segments: [],
+			lastTimeModified: mongoRundown.modified,
 		})
 	}
 

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-part-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-part-repository.ts
@@ -21,7 +21,7 @@ export class MongoPartRepository extends BaseMongoRepository implements PartRepo
 	}
 
 	public async getParts(segmentId: string): Promise<Part[]> {
-		this.assertDatabaseConnection('getParts')
+		this.assertDatabaseConnection(this.getParts.name)
 		const mongoParts: MongoPart[] = (await this.getCollection()
 			.find({ segmentId: segmentId })
 			.toArray()) as unknown as MongoPart[]

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-piece-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-piece-repository.ts
@@ -16,7 +16,7 @@ export class MongoPieceRepository extends BaseMongoRepository implements PieceRe
 	}
 
 	public async getPieces(partId: string): Promise<Piece[]> {
-		this.assertDatabaseConnection('getPieces')
+		this.assertDatabaseConnection(this.getPieces.name)
 		const mongoPieces: MongoPiece[] = (await this.getCollection()
 			.find({ startPartId: partId })
 			.toArray()) as unknown as MongoPiece[]

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-playlist-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-playlist-repository.ts
@@ -51,11 +51,11 @@ export class MongoRundownPlaylistRepository extends BaseMongoRepository implemen
 
 		const activationStatus = (await cursor.toArray())[0]
 
-		if (Object.entries(activationStatus).length !== 0) {
+		if (Object.entries(activationStatus).length > 0) {
 			rundown.setActiveStatus(true)
+		} else {
+			rundown.setActiveStatus(false)
 		}
-		rundown.setActiveStatus(false)
-
 		return rundown
 	}
 

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-playlist-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-playlist-repository.ts
@@ -1,9 +1,9 @@
-import { RundownRepository } from '../interfaces/rundown-repository'
-import { BaseMongoRepository } from './base-mongo-repository'
-import { Rundown } from '../../../model/entities/rundown'
-import { MongoDatabase } from './mongo-database'
-import { MongoEntityConverter, MongoRundownPlaylist } from './mongo-entity-converter'
-import { BasicRundown } from '../../../model/entities/basic-rundown'
+import {RundownRepository} from '../interfaces/rundown-repository'
+import {BaseMongoRepository} from './base-mongo-repository'
+import {Rundown} from '../../../model/entities/rundown'
+import {MongoDatabase} from './mongo-database'
+import {MongoEntityConverter, MongoRundownPlaylist} from './mongo-entity-converter'
+import {BasicRundown} from '../../../model/entities/basic-rundown'
 
 const RUNDOWN_PLAYLIST_COLLECTION_NAME: string = 'rundownPlaylists'
 
@@ -21,8 +21,8 @@ export class MongoRundownPlaylistRepository extends BaseMongoRepository implemen
 	}
 
 	async getBasicRundowns(): Promise<BasicRundown[]> {
-		this.assertDatabaseConnection('getRundownPlaylists')
-		const rundowns: BasicRundown[] = await this.rundownRepository.getBasicRundowns()
+		this.assertDatabaseConnection(this.getBasicRundowns.name)
+		const basicRundowns: BasicRundown[] = await this.rundownRepository.getBasicRundowns()
 
 		const playlists: MongoRundownPlaylist[] = (await this.getCollection()
 			.find()
@@ -31,30 +31,28 @@ export class MongoRundownPlaylistRepository extends BaseMongoRepository implemen
 
 		const activePlaylist: MongoRundownPlaylist | undefined = playlists.find((playlist) => playlist.activationId)
 		if (!activePlaylist) {
-			return rundowns
+			return basicRundowns
 		}
 
-		const activeRundown: BasicRundown | undefined = rundowns.find(
-			(rundown) => rundown.name === activePlaylist.externalId
+		const basicRundown: BasicRundown | undefined = basicRundowns.find(
+			(basicRundown) => basicRundown.name === activePlaylist.externalId
 		)
-		if (!activeRundown) {
-			return rundowns
+		if (!basicRundown) {
+			return basicRundowns
 		}
 
 		Object.assign(
-			activeRundown,
-			new BasicRundown(activeRundown.id, activeRundown.name, true, activeRundown.getLastTimeModified())
+			basicRundown,
+			new BasicRundown(basicRundown.id, basicRundown.name, true, basicRundown.getLastTimeModified())
 		)
 
-		return rundowns
+		return basicRundowns
 	}
 
 	async getRundown(rundownId: string): Promise<Rundown> {
-		this.assertDatabaseConnection('getRundownPlaylist')
+		this.assertDatabaseConnection(this.getRundown.name)
 		const rundown: Rundown = await this.rundownRepository.getRundown(rundownId)
-		const cursor = this.getCollection().find({ externalId: rundown.name }).project({ _id: 0, activationId: 1 })
-		const activationStatus = (await cursor.toArray())[0]
-		const isRundownActive: boolean = Object.entries(activationStatus).length > 0
+		const isRundownActive = await this.isRundownActive(rundown)
 
 		const activatedRundown: BasicRundown = new BasicRundown(
 			rundown.id,
@@ -64,6 +62,12 @@ export class MongoRundownPlaylistRepository extends BaseMongoRepository implemen
 		)
 		Object.assign(rundown, activatedRundown)
 		return rundown
+	}
+
+	private async isRundownActive(rundown: Rundown) {
+		const cursor = this.getCollection().find({ externalId: rundown.name }).project({ _id: 0, activationId: 1 })
+		const activationStatus = (await cursor.toArray())[0]
+        return Object.entries(activationStatus).length > 0
 	}
 
 	saveRundown(_rundown: Rundown): void {

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-playlist-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-playlist-repository.ts
@@ -1,9 +1,9 @@
-import {RundownRepository} from '../interfaces/rundown-repository'
-import {BaseMongoRepository} from './base-mongo-repository'
-import {Rundown} from '../../../model/entities/rundown'
-import {MongoDatabase} from './mongo-database'
-import {MongoEntityConverter, MongoRundownPlaylist} from './mongo-entity-converter'
-import {BasicRundown} from '../../../model/entities/basic-rundown'
+import { RundownRepository } from '../interfaces/rundown-repository'
+import { BaseMongoRepository } from './base-mongo-repository'
+import { Rundown } from '../../../model/entities/rundown'
+import { MongoDatabase } from './mongo-database'
+import { MongoEntityConverter, MongoRundownPlaylist } from './mongo-entity-converter'
+import { BasicRundown } from '../../../model/entities/basic-rundown'
 
 const RUNDOWN_PLAYLIST_COLLECTION_NAME: string = 'rundownPlaylists'
 
@@ -67,7 +67,7 @@ export class MongoRundownPlaylistRepository extends BaseMongoRepository implemen
 	private async isRundownActive(rundown: Rundown) {
 		const cursor = this.getCollection().find({ externalId: rundown.name }).project({ _id: 0, activationId: 1 })
 		const activationStatus = (await cursor.toArray())[0]
-        return Object.entries(activationStatus).length > 0
+		return Object.entries(activationStatus).length > 0
 	}
 
 	saveRundown(_rundown: Rundown): void {

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-playlist-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-playlist-repository.ts
@@ -1,0 +1,65 @@
+import { RundownRepository } from '../interfaces/rundown-repository'
+import { BaseMongoRepository } from './base-mongo-repository'
+import { Rundown } from '../../../model/entities/rundown'
+import { MongoDatabase } from './mongo-database'
+import { MongoEntityConverter, MongoRundownPlaylist } from './mongo-entity-converter'
+
+const RUNDOWN_PLAYLIST_COLLECTION_NAME: string = 'rundownPlaylists'
+
+export class MongoRundownPlaylistRepository extends BaseMongoRepository implements RundownRepository {
+	constructor(
+		mongoDatabase: MongoDatabase,
+		mongoEntityConverter: MongoEntityConverter,
+		private rundownRepository: RundownRepository
+	) {
+		super(mongoDatabase, mongoEntityConverter)
+	}
+
+	protected getCollectionName(): string {
+		return RUNDOWN_PLAYLIST_COLLECTION_NAME
+	}
+
+	async getBasicRundowns(): Promise<Rundown[]> {
+		this.assertDatabaseConnection('getRundownPlaylists')
+		const rundowns: Rundown[] = await this.rundownRepository.getBasicRundowns()
+
+		const playlists: MongoRundownPlaylist[] = (await this.getCollection()
+			.find()
+			.project({})
+			.toArray()) as unknown as MongoRundownPlaylist[]
+
+		rundowns.forEach((rundown) => {
+			playlists.forEach((playlist) => {
+				if (playlist.externalId !== rundown.name) {
+					return
+				}
+				if (typeof playlist.activationId !== 'undefined') {
+					rundown.setActiveStatus(true)
+				} else {
+					rundown.setActiveStatus(false)
+				}
+			})
+		})
+
+		return rundowns
+	}
+
+	async getRundown(rundownId: string): Promise<Rundown> {
+		this.assertDatabaseConnection('getRundownPlaylist')
+		const rundown: Rundown = await this.rundownRepository.getRundown(rundownId)
+		const cursor = this.getCollection().find({ externalId: rundown.name }).project({ _id: 0, activationId: 1 })
+
+		const activationStatus = (await cursor.toArray())[0]
+
+		if (Object.entries(activationStatus).length !== 0) {
+			rundown.setActiveStatus(true)
+		}
+		rundown.setActiveStatus(false)
+
+		return rundown
+	}
+
+	saveRundown(_rundown: Rundown): void {
+		throw new Error('Not implemented')
+	}
+}

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-repository.ts
@@ -22,20 +22,20 @@ export class MongoRundownRepository extends BaseMongoRepository implements Rundo
 	}
 
 	public async getBasicRundowns(): Promise<BasicRundown[]> {
-		this.assertDatabaseConnection('getRundowns')
-		const rundowns: MongoRundown[] = (await this.getCollection()
+		this.assertDatabaseConnection(this.getBasicRundowns.name)
+		const basicRundowns: MongoRundown[] = (await this.getCollection()
 			.find({})
 			.project({ _id: 1, name: 1, modified: 1 })
 			.toArray()) as unknown as MongoRundown[]
-		return this.mongoEntityConverter.convertBasicRundowns(rundowns)
+		return this.mongoEntityConverter.convertBasicRundowns(basicRundowns)
 	}
 
 	public async getRundown(rundownId: string): Promise<Rundown> {
-		this.assertDatabaseConnection('getRundown')
+		this.assertDatabaseConnection(this.getBasicRundowns.name)
 		const mongoRundown: MongoRundown = (await this.getCollection().findOne({
 			_id: rundownId,
 		})) as unknown as MongoRundown
-		const rundown = this.mongoEntityConverter.convertRundown(mongoRundown)
+		const rundown: Rundown = this.mongoEntityConverter.convertRundown(mongoRundown)
 		rundown.setSegments(await this.segmentRepository.getSegments(rundown.id))
 		return rundown
 	}

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-repository.ts
@@ -4,6 +4,7 @@ import { MongoEntityConverter, MongoRundown } from './mongo-entity-converter'
 import { MongoDatabase } from './mongo-database'
 import { SegmentRepository } from '../interfaces/segment-repository'
 import { BaseMongoRepository } from './base-mongo-repository'
+import { BasicRundown } from '../../../model/entities/basic-rundown'
 
 const RUNDOWN_COLLECTION_NAME: string = 'rundowns'
 
@@ -20,13 +21,13 @@ export class MongoRundownRepository extends BaseMongoRepository implements Rundo
 		return RUNDOWN_COLLECTION_NAME
 	}
 
-	public async getBasicRundowns(): Promise<Rundown[]> {
+	public async getBasicRundowns(): Promise<BasicRundown[]> {
 		this.assertDatabaseConnection('getRundowns')
 		const rundowns: MongoRundown[] = (await this.getCollection()
 			.find({})
 			.project({ _id: 1, name: 1, modified: 1 })
 			.toArray()) as unknown as MongoRundown[]
-		return this.mongoEntityConverter.convertRundowns(rundowns)
+		return this.mongoEntityConverter.convertBasicRundowns(rundowns)
 	}
 
 	public async getRundown(rundownId: string): Promise<Rundown> {

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-repository.ts
@@ -1,10 +1,9 @@
 import { Rundown } from '../../../model/entities/rundown'
 import { RundownRepository } from '../interfaces/rundown-repository'
-import { MongoEntityConverter, MongoIdentifier, MongoRundown } from './mongo-entity-converter'
+import { MongoEntityConverter, MongoRundown } from './mongo-entity-converter'
 import { MongoDatabase } from './mongo-database'
 import { SegmentRepository } from '../interfaces/segment-repository'
 import { BaseMongoRepository } from './base-mongo-repository'
-import { Identifier } from '../../../model/interfaces/identifier'
 
 const RUNDOWN_COLLECTION_NAME: string = 'rundowns'
 
@@ -21,13 +20,13 @@ export class MongoRundownRepository extends BaseMongoRepository implements Rundo
 		return RUNDOWN_COLLECTION_NAME
 	}
 
-	public async getRundownIdentifiers(): Promise<Identifier[]> {
+	public async getBasicRundowns(): Promise<Rundown[]> {
 		this.assertDatabaseConnection('getRundowns')
-		const mongoIdentifiers: MongoIdentifier[] = (await this.getCollection()
+		const rundowns: MongoRundown[] = (await this.getCollection()
 			.find({})
-			.project({ _id: 1, name: 1 })
-			.toArray()) as unknown as MongoIdentifier[]
-		return this.mongoEntityConverter.convertIdentifiers(mongoIdentifiers)
+			.project({ _id: 1, name: 1, modified: 1 })
+			.toArray()) as unknown as MongoRundown[]
+		return this.mongoEntityConverter.convertRundowns(rundowns)
 	}
 
 	public async getRundown(rundownId: string): Promise<Rundown> {

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-repository.ts
@@ -31,7 +31,7 @@ export class MongoRundownRepository extends BaseMongoRepository implements Rundo
 	}
 
 	public async getRundown(rundownId: string): Promise<Rundown> {
-		this.assertDatabaseConnection(this.getBasicRundowns.name)
+		this.assertDatabaseConnection(this.getRundown.name)
 		const mongoRundown: MongoRundown = (await this.getCollection().findOne({
 			_id: rundownId,
 		})) as unknown as MongoRundown

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-segment-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-segment-repository.ts
@@ -21,7 +21,7 @@ export class MongoSegmentRepository extends BaseMongoRepository implements Segme
 	}
 
 	public async getSegments(rundownId: string): Promise<Segment[]> {
-		this.assertDatabaseConnection('getSegments')
+		this.assertDatabaseConnection(this.getSegments.name)
 		const mongoSegments: MongoSegment[] = (await this.getCollection()
 			.find({ rundownId: rundownId })
 			.toArray()) as unknown as MongoSegment[]

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-timeline-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-timeline-repository.ts
@@ -16,7 +16,7 @@ export class MongoTimelineRepository extends BaseMongoRepository implements Time
 	}
 
 	public async saveTimeline(timeline: Timeline): Promise<void> {
-		this.assertDatabaseConnection('saveTimeline')
+		this.assertDatabaseConnection(this.saveTimeline.name)
 		const mongoTimeline: MongoTimeline = this.mongoEntityConverter.convertToMongoTimeline(timeline)
 		await this.getCollection().replaceOne({ _id: mongoTimeline._id }, mongoTimeline)
 	}

--- a/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
+++ b/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
@@ -49,14 +49,14 @@ describe('MongoRundownPlaylistRepository', () => {
 			const result: Rundown = await testee.getRundown(activatedRundown.id)
 
 			expect(result.isActive()).toBe(true)
-		})
+		}, 15000)
 		it('does not have an activationId, return inactive rundown', async () => {
 			const db: Db = await populateDatabase([inactiveRundown])
 			const testee: RundownRepository = await createTestee(db, [inactiveRundown])
 			const result: Rundown = await testee.getRundown(inactiveRundown.id)
 
 			expect(result.isActive()).toBe(false)
-		})
+		}, 15000)
 	})
 	describe('getBasicRundowns', () => {
 		it('returns two rundowns, one is active', async () => {
@@ -66,7 +66,7 @@ describe('MongoRundownPlaylistRepository', () => {
 			const result: BasicRundown[] = await testee.getBasicRundowns()
 
 			expect(result[0].isActive()).toBe(true)
-		})
+		}, 15000)
 		it('returns two rundowns, none are active', async () => {
 			const rundowns: Rundown[] = [inactiveRundown, anotherInactiveRundown]
 			const db: Db = await populateDatabase(rundowns)
@@ -74,7 +74,7 @@ describe('MongoRundownPlaylistRepository', () => {
 			const result: BasicRundown[] = await testee.getBasicRundowns()
 
 			expect(result[0].isActive()).toBe(false)
-		})
+		}, 15000)
 	})
 
 	async function populateDatabase(rundowns: Rundown[]): Promise<Db> {

--- a/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
+++ b/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
@@ -4,6 +4,7 @@ import { MongoEntityConverter } from '../mongo/mongo-entity-converter'
 import { MongoRundownPlaylistRepository } from '../mongo/mongo-rundown-playlist-repository'
 import { RundownRepository } from '../interfaces/rundown-repository'
 import { MongoDatabase } from '../mongo/mongo-database'
+// eslint-disable-next-line node/no-unpublished-import
 import { MongoMemoryServer } from 'mongodb-memory-server'
 import { MongoClient } from 'mongodb'
 
@@ -12,7 +13,7 @@ describe('mongo-rundown-playlist-repository.spec.ts', () => {
 	let client: MongoClient
 
 	beforeEach(async () => {
-		mongoServer = await MongoMemoryServer.create({ instance: { port: 27017 } })
+		mongoServer = await MongoMemoryServer.create()
 		client = await MongoClient.connect(mongoServer.getUri())
 	})
 

--- a/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
+++ b/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
@@ -10,6 +10,7 @@ import { MongoClient, Db } from 'mongodb'
 import { BasicRundown } from '../../../model/entities/basic-rundown'
 
 describe('MongoRundownPlaylistRepository', () => {
+	// Set a timeout beyound the default of 5 Seconds to ensure CI tests don't exceed the limit on GitHub
 	jest.setTimeout(15000)
 	let mongoServer: MongoMemoryServer
 	let client: MongoClient

--- a/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
+++ b/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
@@ -10,6 +10,7 @@ import { MongoClient, Db } from 'mongodb'
 import { BasicRundown } from '../../../model/entities/basic-rundown'
 
 describe('MongoRundownPlaylistRepository', () => {
+	jest.setTimeout(15000)
 	let mongoServer: MongoMemoryServer
 	let client: MongoClient
 	const activatedRundown: Rundown = new Rundown({

--- a/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
+++ b/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
@@ -28,12 +28,12 @@ describe('MongoRundownPlaylistRepository', () => {
 		isRundownActive: false,
 	} as RundownInterface)
 
-	beforeEach(async () => {
+	beforeAll(async () => {
 		mongoServer = await MongoMemoryServer.create()
 		client = await MongoClient.connect(mongoServer.getUri())
 	})
 
-	afterEach(async () => {
+	afterAll(async () => {
 		if (client) {
 			await client.close()
 		}

--- a/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
+++ b/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
@@ -75,7 +75,7 @@ describe('MongoRundownPlaylistRepository', () => {
 
 	async function createTestee(rundowns: Rundown[]): Promise<RundownRepository> {
 		const db: Db = client.db(mongoServer.instanceInfo!.dbName)
-		
+
 		for (const rundown of rundowns) {
 			if (rundown.isActive()) {
 				await db.collection('rundownPlaylists').insertOne({

--- a/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
+++ b/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
@@ -1,5 +1,143 @@
+import { instance, mock, when } from 'ts-mockito'
+import { Rundown, RundownInterface } from '../../../model/entities/rundown'
+import { MongoEntityConverter } from '../mongo/mongo-entity-converter'
+import { MongoRundownPlaylistRepository } from '../mongo/mongo-rundown-playlist-repository'
+import { RundownRepository } from '../interfaces/rundown-repository'
+import { MongoDatabase } from '../mongo/mongo-database'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { MongoClient } from 'mongodb'
+
 describe('mongo-rundown-playlist-repository.spec.ts', () => {
-	describe('getRundown', () => {
-		//it('adds true isActive to rundown from an active corresponding playlist', async () => {})
+	let mongoServer: MongoMemoryServer
+	let client: MongoClient
+
+	beforeEach(async () => {
+		mongoServer = await MongoMemoryServer.create({ instance: { port: 27017 } })
+		client = await MongoClient.connect(mongoServer.getUri())
 	})
+
+	afterEach(async () => {
+		if (client) {
+			await client.close()
+		}
+		if (mongoServer) {
+			await mongoServer.stop()
+		}
+	})
+
+	describe('getRundown', () => {
+		it('has an activationId, return an active rundown', async () => {
+			const rundownId: string = 'activatedRundownId'
+			const testee: MongoRundownPlaylistRepository = await createTesteeForRundown(true, rundownId)
+			const result: Rundown = await testee.getRundown(rundownId)
+
+			expect(result.getActiveStatus()).toBe(true)
+		})
+		it('does not have an activationId, return deactivated rundown', async () => {
+			const rundownId: string = 'deactivatedRundownId'
+			const testee: MongoRundownPlaylistRepository = await createTesteeForRundown(false, rundownId)
+			const result: Rundown = await testee.getRundown(rundownId)
+
+			expect(result.getActiveStatus()).toBe(false)
+		})
+	})
+	describe('getBasicRundowns', () => {
+		it('returns two rundowns, one is active', async () => {
+			const firstRundownId: string = 'firstActivatedRundownId'
+			const secondRundownId: string = 'secondActivatedRundownId'
+			const testee: MongoRundownPlaylistRepository = await createTesteeForTwoRundowns(
+				true,
+				firstRundownId,
+				secondRundownId
+			)
+			const result: Rundown[] = await testee.getBasicRundowns()
+
+			expect(result[0].getActiveStatus()).toBe(true)
+		})
+		it('returns two rundowns, none are active', async () => {
+			const firstRundownId: string = 'firstDeactivatedRundownId'
+			const secondRundownId: string = 'secondDeactivatedRundownId'
+			const testee: MongoRundownPlaylistRepository = await createTesteeForTwoRundowns(
+				false,
+				firstRundownId,
+				secondRundownId
+			)
+			const result: Rundown[] = await testee.getBasicRundowns()
+
+			expect(result[0].getActiveStatus()).toBe(false)
+		})
+	})
+
+	async function createTesteeForRundown(
+		includeActiveRundown: boolean,
+		rundownId: string
+	): Promise<MongoRundownPlaylistRepository> {
+		const db = client.db(mongoServer.instanceInfo!.dbName)
+
+		const rundownName: string = 'INEWS_QUEUE_PATH'
+		const playlistExternalId: string = 'INEWS_QUEUE_PATH'
+
+		const rundown: Rundown = new Rundown({ id: rundownId, name: rundownName } as RundownInterface)
+
+		if (includeActiveRundown) {
+			await db.collection('rundownPlaylists').insertOne({
+				externalId: playlistExternalId,
+				activationId: 'activated',
+			})
+		} else {
+			await db.collection('rundownPlaylists').insertOne({
+				externalId: playlistExternalId,
+			})
+		}
+
+		const rundownRepository: RundownRepository = mock<RundownRepository>()
+		const mongoDb: MongoDatabase = mock(MongoDatabase)
+		const mongoConverter: MongoEntityConverter = mock(MongoEntityConverter)
+
+		when(rundownRepository.getRundown(rundown.id)).thenReturn(Promise.resolve(rundown))
+		when(mongoDb.getCollection('rundownPlaylists')).thenReturn(db.collection('rundownPlaylists'))
+
+		return new MongoRundownPlaylistRepository(instance(mongoDb), mongoConverter, instance(rundownRepository))
+	}
+
+	async function createTesteeForTwoRundowns(
+		includeActivateRundown: boolean,
+		firstRundownId: string,
+		secondRundownId: string
+	): Promise<MongoRundownPlaylistRepository> {
+		const db = client.db(mongoServer.instanceInfo!.dbName)
+
+		const firstRundownName: string = 'INEWS_QUEUE_PATH_ONE'
+		const secondRundownName: string = 'INEWS_QUEUE_PATH_TWO'
+		const firstPlaylistExternalId: string = 'INEWS_QUEUE_PATH_ONE'
+		const secondPlaylistExternalId: string = 'INEWS_QUEUE_PATH_TWO'
+
+		const firstRundown: Rundown = new Rundown({ id: firstRundownId, name: firstRundownName } as RundownInterface)
+		const secondRundown: Rundown = new Rundown({ id: secondRundownId, name: secondRundownName } as RundownInterface)
+
+		const rundowns: Rundown[] = [firstRundown, secondRundown]
+
+		if (includeActivateRundown) {
+			await db.collection('rundownPlaylists').insertOne({
+				externalId: firstPlaylistExternalId,
+				activationId: 'activated',
+			})
+		} else {
+			await db.collection('rundownPlaylists').insertOne({
+				externalId: firstPlaylistExternalId,
+			})
+		}
+		await db.collection('rundownPlaylists').insertOne({
+			externalId: secondPlaylistExternalId,
+		})
+
+		const rundownRepository: RundownRepository = mock<RundownRepository>()
+		const mongoDb: MongoDatabase = mock(MongoDatabase)
+		const mongoConverter: MongoEntityConverter = mock(MongoEntityConverter)
+
+		when(rundownRepository.getBasicRundowns()).thenReturn(Promise.resolve(rundowns))
+		when(mongoDb.getCollection('rundownPlaylists')).thenReturn(db.collection('rundownPlaylists'))
+
+		return new MongoRundownPlaylistRepository(instance(mongoDb), mongoConverter, instance(rundownRepository))
+	}
 })

--- a/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
+++ b/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
@@ -44,41 +44,38 @@ describe('MongoRundownPlaylistRepository', () => {
 
 	describe('getRundown', () => {
 		it('has an activationId, return an active rundown', async () => {
-			const db: Db = await populateDatabase([activatedRundown])
-			const testee: RundownRepository = await createTestee(db, [activatedRundown])
+			const testee: RundownRepository = await createTestee([activatedRundown])
 			const result: Rundown = await testee.getRundown(activatedRundown.id)
 
 			expect(result.isActive()).toBe(true)
-		}, 15000)
+		})
 		it('does not have an activationId, return inactive rundown', async () => {
-			const db: Db = await populateDatabase([inactiveRundown])
-			const testee: RundownRepository = await createTestee(db, [inactiveRundown])
+			const testee: RundownRepository = await createTestee([inactiveRundown])
 			const result: Rundown = await testee.getRundown(inactiveRundown.id)
 
 			expect(result.isActive()).toBe(false)
-		}, 15000)
+		})
 	})
 	describe('getBasicRundowns', () => {
 		it('returns two rundowns, one is active', async () => {
 			const rundowns: Rundown[] = [activatedRundown, inactiveRundown]
-			const db: Db = await populateDatabase(rundowns)
-			const testee: RundownRepository = await createTestee(db, rundowns)
+			const testee: RundownRepository = await createTestee(rundowns)
 			const result: BasicRundown[] = await testee.getBasicRundowns()
 
 			expect(result[0].isActive()).toBe(true)
-		}, 15000)
+		})
 		it('returns two rundowns, none are active', async () => {
 			const rundowns: Rundown[] = [inactiveRundown, anotherInactiveRundown]
-			const db: Db = await populateDatabase(rundowns)
-			const testee: RundownRepository = await createTestee(db, rundowns)
+			const testee: RundownRepository = await createTestee(rundowns)
 			const result: BasicRundown[] = await testee.getBasicRundowns()
 
 			expect(result[0].isActive()).toBe(false)
-		}, 15000)
+		})
 	})
 
-	async function populateDatabase(rundowns: Rundown[]): Promise<Db> {
+	async function createTestee(rundowns: Rundown[]): Promise<RundownRepository> {
 		const db: Db = client.db(mongoServer.instanceInfo!.dbName)
+		
 		for (const rundown of rundowns) {
 			if (rundown.isActive()) {
 				await db.collection('rundownPlaylists').insertOne({
@@ -91,10 +88,7 @@ describe('MongoRundownPlaylistRepository', () => {
 				})
 			}
 		}
-		return db
-	}
 
-	async function createTestee(db: Db, rundowns: Rundown[]): Promise<RundownRepository> {
 		const rundownRepository: RundownRepository = mock<RundownRepository>()
 		const mongoDb: MongoDatabase = mock(MongoDatabase)
 		const mongoConverter: MongoEntityConverter = mock(MongoEntityConverter)

--- a/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
+++ b/meteor/sofie-server/data-access/repositories/test/mongo-rundown-playlist-repository.spec.ts
@@ -1,0 +1,5 @@
+describe('mongo-rundown-playlist-repository.spec.ts', () => {
+	describe('getRundown', () => {
+		//it('adds true isActive to rundown from an active corresponding playlist', async () => {})
+	})
+})

--- a/meteor/sofie-server/model/entities/basic-rundown.ts
+++ b/meteor/sofie-server/model/entities/basic-rundown.ts
@@ -1,0 +1,21 @@
+export class BasicRundown {
+	readonly id: string
+	readonly name: string
+	protected isRundownActive: boolean
+	protected lastTimeModified: number
+
+	constructor(id: string, name: string, isActive: boolean, lastTimeModified: number) {
+		this.id = id
+		this.name = name
+		this.isRundownActive = isActive
+		this.lastTimeModified = lastTimeModified
+	}
+
+	public isActive(): boolean {
+		return this.isRundownActive
+	}
+
+	public getLastTimeModified(): number {
+		return this.lastTimeModified
+	}
+}

--- a/meteor/sofie-server/model/entities/basic-rundown.ts
+++ b/meteor/sofie-server/model/entities/basic-rundown.ts
@@ -2,13 +2,13 @@ export class BasicRundown {
 	readonly id: string
 	readonly name: string
 	protected isRundownActive: boolean
-	protected lastTimeModified: number
+	protected modifiedAt: number
 
-	constructor(id: string, name: string, isActive: boolean, lastTimeModified: number) {
+	constructor(id: string, name: string, isActive: boolean, modifiedAt: number) {
 		this.id = id
 		this.name = name
 		this.isRundownActive = isActive
-		this.lastTimeModified = lastTimeModified
+		this.modifiedAt = modifiedAt
 	}
 
 	public isActive(): boolean {
@@ -16,6 +16,6 @@ export class BasicRundown {
 	}
 
 	public getLastTimeModified(): number {
-		return this.lastTimeModified
+		return this.modifiedAt
 	}
 }

--- a/meteor/sofie-server/model/entities/rundown.ts
+++ b/meteor/sofie-server/model/entities/rundown.ts
@@ -8,22 +8,18 @@ import { NotActivatedException } from '../exceptions/not-activated-exception'
 import { AlreadyActivatedException } from '../exceptions/already-activated-exception'
 import { AdLibPiece } from './ad-lib-piece'
 import { Piece } from './piece'
+import { BasicRundown } from './basic-rundown'
 
 export interface RundownInterface {
 	id: string
 	name: string
 	segments: Segment[]
-	isActive: boolean
+	isRundownActive: boolean
 	lastTimeModified: number
 }
 
-export class Rundown {
-	readonly id: string
-	readonly name: string
-
+export class Rundown extends BasicRundown {
 	private segments: Segment[]
-	private isActive: boolean = false
-	private lastTimeModified: number
 
 	private activeSegment: Segment
 	private activePart: Part
@@ -34,18 +30,15 @@ export class Rundown {
 	private infinitePieces: Map<string, Piece> = new Map()
 
 	constructor(rundown: RundownInterface) {
-		this.id = rundown.id
-		this.name = rundown.name
+		super(rundown.id, rundown.name, rundown.isRundownActive, rundown.lastTimeModified)
 		this.segments = rundown.segments ?? []
-		this.isActive = rundown.isActive
-		this.lastTimeModified = rundown.lastTimeModified
 	}
 
 	public activate(): void {
-		if (this.getActiveStatus()) {
+		if (this.isActive()) {
 			throw new AlreadyActivatedException("Can't activate Rundown since it is already activated")
 		}
-		this.isActive = true
+		this.isRundownActive = true
 
 		this.nextSegment = this.findFirstSegment()
 		this.nextPart = this.nextSegment.findFirstPart()
@@ -110,21 +103,13 @@ export class Rundown {
 		this.activePart.takeOffAir()
 		this.unmarkNextSegmentAndPart()
 		this.infinitePieces = new Map()
-		this.isActive = false
+		this.isRundownActive = false
 	}
 
 	private assertActive(operationName: string): void {
-		if (!this.isActive) {
+		if (!this.isRundownActive) {
 			throw new NotActivatedException(`Rundown "${this.name}" is not active. Unable to ${operationName}`)
 		}
-	}
-
-	public getLastTimeModified(): number {
-		return this.lastTimeModified
-	}
-
-	public setLastTimeModified(timeModified: number): void {
-		this.lastTimeModified = timeModified
 	}
 
 	public getActiveSegment(): Segment {
@@ -145,14 +130,6 @@ export class Rundown {
 	public getNextPart(): Part {
 		this.assertActive('getNextPart')
 		return this.nextPart
-	}
-
-	public getActiveStatus(): boolean {
-		return this.isActive
-	}
-
-	public setActiveStatus(newActiveStatus: boolean): void {
-		this.isActive = newActiveStatus
 	}
 
 	public takeNext(): void {

--- a/meteor/sofie-server/model/entities/rundown.ts
+++ b/meteor/sofie-server/model/entities/rundown.ts
@@ -15,7 +15,7 @@ export interface RundownInterface {
 	name: string
 	segments: Segment[]
 	isRundownActive: boolean
-	lastTimeModified: number
+	modifiedAt: number
 }
 
 export class Rundown extends BasicRundown {
@@ -30,7 +30,7 @@ export class Rundown extends BasicRundown {
 	private infinitePieces: Map<string, Piece> = new Map()
 
 	constructor(rundown: RundownInterface) {
-		super(rundown.id, rundown.name, rundown.isRundownActive, rundown.lastTimeModified)
+		super(rundown.id, rundown.name, rundown.isRundownActive, rundown.modifiedAt)
 		this.segments = rundown.segments ?? []
 	}
 

--- a/meteor/sofie-server/model/entities/rundown.ts
+++ b/meteor/sofie-server/model/entities/rundown.ts
@@ -14,6 +14,7 @@ export interface RundownInterface {
 	name: string
 	segments: Segment[]
 	isActive: boolean
+	lastTimeModified: number
 }
 
 export class Rundown {
@@ -21,7 +22,8 @@ export class Rundown {
 	readonly name: string
 
 	private segments: Segment[]
-	private isRundownActive: boolean = false
+	private isActive: boolean = false
+	private lastTimeModified: number
 
 	private activeSegment: Segment
 	private activePart: Part
@@ -35,14 +37,15 @@ export class Rundown {
 		this.id = rundown.id
 		this.name = rundown.name
 		this.segments = rundown.segments ?? []
-		this.isRundownActive = rundown.isActive
+		this.isActive = rundown.isActive
+		this.lastTimeModified = rundown.lastTimeModified
 	}
 
 	public activate(): void {
-		if (this.isActive()) {
+		if (this.getActiveStatus()) {
 			throw new AlreadyActivatedException("Can't activate Rundown since it is already activated")
 		}
-		this.isRundownActive = true
+		this.isActive = true
 
 		this.nextSegment = this.findFirstSegment()
 		this.nextPart = this.nextSegment.findFirstPart()
@@ -107,13 +110,21 @@ export class Rundown {
 		this.activePart.takeOffAir()
 		this.unmarkNextSegmentAndPart()
 		this.infinitePieces = new Map()
-		this.isRundownActive = false
+		this.isActive = false
 	}
 
 	private assertActive(operationName: string): void {
-		if (!this.isRundownActive) {
+		if (!this.isActive) {
 			throw new NotActivatedException(`Rundown "${this.name}" is not active. Unable to ${operationName}`)
 		}
+	}
+
+	public getLastTimeModified(): number {
+		return this.lastTimeModified
+	}
+
+	public setLastTimeModified(timeModified: number): void {
+		this.lastTimeModified = timeModified
 	}
 
 	public getActiveSegment(): Segment {
@@ -136,8 +147,12 @@ export class Rundown {
 		return this.nextPart
 	}
 
-	public isActive(): boolean {
-		return this.isRundownActive
+	public getActiveStatus(): boolean {
+		return this.isActive
+	}
+
+	public setActiveStatus(newActiveStatus: boolean): void {
+		this.isActive = newActiveStatus
 	}
 
 	public takeNext(): void {

--- a/meteor/sofie-server/presentation/controllers/rundown-controller.ts
+++ b/meteor/sofie-server/presentation/controllers/rundown-controller.ts
@@ -6,6 +6,7 @@ import { Rundown } from '../../model/entities/rundown'
 import { RundownDto } from '../dtos/rundown-dto'
 import { Exception } from '../../model/exceptions/exception'
 import { HttpErrorHandler } from '../interfaces/http-error-handler'
+import { BasicRundown } from '../../model/entities/basic-rundown'
 
 @RestController('/rundowns')
 export class RundownController extends BaseController {
@@ -20,8 +21,8 @@ export class RundownController extends BaseController {
 	@GetRequest('/basic')
 	public async getBasicRundowns(_reg: Request, res: Response): Promise<void> {
 		try {
-			const basicRundowns: Rundown[] = await this.rundownRepository.getBasicRundowns()
-			res.send(basicRundowns.map((rundown) => new RundownDto(rundown)))
+			const basicRundowns: BasicRundown[] = await this.rundownRepository.getBasicRundowns()
+			res.send(basicRundowns)
 		} catch (error) {
 			this.httpErrorHandler.handleError(res, error as Exception)
 		}

--- a/meteor/sofie-server/presentation/controllers/rundown-controller.ts
+++ b/meteor/sofie-server/presentation/controllers/rundown-controller.ts
@@ -5,7 +5,6 @@ import { RundownRepository } from '../../data-access/repositories/interfaces/run
 import { Rundown } from '../../model/entities/rundown'
 import { RundownDto } from '../dtos/rundown-dto'
 import { Exception } from '../../model/exceptions/exception'
-import { Identifier } from '../../model/interfaces/identifier'
 import { HttpErrorHandler } from '../interfaces/http-error-handler'
 
 @RestController('/rundowns')
@@ -18,11 +17,11 @@ export class RundownController extends BaseController {
 		super()
 	}
 
-	@GetRequest('/identifiers')
-	public async getRundownIdentifiers(_reg: Request, res: Response): Promise<void> {
+	@GetRequest('/basic')
+	public async getBasicRundowns(_reg: Request, res: Response): Promise<void> {
 		try {
-			const rundownIdentifiers: Identifier[] = await this.rundownRepository.getRundownIdentifiers()
-			res.send(rundownIdentifiers)
+			const basicRundowns: Rundown[] = await this.rundownRepository.getBasicRundowns()
+			res.send(basicRundowns.map((rundown) => new RundownDto(rundown)))
 		} catch (error) {
 			this.httpErrorHandler.handleError(res, error as Exception)
 		}

--- a/meteor/sofie-server/presentation/dtos/rundown-dto.ts
+++ b/meteor/sofie-server/presentation/dtos/rundown-dto.ts
@@ -13,7 +13,7 @@ export class RundownDto {
 	constructor(rundown: Rundown) {
 		this.id = rundown.id
 		this.name = rundown.name
-		this.isActive = rundown.getActiveStatus()
+		this.isActive = rundown.isActive()
 		this.infinitePieces = rundown.getInfinitePieces().map((piece) => new PieceDto(piece))
 		this.segments = rundown.getSegments().map((segment) => new SegmentDto(segment))
 		this.lastTimeModified = rundown.getLastTimeModified()

--- a/meteor/sofie-server/presentation/dtos/rundown-dto.ts
+++ b/meteor/sofie-server/presentation/dtos/rundown-dto.ts
@@ -8,12 +8,14 @@ export class RundownDto {
 	readonly isActive: boolean
 	readonly infinitePieces: PieceDto[]
 	readonly segments: SegmentDto[]
+	readonly lastTimeModified: number
 
 	constructor(rundown: Rundown) {
 		this.id = rundown.id
 		this.name = rundown.name
-		this.isActive = rundown.isActive()
+		this.isActive = rundown.getActiveStatus()
 		this.infinitePieces = rundown.getInfinitePieces().map((piece) => new PieceDto(piece))
 		this.segments = rundown.getSegments().map((segment) => new SegmentDto(segment))
+		this.lastTimeModified = rundown.getLastTimeModified()
 	}
 }

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -19,6 +19,418 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@aws-crypto/crc32@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-3.0.0.tgz#07300eca214409c33e3ff769cd5697b57fdd38fa"
+  integrity sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==
+  dependencies:
+    "@aws-crypto/util" "^3.0.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/ie11-detection@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz#640ae66b4ec3395cee6a8e94ebcd9f80c24cd688"
+  integrity sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-browser@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz#05f160138ab893f1c6ba5be57cfd108f05827766"
+  integrity sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^3.0.0"
+    "@aws-crypto/sha256-js" "^3.0.0"
+    "@aws-crypto/supports-web-crypto" "^3.0.0"
+    "@aws-crypto/util" "^3.0.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@3.0.0", "@aws-crypto/sha256-js@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz#f06b84d550d25521e60d2a0e2a90139341e007c2"
+  integrity sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==
+  dependencies:
+    "@aws-crypto/util" "^3.0.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/supports-web-crypto@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz#5d1bf825afa8072af2717c3e455f35cda0103ec2"
+  integrity sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-3.0.0.tgz#1c7ca90c29293f0883468ad48117937f0fe5bfb0"
+  integrity sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==
+  dependencies:
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-sdk/client-cognito-identity@3.386.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.386.0.tgz#aae2537afb590ad0ea928e6e26acf7c8989446d0"
+  integrity sha512-greo255LzFJI2rMwOuAywb+CkO8iKNp058Ve4E4F1Xp/ipOoc9UnzQuO+99N/1PbRnph55qYbM8D2WE2cokx0Q==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/client-sts" "3.386.0"
+    "@aws-sdk/credential-provider-node" "3.386.0"
+    "@aws-sdk/middleware-host-header" "3.379.1"
+    "@aws-sdk/middleware-logger" "3.378.0"
+    "@aws-sdk/middleware-recursion-detection" "3.378.0"
+    "@aws-sdk/middleware-signing" "3.379.1"
+    "@aws-sdk/middleware-user-agent" "3.386.0"
+    "@aws-sdk/types" "3.378.0"
+    "@aws-sdk/util-endpoints" "3.386.0"
+    "@aws-sdk/util-user-agent-browser" "3.378.0"
+    "@aws-sdk/util-user-agent-node" "3.378.0"
+    "@smithy/config-resolver" "^2.0.1"
+    "@smithy/fetch-http-handler" "^2.0.1"
+    "@smithy/hash-node" "^2.0.1"
+    "@smithy/invalid-dependency" "^2.0.1"
+    "@smithy/middleware-content-length" "^2.0.1"
+    "@smithy/middleware-endpoint" "^2.0.1"
+    "@smithy/middleware-retry" "^2.0.1"
+    "@smithy/middleware-serde" "^2.0.1"
+    "@smithy/middleware-stack" "^2.0.0"
+    "@smithy/node-config-provider" "^2.0.1"
+    "@smithy/node-http-handler" "^2.0.1"
+    "@smithy/protocol-http" "^2.0.1"
+    "@smithy/smithy-client" "^2.0.1"
+    "@smithy/types" "^2.0.2"
+    "@smithy/url-parser" "^2.0.1"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.0.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.1"
+    "@smithy/util-defaults-mode-node" "^2.0.1"
+    "@smithy/util-retry" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/client-sso@3.386.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.386.0.tgz#b3ca3d92d1b618f1a35ff2cec40501d88dcc7c7e"
+  integrity sha512-UBgRo0q/XSle9CHCpoFhzq9wCfdc4kJw40cpPoHJPbb5m3JMcDu0mq4LTY7Nwnoy9jBThfRVYf3EF2BMF8fo6A==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/middleware-host-header" "3.379.1"
+    "@aws-sdk/middleware-logger" "3.378.0"
+    "@aws-sdk/middleware-recursion-detection" "3.378.0"
+    "@aws-sdk/middleware-user-agent" "3.386.0"
+    "@aws-sdk/types" "3.378.0"
+    "@aws-sdk/util-endpoints" "3.386.0"
+    "@aws-sdk/util-user-agent-browser" "3.378.0"
+    "@aws-sdk/util-user-agent-node" "3.378.0"
+    "@smithy/config-resolver" "^2.0.1"
+    "@smithy/fetch-http-handler" "^2.0.1"
+    "@smithy/hash-node" "^2.0.1"
+    "@smithy/invalid-dependency" "^2.0.1"
+    "@smithy/middleware-content-length" "^2.0.1"
+    "@smithy/middleware-endpoint" "^2.0.1"
+    "@smithy/middleware-retry" "^2.0.1"
+    "@smithy/middleware-serde" "^2.0.1"
+    "@smithy/middleware-stack" "^2.0.0"
+    "@smithy/node-config-provider" "^2.0.1"
+    "@smithy/node-http-handler" "^2.0.1"
+    "@smithy/protocol-http" "^2.0.1"
+    "@smithy/smithy-client" "^2.0.1"
+    "@smithy/types" "^2.0.2"
+    "@smithy/url-parser" "^2.0.1"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.0.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.1"
+    "@smithy/util-defaults-mode-node" "^2.0.1"
+    "@smithy/util-retry" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/client-sts@3.386.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.386.0.tgz#fa86792ab31c810af0a1cad3a5bcdf254c12d67b"
+  integrity sha512-VK+tdZaI971IDP/1WqpYNorf+Q5uoJTqcp3y/bQY4Hr5bf8N3aztDrX7a2GaA07zgSdUa82VkScMKzW31jhsxw==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/credential-provider-node" "3.386.0"
+    "@aws-sdk/middleware-host-header" "3.379.1"
+    "@aws-sdk/middleware-logger" "3.378.0"
+    "@aws-sdk/middleware-recursion-detection" "3.378.0"
+    "@aws-sdk/middleware-sdk-sts" "3.379.1"
+    "@aws-sdk/middleware-signing" "3.379.1"
+    "@aws-sdk/middleware-user-agent" "3.386.0"
+    "@aws-sdk/types" "3.378.0"
+    "@aws-sdk/util-endpoints" "3.386.0"
+    "@aws-sdk/util-user-agent-browser" "3.378.0"
+    "@aws-sdk/util-user-agent-node" "3.378.0"
+    "@smithy/config-resolver" "^2.0.1"
+    "@smithy/fetch-http-handler" "^2.0.1"
+    "@smithy/hash-node" "^2.0.1"
+    "@smithy/invalid-dependency" "^2.0.1"
+    "@smithy/middleware-content-length" "^2.0.1"
+    "@smithy/middleware-endpoint" "^2.0.1"
+    "@smithy/middleware-retry" "^2.0.1"
+    "@smithy/middleware-serde" "^2.0.1"
+    "@smithy/middleware-stack" "^2.0.0"
+    "@smithy/node-config-provider" "^2.0.1"
+    "@smithy/node-http-handler" "^2.0.1"
+    "@smithy/protocol-http" "^2.0.1"
+    "@smithy/smithy-client" "^2.0.1"
+    "@smithy/types" "^2.0.2"
+    "@smithy/url-parser" "^2.0.1"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.0.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.1"
+    "@smithy/util-defaults-mode-node" "^2.0.1"
+    "@smithy/util-retry" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    fast-xml-parser "4.2.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-cognito-identity@3.386.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.386.0.tgz#d46419ad7231b9f3e7776d986d1a4f638072f27b"
+  integrity sha512-bH160dPWs5Sz1duZL5OW6IEeJK36lxiGuYpmhAu7yndnyXszoBPtFXjWR3c4smE4VawEBdPY8mFxwrW1Ah794g==
+  dependencies:
+    "@aws-sdk/client-cognito-identity" "3.386.0"
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-env@3.378.0":
+  version "3.378.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.378.0.tgz#a0f6291eff4e002c140599acede2433f58e4f4cb"
+  integrity sha512-B2OVdO9kBClDwGgWTBLAQwFV8qYTYGyVujg++1FZFSFMt8ORFdZ5fNpErvJtiSjYiOOQMzyBeSNhKyYNXCiJjQ==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-ini@3.386.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.386.0.tgz#39699906eeda97e8e951dba5daed0571dd0224b5"
+  integrity sha512-TDeOFwCq6Ri58OP4CvVIAbc+iJPld7TpOFB+YYQ+q0ut+92zaVTNrNoWZkygPCXKmeHUGZcwC9Mjt/4L+fBAkg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.378.0"
+    "@aws-sdk/credential-provider-process" "3.378.0"
+    "@aws-sdk/credential-provider-sso" "3.386.0"
+    "@aws-sdk/credential-provider-web-identity" "3.378.0"
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/credential-provider-imds" "^2.0.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-node@3.386.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.386.0.tgz#0993fa01bb0c5993c361aa9449ba7eafb6e93b5c"
+  integrity sha512-dvYSN+T1B96TqiZE5tBV8bHCNU6TKq5meeI06AdClHz3VPvPKDN/EL0undXpl/GnlvuhKUftmVwdUBefG3otZA==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.378.0"
+    "@aws-sdk/credential-provider-ini" "3.386.0"
+    "@aws-sdk/credential-provider-process" "3.378.0"
+    "@aws-sdk/credential-provider-sso" "3.386.0"
+    "@aws-sdk/credential-provider-web-identity" "3.378.0"
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/credential-provider-imds" "^2.0.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-process@3.378.0":
+  version "3.378.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.378.0.tgz#8fd594c9600f9e4b7121f3cf2cea13b4d37f09e5"
+  integrity sha512-KFTIy7u+wXj3eDua4rgS0tODzMnXtXhAm1RxzCW9FL5JLBBrd82ymCj1Dp72217Sw5Do6NjCnDTTNkCHZMA77w==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-sso@3.386.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.386.0.tgz#363d28f9bf2366e132efdcff3ec51c4c17796e6a"
+  integrity sha512-7PvtrxMFpphQP8D5Zu5WpqZ/p7FBWiOQ2UQhzGKEry/9JIyTKiIZWsCu7OIWcfEx8RqSnLu3pDydc6HSTNs+lw==
+  dependencies:
+    "@aws-sdk/client-sso" "3.386.0"
+    "@aws-sdk/token-providers" "3.386.0"
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-web-identity@3.378.0":
+  version "3.378.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.378.0.tgz#019db9f17bd9fb2fd9a4171fe3b443c9e049a70a"
+  integrity sha512-GWjydOszhc4xDF8xuPtBvboglXQr0gwCW1oHAvmLcOT38+Hd6qnKywnMSeoXYRPgoKfF9TkWQgW1jxplzCG0UA==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-providers@^3.186.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-providers/-/credential-providers-3.386.0.tgz#dc52a2ec57151821252077aa7ff7e6c33c5cffde"
+  integrity sha512-e5v6uP4bz34rWjiBL5GeaC1Rqw5Oqs3vTLbtuhAXyLYy2MfM39DVqK6ccwyqu053WPIfLzsK6boaOBohRdlg3Q==
+  dependencies:
+    "@aws-sdk/client-cognito-identity" "3.386.0"
+    "@aws-sdk/client-sso" "3.386.0"
+    "@aws-sdk/client-sts" "3.386.0"
+    "@aws-sdk/credential-provider-cognito-identity" "3.386.0"
+    "@aws-sdk/credential-provider-env" "3.378.0"
+    "@aws-sdk/credential-provider-ini" "3.386.0"
+    "@aws-sdk/credential-provider-node" "3.386.0"
+    "@aws-sdk/credential-provider-process" "3.378.0"
+    "@aws-sdk/credential-provider-sso" "3.386.0"
+    "@aws-sdk/credential-provider-web-identity" "3.378.0"
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/credential-provider-imds" "^2.0.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-host-header@3.379.1":
+  version "3.379.1"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.379.1.tgz#26d8af6100de4e03d201553360dfe16e10ae1aa5"
+  integrity sha512-LI4KpAFWNWVr2aH2vRVblr0Y8tvDz23lj8LOmbDmCrzd5M21nxuocI/8nEAQj55LiTIf9Zs+dHCdsyegnFXdrA==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/protocol-http" "^2.0.1"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-logger@3.378.0":
+  version "3.378.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.378.0.tgz#f27fe3a979f3ef49034a860aa2c38c8a16faa879"
+  integrity sha512-l1DyaDLm3KeBMNMuANI3scWh8Xvu248x+vw6Z7ExWOhGXFmQ1MW7YvASg/SdxWkhlF9HmkkTif1LdMB22x6QDA==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-recursion-detection@3.378.0":
+  version "3.378.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.378.0.tgz#706f505f608a766d617fbdad20ca30a7abccb311"
+  integrity sha512-mUMfHAz0oGNIWiTZHTVJb+I515Hqs2zx1j36Le4MMiiaMkPW1SRUF1FIwGuc1wh6E8jB5q+XfEMriDjRi4TZRA==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/protocol-http" "^2.0.1"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-sdk-sts@3.379.1":
+  version "3.379.1"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.379.1.tgz#4238aa2fa4ad4b0f7e0f6bb08d7c131b7d6a2baa"
+  integrity sha512-SK3gSyT0XbLiY12+AjLFYL9YngxOXHnZF3Z33Cdd4a+AUYrVBV7JBEEGD1Nlwrcmko+3XgaKlmgUaR5s91MYvg==
+  dependencies:
+    "@aws-sdk/middleware-signing" "3.379.1"
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-signing@3.379.1":
+  version "3.379.1"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.379.1.tgz#ebb7912868076babec851f9f703862dae6583a89"
+  integrity sha512-kBk2ZUvR84EM4fICjr8K+Ykpf8SI1UzzPp2/UVYZ0X+4H/ZCjfSqohGRwHykMqeplne9qHSL7/rGJs1H3l3gPg==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/protocol-http" "^2.0.1"
+    "@smithy/signature-v4" "^2.0.0"
+    "@smithy/types" "^2.0.2"
+    "@smithy/util-middleware" "^2.0.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-user-agent@3.386.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.386.0.tgz#e245d0e6263035b624904d2a39ee6e6edf837bae"
+  integrity sha512-h6nVr5dvzrSLM+5BGbyqISh1p2NoTNv0+IZkMcGyig2jpdhbkMOPvvoOGMg16/cmelUQCguT26Jr7WYpLFDsTg==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@aws-sdk/util-endpoints" "3.386.0"
+    "@smithy/protocol-http" "^2.0.1"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/token-providers@3.386.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.386.0.tgz#8a6bae85a74bc336389a9f2e9fc3b3aa87b54afe"
+  integrity sha512-DStdqBtpO0FRC4mDCIPtrpLCFMnYJFo4cYlUyr9CKvKvh2IzPMU4rsKQjUhtmzdjLEvPTAcdfRx2Q9/sJkfe9Q==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.0"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/types@3.378.0", "@aws-sdk/types@^3.222.0":
+  version "3.378.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.378.0.tgz#93a811ccdf15c81b1947f1cd67922c4690792189"
+  integrity sha512-qP0CvR/ItgktmN8YXpGQglzzR/6s0nrsQ4zIfx3HMwpsBTwuouYahcCtF1Vr82P4NFcoDA412EJahJ2pIqEd+w==
+  dependencies:
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/util-endpoints@3.386.0":
+  version "3.386.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.386.0.tgz#a8477dedfa4c64822b8f57ddf11286b5770646a8"
+  integrity sha512-FDQRC9f78Kx12KsR43MukLRfqF3BNz5VfFdKP9ZYx3KK+bMjU1czjmjOS8bNMJWYM1Sn+nobBpPS3e2uupBtpg==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.310.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz#b071baf050301adee89051032bd4139bba32cc40"
+  integrity sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==
+  dependencies:
+    tslib "^2.5.0"
+
+"@aws-sdk/util-user-agent-browser@3.378.0":
+  version "3.378.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.378.0.tgz#e756215da5bd1654a308b4e5383ebdcfc938fb0a"
+  integrity sha512-FSCpagzftK1W+m7Ar6lpX7/Gr9y5P56nhFYz8U4EYQ4PkufS6czWX9YW+/FA5OYV0vlQ/SvPqMnzoHIPUNhZrQ==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/types" "^2.0.2"
+    bowser "^2.11.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/util-user-agent-node@3.378.0":
+  version "3.378.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.378.0.tgz#7af728f1823e860853998166a2bda0f0044251ef"
+  integrity sha512-IdwVJV0E96MkJeFte4dlWqvB+oiqCiZ5lOlheY3W9NynTuuX0GGYNC8Y9yIsV8Oava1+ujpJq0ww6qXdYxmO4A==
+  dependencies:
+    "@aws-sdk/types" "3.378.0"
+    "@smithy/node-config-provider" "^2.0.1"
+    "@smithy/types" "^2.0.2"
+    tslib "^2.5.0"
+
+"@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.259.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz#3275a6f5eb334f96ca76635b961d3c50259fd9ff"
+  integrity sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==
+  dependencies:
+    tslib "^2.3.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -1180,6 +1592,346 @@
     "@types/node" ">=12.0.0"
     axios "^0.21.4"
 
+"@smithy/abort-controller@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-2.0.2.tgz#e2188247a1723b58d60b0803f3ba24b76a714413"
+  integrity sha512-ln5Cob0mksym62sLr7NiPOSqJ0jKao4qjfcNLDdgINM1lQI12hXrZBlKdPHbXJqpKhKiECDgonMoqCM8bigq4g==
+  dependencies:
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/config-resolver@^2.0.1", "@smithy/config-resolver@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-2.0.2.tgz#64496d2f2f9f1482d2e982d3dc057dccc4ba97db"
+  integrity sha512-0kdsqBL6BdmSbdU6YaDkodVBMua5MuQQluC3nocJ7OJ6PnOuM7i2FEQHE46LBadLqT+CimlDSM+6j91uHNL1ng==
+  dependencies:
+    "@smithy/types" "^2.1.0"
+    "@smithy/util-config-provider" "^2.0.0"
+    "@smithy/util-middleware" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/credential-provider-imds@^2.0.0", "@smithy/credential-provider-imds@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.2.tgz#9096ff1a2ceb235497a62d469ac70086b96022ad"
+  integrity sha512-mbWFYEZ00LBRDk3WvcXViwpdpkJQcfrM3seuKzFxZnF6wIBLMwrcWcsj+OUC/1L+86m8aQY9imXMAaQsAoGxow==
+  dependencies:
+    "@smithy/node-config-provider" "^2.0.2"
+    "@smithy/property-provider" "^2.0.2"
+    "@smithy/types" "^2.1.0"
+    "@smithy/url-parser" "^2.0.2"
+    tslib "^2.5.0"
+
+"@smithy/eventstream-codec@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-2.0.2.tgz#9d81c8d081ac28ba098d98b06cbb39955af1e09b"
+  integrity sha512-PQZiKx7fMnNwx4zxcUCm82VjnqK6wV4MEHSmMy3taj5dKfXV782IjRGyaDT+8TsmNqVdZIkve5zLRAzh+7kOhA==
+  dependencies:
+    "@aws-crypto/crc32" "3.0.0"
+    "@smithy/types" "^2.1.0"
+    "@smithy/util-hex-encoding" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/fetch-http-handler@^2.0.1", "@smithy/fetch-http-handler@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.2.tgz#dcc0e9d365efd8feef4a54dd96a264735a1446b7"
+  integrity sha512-Wo2m1RaiXNSLF4J3D62LpdSoj/YYb+6tn0H8is1tSrzr7eXAdiYVBc0wIa23N0wT4zmN0iG/yNY6gTCDQ6799A==
+  dependencies:
+    "@smithy/protocol-http" "^2.0.2"
+    "@smithy/querystring-builder" "^2.0.2"
+    "@smithy/types" "^2.1.0"
+    "@smithy/util-base64" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/hash-node@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-2.0.2.tgz#e968a3e7ab7072bd12297063e3770ae6d9249dee"
+  integrity sha512-JKDzZ1YVR7JzOBaJoWy3ToJCE86OQE6D4kOBvvVsu93a3lcF9kv6KYTKBYEWAjwOn/CpK4NH7mKB01OQ8H+aiA==
+  dependencies:
+    "@smithy/types" "^2.1.0"
+    "@smithy/util-buffer-from" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/invalid-dependency@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/invalid-dependency/-/invalid-dependency-2.0.2.tgz#1f7b6a860395e9f11fcdbdf3ac22fb95ce863c69"
+  integrity sha512-inQZQ5gCO3WRWuXpsc1YJ4KBjsvj2qsoU32yTIKznBWTCQe/D5Dp+sSaysqBqxe0VTZ+8nFEHdUMWUX2BxQThw==
+  dependencies:
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/is-array-buffer@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz#8fa9b8040651e7ba0b2f6106e636a91354ff7d34"
+  integrity sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/middleware-content-length@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-2.0.2.tgz#6167e8ca52cb5f2b06d3c76fa445080c45baaf25"
+  integrity sha512-FmHlNfuvYgDZE3fIx0G3rD/wLXfAmBYE4mVc/w6d7RllA7TygPzq2pfHL1iCMzWkWTdoAVnt3h4aavAZnhaxEQ==
+  dependencies:
+    "@smithy/protocol-http" "^2.0.2"
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/middleware-endpoint@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.2.tgz#29f4c8ae799ffb0891f96148eb754f8d0a41a97c"
+  integrity sha512-ropE7/c+g22QeluZ+By/B/WvVep0UFreX+IeRMGIO7EbOUPgqtJRXpbJFdG6JKB1uC+CdaJLn4MnZnVBpcyjuA==
+  dependencies:
+    "@smithy/middleware-serde" "^2.0.2"
+    "@smithy/types" "^2.1.0"
+    "@smithy/url-parser" "^2.0.2"
+    "@smithy/util-middleware" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/middleware-retry@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-2.0.2.tgz#0d6feb551a5d546c720106435d2a4e7878fd8ea2"
+  integrity sha512-wtBUXqtZVriiXppYaFkUrybAPhFVX7vebnW/yVPliLMWMcguOMS58qhOYPZe3t9Wki2+mASfyu+kO3An8lAg2A==
+  dependencies:
+    "@smithy/protocol-http" "^2.0.2"
+    "@smithy/service-error-classification" "^2.0.0"
+    "@smithy/types" "^2.1.0"
+    "@smithy/util-middleware" "^2.0.0"
+    "@smithy/util-retry" "^2.0.0"
+    tslib "^2.5.0"
+    uuid "^8.3.2"
+
+"@smithy/middleware-serde@^2.0.1", "@smithy/middleware-serde@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-serde/-/middleware-serde-2.0.2.tgz#a59f74e981be8b76ef18e272d525e24e3974dc82"
+  integrity sha512-Kw9xLdlueIaivUWslKB67WZ/cCUg3QnzYVIA3t5KfgsseEEuU4UxXw8NSTvIt71gqQloY+Um8ugS+idgxrWWnw==
+  dependencies:
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/middleware-stack@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz#cd9f442c2788b1ef0ea6b32236d80c76b3c342e9"
+  integrity sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/node-config-provider@^2.0.1", "@smithy/node-config-provider@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-2.0.2.tgz#a15f125f7011ff82610297d899826b7ef7889867"
+  integrity sha512-9wVJccASfuCctNWrzR0zrDkf0ox3HCHGEhFlWL2LBoghUYuK28pVRBbG69wvnkhlHnB8dDZHagxH+Nq9dm7eWw==
+  dependencies:
+    "@smithy/property-provider" "^2.0.2"
+    "@smithy/shared-ini-file-loader" "^2.0.2"
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/node-http-handler@^2.0.1", "@smithy/node-http-handler@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-2.0.2.tgz#3c4d43352f5412cdb23ca075327ac997f5b03df2"
+  integrity sha512-lpZjmtmyZqSAtMPsbrLhb7XoAQ2kAHeuLY/csW6I2k+QyFvOk7cZeQsqEngWmZ9SJaeYiDCBINxAIM61i5WGLw==
+  dependencies:
+    "@smithy/abort-controller" "^2.0.2"
+    "@smithy/protocol-http" "^2.0.2"
+    "@smithy/querystring-builder" "^2.0.2"
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/property-provider@^2.0.0", "@smithy/property-provider@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/property-provider/-/property-provider-2.0.2.tgz#abe091d1e7dc5b617e3418b63eaed11363c96f21"
+  integrity sha512-DfaZ8cO+d/mgnMzIllcXcU4OYP+omiOl2LYdn/fTGpw/EAQSVzscYV2muV3sDDnuPYQ/r014hUqIxnF+pzh+SQ==
+  dependencies:
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/protocol-http@^2.0.1", "@smithy/protocol-http@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-2.0.2.tgz#ec3d45a650cb5554b6aba1c38768f51fc9cf79b5"
+  integrity sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==
+  dependencies:
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/querystring-builder@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-2.0.2.tgz#67a1bb503037c4666b5df56ad4b9e10bc525f568"
+  integrity sha512-H99LOMWEssfwqkOoTs4Y12UiZ7CTGQSX5Nrx5UkYgRbUEpC1GnnaprHiYrqclC58/xr4K76aNchdPyioxewMzA==
+  dependencies:
+    "@smithy/types" "^2.1.0"
+    "@smithy/util-uri-escape" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/querystring-parser@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-parser/-/querystring-parser-2.0.2.tgz#d6b2562e7ae29282b144939e5fd439b17bdf61dd"
+  integrity sha512-L4VtKQ8O4/aWPQJbiFymbhAmxdfLnEaROh/Vs0OstJ7jtOZeBl2QJmuWY2V7hjt64W7V+tEn2sv6vVvnxkm/xQ==
+  dependencies:
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/service-error-classification@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz#bbce07c9c529d9333d40db881fd4a1795dd84892"
+  integrity sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==
+
+"@smithy/shared-ini-file-loader@^2.0.0", "@smithy/shared-ini-file-loader@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.2.tgz#49b9bf384ece821352f50c8f6cb989edc77d2dbf"
+  integrity sha512-2VkNOM/82u4vatVdK5nfusgGIlvR48Fkq6me17Oc+V1iyxfR/1x0pG6LzW0br1qlGtzBYFZKmDyviBRcPVFTVw==
+  dependencies:
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/signature-v4@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-2.0.2.tgz#c1ec6d9485a72039060e9a8fe2c02e0afb9d7764"
+  integrity sha512-YMooDEw/UmGxcXY4qWnSXkbPFsRloluSvyXVT678YPDN/K2AS1GzKfRsvSU7fbccOB4WF8MHZf2UqcRGEltE3Q==
+  dependencies:
+    "@smithy/eventstream-codec" "^2.0.2"
+    "@smithy/is-array-buffer" "^2.0.0"
+    "@smithy/types" "^2.1.0"
+    "@smithy/util-hex-encoding" "^2.0.0"
+    "@smithy/util-middleware" "^2.0.0"
+    "@smithy/util-uri-escape" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/smithy-client@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-2.0.2.tgz#3364bfb4afa73d57712b95cb9319f7c8324a104e"
+  integrity sha512-mDfokI8WwLU5C0gcQ4ww/zJI/WLGSh2+vdIA42JRnjfYUjJNH/rKfX9YOnn2eBOxl3loATERVUqkHmKe+P8s2Q==
+  dependencies:
+    "@smithy/middleware-stack" "^2.0.0"
+    "@smithy/types" "^2.1.0"
+    "@smithy/util-stream" "^2.0.2"
+    tslib "^2.5.0"
+
+"@smithy/types@^2.0.2", "@smithy/types@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-2.1.0.tgz#67fd47c25bbb0fd818951891bf7bcf19a8ee2fe6"
+  integrity sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/url-parser@^2.0.1", "@smithy/url-parser@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-2.0.2.tgz#af50bd62298b209b1a16c80912a03460b7cb8994"
+  integrity sha512-X1mHCzrSVDlhVy7d3S7Vq+dTfYzwh4n7xGHhyJumu77nJqIss0lazVug85Pwo0DKIoO314wAOvMnBxNYDa+7wA==
+  dependencies:
+    "@smithy/querystring-parser" "^2.0.2"
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/util-base64@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-2.0.0.tgz#1beeabfb155471d1d41c8d0603be1351f883c444"
+  integrity sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-body-length-browser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz#5447853003b4c73da3bc5f3c5e82c21d592d1650"
+  integrity sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-body-length-node@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz#4870b71cb9ded0123d984898ce952ce56896bc53"
+  integrity sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-buffer-from@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz#7eb75d72288b6b3001bc5f75b48b711513091deb"
+  integrity sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==
+  dependencies:
+    "@smithy/is-array-buffer" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-config-provider@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz#4dd6a793605559d94267312fd06d0f58784b4c38"
+  integrity sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-defaults-mode-browser@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.2.tgz#fb3ad350573ddea0ff7222adc98e9ecc4155b0d3"
+  integrity sha512-c2tMMjb624XLuzmlRoZpnFOkejVxcgw3WQKdmgdGZYZapcLzXyC0H9JhnXMjQCt30GqLTlsILRNVBYwFRbw/4Q==
+  dependencies:
+    "@smithy/property-provider" "^2.0.2"
+    "@smithy/types" "^2.1.0"
+    bowser "^2.11.0"
+    tslib "^2.5.0"
+
+"@smithy/util-defaults-mode-node@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.2.tgz#2e16e3eb57427c76604c255c38d9e1eacd385d7e"
+  integrity sha512-gt7m5LLqUtEKldJLyc14DE4kb85vxwomvt9AfEMEvWM4VwfWS1kGJqiStZFb5KNqnQPXw8vvpgLTi8NrWAOXqg==
+  dependencies:
+    "@smithy/config-resolver" "^2.0.2"
+    "@smithy/credential-provider-imds" "^2.0.2"
+    "@smithy/node-config-provider" "^2.0.2"
+    "@smithy/property-provider" "^2.0.2"
+    "@smithy/types" "^2.1.0"
+    tslib "^2.5.0"
+
+"@smithy/util-hex-encoding@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz#0aa3515acd2b005c6d55675e377080a7c513b59e"
+  integrity sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-middleware@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-2.0.0.tgz#706681d4a1686544a2275f68266304233f372c99"
+  integrity sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-retry@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-2.0.0.tgz#7ac5d5f12383a9d9b2a43f9ff25f3866c8727c24"
+  integrity sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==
+  dependencies:
+    "@smithy/service-error-classification" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-stream@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-2.0.2.tgz#cb4f3c4eca4253f77a780fd861630ed02d67b220"
+  integrity sha512-Mg9IJcKIu4YKlbzvpp1KLvh4JZLdcPgpxk+LICuDwzZCfxe47R9enVK8dNEiuyiIGK2ExbfvzCVT8IBru62vZw==
+  dependencies:
+    "@smithy/fetch-http-handler" "^2.0.2"
+    "@smithy/node-http-handler" "^2.0.2"
+    "@smithy/types" "^2.1.0"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-buffer-from" "^2.0.0"
+    "@smithy/util-hex-encoding" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-uri-escape@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz#19955b1a0f517a87ae77ac729e0e411963dfda95"
+  integrity sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-utf8@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.0.0.tgz#b4da87566ea7757435e153799df9da717262ad42"
+  integrity sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.0.0"
+    tslib "^2.5.0"
+
 "@sofie-automation/blueprints-integration@link:../packages/blueprints-integration":
   version "0.0.0"
   uid ""
@@ -2090,6 +2842,13 @@ async-cache@^1.1.0:
   dependencies:
     lru-cache "^4.0.0"
 
+async-mutex@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.2.tgz#1485eda5bda1b0ec7c8df1ac2e815757ad1831df"
+  integrity sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==
+  dependencies:
+    tslib "^2.3.1"
+
 async-value-promise@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/async-value-promise/-/async-value-promise-1.1.1.tgz#68957819e3eace804f3b4b69477e2bd276c15378"
@@ -2973,6 +3732,15 @@ binary-search@^1.3.3:
   resolved "https://registry.yarnpkg.com/binary-search/-/binary-search-1.3.6.tgz#e32426016a0c5092f0f3598836a1c7da3560565c"
   integrity sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==
 
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
@@ -3018,6 +3786,11 @@ body-parser@^1.20.0:
     raw-body "2.5.1"
     type-is "~1.6.18"
     unpipe "1.0.0"
+
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3174,6 +3947,18 @@ bson@^4.7.0:
   dependencies:
     buffer "^5.6.0"
 
+bson@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-4.7.2.tgz#320f4ad0eaf5312dd9b45dc369cc48945e2a5f2e"
+  integrity sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==
+  dependencies:
+    buffer "^5.6.0"
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
+
 buffer-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
@@ -3194,7 +3979,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==
 
-buffer@^5.6.0, buffer@^5.7.1:
+buffer@^5.5.0, buffer@^5.6.0, buffer@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -3523,6 +4308,11 @@ commander@^9.0.0, commander@^9.3.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
   integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
 compare-func@^2.0.0:
   version "2.0.0"
@@ -4932,6 +5722,13 @@ fast-stream-to-buffer@^1.0.0:
   dependencies:
     end-of-stream "^1.4.1"
 
+fast-xml-parser@4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz#a6747a09296a6cb34f2ae634019bf1738f3b421f"
+  integrity sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==
+  dependencies:
+    strnum "^1.0.5"
+
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
@@ -4945,6 +5742,13 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+  dependencies:
+    pend "~1.2.0"
 
 fecha@^4.2.0:
   version "4.2.3"
@@ -5016,6 +5820,15 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+find-cache-dir@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
+  integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
+
 find-up@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -5085,7 +5898,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.0:
+follow-redirects@^1.14.0, follow-redirects@^1.15.2:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -5141,6 +5954,11 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-minipass@^2.0.0:
   version "2.1.0"
@@ -5240,6 +6058,11 @@ get-pkg-repo@^4.0.0:
     hosted-git-info "^4.0.0"
     through2 "^2.0.0"
     yargs "^16.2.0"
+
+get-port@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
+  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
 get-stdin@^9.0.0:
   version "9.0.0"
@@ -5648,7 +6471,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==
 
-https-proxy-agent@^5.0.0:
+https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
@@ -7108,7 +7931,7 @@ magic-string@^0.25.3:
   dependencies:
     sourcemap-codec "^1.4.8"
 
-make-dir@^3.0.0, make-dir@^3.1.0:
+make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -7153,6 +7976,11 @@ mapcap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mapcap/-/mapcap-1.0.0.tgz#e8e29d04a160eaf8c92ec4bcbd2c5d07ed037e5a"
   integrity sha512-KcNlZSlFPx+r1jYZmxEbTVymG+dIctf10WmWkuhrhrblM+KMoF77HelwihL5cxYlORye79KoR4IlOOk99lUJ0g==
+
+md5-file@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-5.0.0.tgz#e519f631feca9c39e7f9ea1780b63c4745012e20"
+  integrity sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -7493,6 +8321,55 @@ mongodb-connection-string-url@^2.5.3:
     "@types/whatwg-url" "^8.2.1"
     whatwg-url "^11.0.0"
 
+mongodb-connection-string-url@^2.5.4:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz#57901bf352372abdde812c81be47b75c6b2ec5cf"
+  integrity sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==
+  dependencies:
+    "@types/whatwg-url" "^8.2.1"
+    whatwg-url "^11.0.0"
+
+mongodb-memory-server-core@8.14.0:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-8.14.0.tgz#f7928cf00db18d6c78d2a02774e67aa72ef74aa3"
+  integrity sha512-neR9nZC/hqEpaRVkbzy019OqFYnlz5y+3cqZSxL15lcl0K73zwKWU/1jS0UpIii5RlSdgFuDc8xG7+M/IDnzzQ==
+  dependencies:
+    async-mutex "^0.3.2"
+    camelcase "^6.3.0"
+    debug "^4.3.4"
+    find-cache-dir "^3.3.2"
+    follow-redirects "^1.15.2"
+    get-port "^5.1.1"
+    https-proxy-agent "^5.0.1"
+    md5-file "^5.0.0"
+    mongodb "^4.16.0"
+    new-find-package-json "^2.0.0"
+    semver "^7.5.4"
+    tar-stream "^2.1.4"
+    tslib "^2.6.1"
+    uuid "^9.0.0"
+    yauzl "^2.10.0"
+
+mongodb-memory-server@^8.14.0:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-8.14.0.tgz#737b94d4aefb35000dbea571661bd981b06c8ba7"
+  integrity sha512-xY6ATsFeGLgzuZPy+13ho/JdYgar8Hv+yeGuI6E5uGuh++LyUKqgJlxh92dQbJUeEhrbFX50wgC8aWIDBXObKQ==
+  dependencies:
+    mongodb-memory-server-core "8.14.0"
+    tslib "^2.6.1"
+
+mongodb@^4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.16.0.tgz#8b0043de7b577c6a7e0ce44a2ca7315b9c0a7927"
+  integrity sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==
+  dependencies:
+    bson "^4.7.2"
+    mongodb-connection-string-url "^2.5.4"
+    socks "^2.7.1"
+  optionalDependencies:
+    "@aws-sdk/credential-providers" "^3.186.0"
+    saslprep "^1.0.3"
+
 mongodb@^4.3.1, mongodb@^4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.9.1.tgz#0c769448228bcf9a6aa7d16daa3625b48312479e"
@@ -7572,6 +8449,13 @@ neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+new-find-package-json@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/new-find-package-json/-/new-find-package-json-2.0.0.tgz#96553638781db35061f351e8ccb4d07126b6407d"
+  integrity sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==
+  dependencies:
+    debug "^4.3.4"
 
 next-line@^1.1.0:
   version "1.1.0"
@@ -8209,6 +9093,11 @@ peek-readable@^4.1.0:
   resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.1.0.tgz#4ece1111bf5c2ad8867c314c81356847e8a62e72"
   integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -8262,7 +9151,7 @@ pirates@^4.0.1:
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
 
-pkg-dir@^4.2.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -8891,6 +9780,15 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.5, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.1.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-web-to-node-stream@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz#5d52bb5df7b54861fd48d015e93a2cb87b3ee0bb"
@@ -9324,6 +10222,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
@@ -9559,6 +10464,14 @@ socks@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.0.tgz#f9225acdb841e874dca25f870e9130990f3913d0"
   integrity sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==
+  dependencies:
+    ip "^2.0.0"
+    smart-buffer "^4.2.0"
+
+socks@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
+  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
   dependencies:
     ip "^2.0.0"
     smart-buffer "^4.2.0"
@@ -9956,6 +10869,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
+
 strtok3@^6.2.4:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.3.0.tgz#358b80ffe6d5d5620e19a073aa78ce947a90f9a0"
@@ -10013,6 +10931,17 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 tar@^6.1.11:
   version "6.1.11"
@@ -10312,7 +11241,7 @@ ts-mockito@2.6.1:
   dependencies:
     lodash "^4.17.5"
 
-tslib@^1.13.0, tslib@^1.8.1:
+tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -10321,6 +11250,11 @@ tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.1, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@^2.5.0, tslib@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
+  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -10605,10 +11539,15 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-to-istanbul@^7.0.0:
   version "7.1.2"
@@ -11080,6 +12019,14 @@ yargs@^17.5.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR opens an endpoint called getBasicRundowns which has the goal of providing rundown information for the Rundown Overview page of the Angular front-end. 

To distinguish if a rundown is active, the `MongoRundownPlaylistRepository` has been inserted as a top-layer calling the `MongoRundownRepository` inside the `RepositoryFacade`.

To test this i used ts-mockito, i understand now, however, that we are moving to a new framework. I will look into this for future use. 