### PR TITLE
fix: SOF-1581 make infinite pieceInstance deduplication work

### DIFF
--- a/packages/corelib/src/playout/infinites.ts
+++ b/packages/corelib/src/playout/infinites.ts
@@ -503,16 +503,7 @@ export function getPieceInstancesForPart(
 }
 
 function removeDuplicatePieceInstances(pieceInstances: PieceInstance[]): PieceInstance[] {
-	return pieceInstances.reduce((uniquePieceInstances: PieceInstance[], pieceInstance: PieceInstance) => {
-		if (!isUniquePieceInstance(pieceInstances, pieceInstance)) {
-			return uniquePieceInstances
-		}
-		return [...uniquePieceInstances, pieceInstance]
-	}, [])
-}
-
-function isUniquePieceInstance(pieceInstances: PieceInstance[], pieceInstance: PieceInstance): boolean {
-	return pieceInstances.some(({ _id }) => _id == pieceInstance._id)
+	return _.uniq(pieceInstances, (pieceInstance) => pieceInstance._id)
 }
 
 export interface PieceInstanceWithTimings extends PieceInstance {


### PR DESCRIPTION
Fixes a bug introduced in a925644. I went with `_.uniq()`, which on this amount of data will likely perform as good or better than the original approach that was using a `Set`, and is more readable than a `reduce` solution