### PR TITLE
chore: MONGO_URL can have URL parameters such as ?directConnection=true.

### DIFF
--- a/meteor/server/worker/worker.ts
+++ b/meteor/server/worker/worker.ts
@@ -239,7 +239,7 @@ Meteor.startup(() => {
 
 	// Meteor wants the dbname as the path of the mongo url, but the mongodb driver needs it separate
 	const rawUrl = new URL(process.env.MONGO_URL)
-	const dbName = rawUrl.pathname.substring(1) // Trim off first '/'
+	const dbName = rawUrl.pathname.substring(1).replace(/\?.+$/, '') // Trim off first '/'
 	rawUrl.pathname = ''
 	const mongoUri = rawUrl.toString()
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"install:meteor": "cd meteor && meteor --version && meteor npm install -g yarn && node ../scripts/fix-windows-yarn.js && meteor yarn install",
 		"install:packages": "cd packages && yarn install",
 		"start": "yarn install && yarn dev",
+		"watch": "cross-env MONGO_URL=mongodb://localhost:3002/sofie?directConnection=true MONGO_OPLOG_URL=mongodb://localhost:3002/local?directConnection=true yarn dev",
 		"dev": "node ./scripts/run.js",
 		"restart:meteor": "node ./scripts/meteor-force-restart.js",
 		"build:packages": "cd packages && yarn build",
@@ -34,6 +35,7 @@
 	},
 	"devDependencies": {
 		"concurrently": "^7.4.0",
+		"cross-env": "^7.0.3",
 		"rimraf": "^3.0.2",
 		"semver": "^7.3.7",
 		"snyk-nodejs-lockfile-parser": "^1.43.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,7 +443,14 @@ concurrently@^7.4.0:
     tree-kill "^1.2.2"
     yargs "^17.3.1"
 
-cross-spawn@7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@7.0.3, cross-spawn@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Is dependent on https://github.com/tv2/sofie-server/pull/22.

To start meteor dev server up with an external mongodb on port 3002, use `yarn watch` from root of repo instead of `yarn dev`.