### PR TITLE
fix: Removes upsert and unhandled properties. 

### DIFF
--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -122,9 +122,9 @@ export class MongoEntityConverter {
 
 	public convertToMongoRundown(rundown: Rundown): MongoRundown {
 		return {
-			isActive: rundown.isActive(),
 			_id: rundown.id,
 			name: rundown.name,
+			isActive: rundown.isActive(),
 		} as MongoRundown
 	}
 
@@ -158,15 +158,13 @@ export class MongoEntityConverter {
 
 	public convertToMongoSegment(segment: Segment): MongoSegment {
 		return {
-			externalId: '', // Todo: figure out where the value for this attribute is
-			isHidden: false, // Todo: figure out where the value for this attribute is
 			_id: segment.id,
 			name: segment.name,
 			rundownId: segment.rundownId,
 			_rank: segment.rank,
 			isOnAir: segment.isOnAir(),
 			isNext: segment.isNext(),
-		}
+		} as MongoSegment
 	}
 
 	public convertToMongoSegments(segments: Segment[]): MongoSegment[] {
@@ -201,9 +199,9 @@ export class MongoEntityConverter {
 
 	public convertToMongoPart(part: Part): MongoPart {
 		return {
+			_id: part.id,
 			expectedDuration: part.expectedDuration,
 			title: part.name,
-			_id: part.id,
 			segmentId: part.segmentId,
 			_rank: part.rank,
 			isOnAir: part.isOnAir(),
@@ -278,7 +276,6 @@ export class MongoEntityConverter {
 			enable: { duration: piece.duration, start: piece.start },
 			lifespan: piece.pieceLifespan,
 			sourceLayerId: piece.layer,
-			timelineObjectsString: '',
 			_id: piece.id,
 			startPartId: piece.partId,
 			name: piece.name,

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -123,19 +123,9 @@ export class MongoEntityConverter {
 	public convertToMongoRundown(rundown: Rundown): MongoRundown {
 		return {
 			isActive: rundown.isActive(),
-			externalId: '', // Todo: figure out where the value for this attribute is
-			metaData: { rank: 0 }, // Todo: figure out where the value for this attribute is
-			modified: rundown.getLastTimeModified(),
-			notes: [], // Todo: figure out where the value for this attribute is
-			organizationId: '', // Todo: figure out where the value for this attribute is
-			playlistExternalId: '', // Todo: figure out where the value for this attribute is
-			showStyleBaseId: '', // Todo: figure out where the value for this attribute is
-			showStyleVariantId: '', // Todo: figure out where the value for this attribute is
-			studioId: '', // Todo: figure out where the value for this attribute is
-			timing: { expectedDuration: 0, expectedEnd: 0, expectedStart: 0, type: '' }, // Todo: figure out where the value for this attribute is
 			_id: rundown.id,
 			name: rundown.name,
-		}
+		} as MongoRundown
 	}
 
 	public convertToMongoRundowns(rundowns: Rundown[]): MongoRundown[] {

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-part-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-part-repository.ts
@@ -38,7 +38,7 @@ export class MongoPartRepository extends BaseMongoRepository implements PartRepo
 
 	public async savePart(part: Part): Promise<void> {
 		const mongoPart: MongoPart = this.mongoEntityConverter.convertToMongoPart(part)
-		await this.getCollection().updateOne({ _id: part.id }, { $set: mongoPart }, { upsert: true })
+		await this.getCollection().updateOne({ _id: part.id }, { $set: mongoPart })
 	}
 
 	public async deletePartsForSegment(segmentId: string): Promise<void> {

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-rundown-repository.ts
@@ -52,7 +52,7 @@ export class MongoRundownRepository extends BaseMongoRepository implements Rundo
 
 	public async saveRundown(rundown: Rundown): Promise<void> {
 		const mongoRundown: MongoRundown = this.mongoEntityConverter.convertToMongoRundown(rundown)
-		await this.getCollection().updateOne({ _id: rundown.id }, { $set: mongoRundown }, { upsert: true })
+		await this.getCollection().updateOne({ _id: rundown.id }, { $set: mongoRundown })
 		for (const segment of rundown.getSegments()) {
 			await this.segmentRepository.saveSegment(segment)
 		}

--- a/meteor/sofie-server/data-access/repositories/mongo/mongo-segment-repository.ts
+++ b/meteor/sofie-server/data-access/repositories/mongo/mongo-segment-repository.ts
@@ -38,7 +38,7 @@ export class MongoSegmentRepository extends BaseMongoRepository implements Segme
 
 	public async saveSegment(segment: Segment): Promise<void> {
 		const mongoSegment: MongoSegment = this.mongoEntityConverter.convertToMongoSegment(segment)
-		await this.getCollection().updateOne({ _id: segment.id }, { $set: mongoSegment }, { upsert: true })
+		await this.getCollection().updateOne({ _id: segment.id }, { $set: mongoSegment })
 		for (const part of segment.getParts()) {
 			await this.partRepository.savePart(part)
 		}


### PR DESCRIPTION
This PR adresses an issue that came with the save-functionality. The upserts overwrote the rundowns saved in the database with empty properties provided in the `MongoEntityConverter`.  For now it does not seem like the upsert-options are needed either. 