### PR TITLE
fix: Ensure that we populate isActive on Rundown and BasicRundown.

### DIFF
--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -43,7 +43,7 @@ export interface MongoRundown {
 	showStyleVariantId: string
 	showStyleBaseId: string
 	modified: number
-	isActive: boolean
+	isActive?: boolean // TODO: Remove optionality when we have control over data structure.
 }
 
 export interface MongoSegment {
@@ -113,7 +113,7 @@ export class MongoEntityConverter {
 		return new Rundown({
 			id: mongoRundown._id,
 			name: mongoRundown.name,
-			isRundownActive: mongoRundown.isActive,
+			isRundownActive: mongoRundown.isActive ?? false,
 			baselineTimelineObjects: baselineTimelineObjects ?? [],
 			segments: [],
 			modifiedAt: mongoRundown.modified,
@@ -143,7 +143,7 @@ export class MongoEntityConverter {
 	}
 
 	public convertToBasicRundown(mongoRundown: MongoRundown): BasicRundown {
-		return new BasicRundown(mongoRundown._id, mongoRundown.name, mongoRundown.isActive, mongoRundown.modified)
+		return new BasicRundown(mongoRundown._id, mongoRundown.name, mongoRundown.isActive ?? false, mongoRundown.modified)
 	}
 
 	public convertToBasicRundowns(mongoRundowns: MongoRundown[]): BasicRundown[] {

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -143,7 +143,12 @@ export class MongoEntityConverter {
 	}
 
 	public convertToBasicRundown(mongoRundown: MongoRundown): BasicRundown {
-		return new BasicRundown(mongoRundown._id, mongoRundown.name, mongoRundown.isActive ?? false, mongoRundown.modified)
+		return new BasicRundown(
+			mongoRundown._id,
+			mongoRundown.name,
+			mongoRundown.isActive ?? false,
+			mongoRundown.modified
+		)
 	}
 
 	public convertToBasicRundowns(mongoRundowns: MongoRundown[]): BasicRundown[] {

--- a/meteor/sofie-server/presentation/controllers/rundown-controller.ts
+++ b/meteor/sofie-server/presentation/controllers/rundown-controller.ts
@@ -23,7 +23,7 @@ export class RundownController extends BaseController {
 	public async getBasicRundowns(_reg: Request, res: Response): Promise<void> {
 		try {
 			const basicRundowns: BasicRundown[] = await this.rundownRepository.getBasicRundowns()
-			res.send(basicRundowns.map(basicRundown => new BasicRundownDto(basicRundown)))
+			res.send(basicRundowns.map((basicRundown) => new BasicRundownDto(basicRundown)))
 		} catch (error) {
 			this.httpErrorHandler.handleError(res, error as Exception)
 		}

--- a/meteor/sofie-server/presentation/controllers/rundown-controller.ts
+++ b/meteor/sofie-server/presentation/controllers/rundown-controller.ts
@@ -7,6 +7,7 @@ import { RundownDto } from '../dtos/rundown-dto'
 import { Exception } from '../../model/exceptions/exception'
 import { HttpErrorHandler } from '../interfaces/http-error-handler'
 import { BasicRundown } from '../../model/entities/basic-rundown'
+import { BasicRundownDto } from '../dtos/basic-rundown-dto'
 
 @RestController('/rundowns')
 export class RundownController extends BaseController {
@@ -22,7 +23,7 @@ export class RundownController extends BaseController {
 	public async getBasicRundowns(_reg: Request, res: Response): Promise<void> {
 		try {
 			const basicRundowns: BasicRundown[] = await this.rundownRepository.getBasicRundowns()
-			res.send(basicRundowns)
+			res.send(basicRundowns.map(basicRundown => new BasicRundownDto(basicRundown)))
 		} catch (error) {
 			this.httpErrorHandler.handleError(res, error as Exception)
 		}

--- a/meteor/sofie-server/presentation/dtos/basic-rundown-dto.ts
+++ b/meteor/sofie-server/presentation/dtos/basic-rundown-dto.ts
@@ -1,0 +1,15 @@
+import { BasicRundown } from '../../model/entities/basic-rundown'
+
+export class BasicRundownDto {
+	readonly id: string
+	readonly name: string
+	readonly isActive: boolean
+	readonly modifiedAt: number
+
+	constructor(basicRundown: BasicRundown) {
+		this.id = basicRundown.id
+		this.name = basicRundown.name
+		this.isActive = basicRundown.isActive()
+		this.modifiedAt = basicRundown.getLastTimeModified()
+	}
+}

--- a/meteor/sofie-server/presentation/dtos/rundown-dto.ts
+++ b/meteor/sofie-server/presentation/dtos/rundown-dto.ts
@@ -8,14 +8,14 @@ export class RundownDto {
 	readonly isActive: boolean
 	readonly infinitePieces: PieceDto[]
 	readonly segments: SegmentDto[]
-	readonly lastTimeModified: number
+	readonly modifiedAt: number
 
 	constructor(rundown: Rundown) {
 		this.id = rundown.id
 		this.name = rundown.name
-		this.isActive = rundown.isActive()
+		this.isActive = rundown.isActive() ?? false
 		this.infinitePieces = rundown.getInfinitePieces().map((piece) => new PieceDto(piece))
 		this.segments = rundown.getSegments().map((segment) => new SegmentDto(segment))
-		this.lastTimeModified = rundown.getLastTimeModified()
+		this.modifiedAt = rundown.getLastTimeModified()
 	}
 }


### PR DESCRIPTION
Currently we are not checking whether or not `isActive` is set on rundowns in the database. Thus, we pass `isActive` as an undefined value through the entire codebase, while treating it as a boolean.
The PR also adds BasicRundownDto that uses `isActive` instead of `isRundownActive` and `modifiedAt` instead of `lastModifiedAt`.